### PR TITLE
Remove silent flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Tools versions:
 - djade: v1.3.2
 - djhtml: v3.0.7
 
-<pre><code>Benchmark 1: cat /tmp/test-files | xargs --max-procs=0 ../../target/release/djangofmt format --profile django --line-length 120 --silent
+<pre><code>Benchmark 1: cat /tmp/test-files | xargs --max-procs=0 ../../target/release/djangofmt format --profile django --line-length 120 --quiet
   Time (mean ± σ):      19.8 ms ±   0.9 ms    [User: 179.6 ms, System: 73.7 ms]
   Range (min … max):    18.3 ms …  23.3 ms    73 runs
 
@@ -124,7 +124,7 @@ Benchmark 5: cat /tmp/test-files | xargs --max-procs=0 ./node_modules/.bin/prett
   Warning: Ignoring non-zero exit code.
 
 Summary
-  cat /tmp/test-files | xargs --max-procs=0 ../../target/release/djangofmt format --profile django --line-length 120 --silent ran
+  cat /tmp/test-files | xargs --max-procs=0 ../../target/release/djangofmt format --profile django --line-length 120 --quiet ran
     3.63 ± 0.17 times faster than cat /tmp/test-files | xargs --max-procs=0 djade --target-version 5.1
    70.71 ± 3.45 times faster than cat /tmp/test-files | xargs --max-procs=0 djhtml
   118.28 ± 5.48 times faster than cat /tmp/test-files | xargs --max-procs=0 djlint --reformat --profile=django --max-line-length 120

--- a/python/benchmark_cargo_profiles.py
+++ b/python/benchmark_cargo_profiles.py
@@ -88,7 +88,7 @@ class Profile(NamedTuple):
 
 
 ##### Configuration for benchmarking #####
-BENCHMARK_ARGS = "--profile django --line-length 120 --silent"
+BENCHMARK_ARGS = "--profile django --line-length 120 --quiet"
 WARMUP_RUNS = 10
 BENCHMARK_RUNS = 100
 CARGO_TOML_PATH = Path("Cargo.toml")

--- a/python/benchmarks/run_formatter.sh
+++ b/python/benchmarks/run_formatter.sh
@@ -8,7 +8,7 @@ LINE_LENGTH=${LINE_LENGTH:-120}
 
 # Setup run commands
 _XARGS_FILES="cat /tmp/files-list | xargs --max-procs=0"
-DJANGOFMT_CMD="$_XARGS_FILES ../../target/release/djangofmt --profile django --line-length $LINE_LENGTH --silent"
+DJANGOFMT_CMD="$_XARGS_FILES ../../target/release/djangofmt --profile django --line-length $LINE_LENGTH --quiet"
 PRETTIER_CMD="$_XARGS_FILES ./node_modules/.bin/prettier --ignore-unknown --write --print-width $LINE_LENGTH --log-level silent"
 DJLINT_CMD="$_XARGS_FILES djlint --reformat --profile=django --max-line-length $LINE_LENGTH"
 DJADE_CMD="$_XARGS_FILES djade --target-version 5.1"

--- a/src/args.rs
+++ b/src/args.rs
@@ -85,7 +85,7 @@ pub struct LogLevelArgs {
         help_heading = "Log levels"
     )]
     pub verbose: bool,
-    /// Print diagnostics, but nothing else.
+    /// Disable all logging.
     #[arg(
         short,
         long,
@@ -94,22 +94,11 @@ pub struct LogLevelArgs {
         help_heading = "Log levels"
     )]
     pub quiet: bool,
-    /// Disable all logging (but still exit with status code "1" upon detecting diagnostics).
-    #[arg(
-        short,
-        long,
-        global = true,
-        group = "verbosity",
-        help_heading = "Log levels"
-    )]
-    pub silent: bool,
 }
 
 impl From<&LogLevelArgs> for LogLevel {
     fn from(args: &LogLevelArgs) -> Self {
-        if args.silent {
-            Self::Silent
-        } else if args.quiet {
+        if args.quiet {
             Self::Quiet
         } else if args.verbose {
             Self::Verbose

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,9 +7,6 @@ use tracing_tree::time::Uptime;
 #[derive(Debug, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Clone)]
 pub enum LogLevel {
     /// No output ([`log::LevelFilter::Off`]).
-    Silent,
-    /// Only show lint violations, with no decorative output
-    /// ([`log::LevelFilter::Off`]).
     Quiet,
     /// All user-facing output ([`log::LevelFilter::Info`]).
     #[default]
@@ -24,7 +21,7 @@ impl LogLevel {
         match self {
             LogLevel::Default => LevelFilter::INFO,
             LogLevel::Verbose => LevelFilter::DEBUG,
-            LogLevel::Quiet | LogLevel::Silent => LevelFilter::OFF,
+            LogLevel::Quiet => LevelFilter::OFF,
         }
     }
 }


### PR DESCRIPTION
Fixes #39

Only keep `--verbose` and `--quiet` flags which are more usual (see `cargo`, `rg`, ...)