### PR TITLE
Support unquoted attr value recovery for jinja tags & blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 [[package]]
 name = "dprint_plugin_markup"
 version = "0.20.0"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.20.0.2#3c0e3e5f4531ec8d803db2d8c4dd5c4e247faefd"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.20.0.3#085f0b2f94cecd3c07539abe61c8d7d5c9675113"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.20.0"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.20.0.2#3c0e3e5f4531ec8d803db2d8c4dd5c4e247faefd"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.20.0.3#085f0b2f94cecd3c07539abe61c8d7d5c9675113"
 dependencies = [
  "aho-corasick",
  "css_dataset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ rust-version = "1.85"
 description = "A fast, HTML aware, Django template formatter, written in Rust."
 
 [dependencies]
-dprint_plugin_markup = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.20.0.2" }
+dprint_plugin_markup = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.20.0.3" }
 malva = { version = "0.12.1", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.20.0.2" }
+markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.20.0.3" }
 
 anyhow = "1.0.98"
 clap = { version = "4.5.38", features = ["derive", "wrap_help"] }


### PR DESCRIPTION
Support these:

```diff
-<html alt={% url ... %}></html>
+<html alt="{% url ... %}"></html>
-<input value={% if initial_value %}{{ initial_value }}{% endif %}>
+<input value="{% if initial_value %}{{ initial_value }}{% endif %}">
```


Prior to that, it would crash on these with `ExpectAttrName` errors like the following:
- `Syntax(SyntaxError { kind: ExpectAttrName, pos: 17, line: 1, column: 18 })"`