### PR TITLE
Improvements on inline node formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,8 +240,8 @@ dependencies = [
 
 [[package]]
 name = "dprint_plugin_markup"
-version = "0.20.0"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.20.0.3#085f0b2f94cecd3c07539abe61c8d7d5c9675113"
+version = "0.21.0"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.21.0.0#1569a83a11c05d3262af5c27a9a0ca841052f7f6"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -393,8 +393,8 @@ dependencies = [
 
 [[package]]
 name = "markup_fmt"
-version = "0.20.0"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.20.0.3#085f0b2f94cecd3c07539abe61c8d7d5c9675113"
+version = "0.21.0"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.21.0.0#1569a83a11c05d3262af5c27a9a0ca841052f7f6"
 dependencies = [
  "aho-corasick",
  "css_dataset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ rust-version = "1.85"
 description = "A fast, HTML aware, Django template formatter, written in Rust."
 
 [dependencies]
-dprint_plugin_markup = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.20.0.3" }
+dprint_plugin_markup = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.21.0.0" }
 malva = { version = "0.12.1", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.20.0.3" }
+markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.21.0.0" }
 
 anyhow = "1.0.98"
 clap = { version = "4.5.38", features = ["derive", "wrap_help"] }


### PR DESCRIPTION
Bump to latest `markup_fmt` to bring improvements on inline node formatting