### PR TITLE
Try `pretty_jinja`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +259,7 @@ dependencies = [
  "insta-cmd",
  "malva",
  "markup_fmt",
+ "pretty_jinja",
  "rayon",
  "serde_json",
  "similar-asserts",
@@ -327,6 +334,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
@@ -344,7 +357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -473,6 +486,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pretty_jinja"
+version = "0.2.0"
+source = "git+https://github.com/g-plane/pretty_jinja?rev=v0.2.0#b4d32d50d77ec0157a60a8423e71e8659ade7717"
+dependencies = [
+ "rowan",
+ "serde",
+ "tiny_pretty",
+ "winnow",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +572,24 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash",
+ "text-size",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -682,6 +724,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thread_local"
@@ -907,3 +955,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ description = "A fast, HTML aware, Django template formatter, written in Rust."
 dprint_plugin_markup = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.25.0.0" }
 malva = { version = "0.15.0", features = ["config_serde"] }
 markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.25.0.0" }
+pretty_jinja = { git = "https://github.com/g-plane/pretty_jinja", rev = "v0.2.0", features = ["config_serde"] }
 
 clap = { version = "4.5.38", features = ["derive", "wrap_help"] }
 clap_complete_command = "0.6.1"

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -127,8 +127,7 @@ fn format_path(
                 let pretty_jinja_config = pretty_jinja::config::FormatOptions::default();
                 Ok(match ext {
                     "markup-fmt-jinja-expr" => format_expr(code, &pretty_jinja_config)
-                        .map(Cow::from)
-                        .unwrap_or(code.into()),
+                        .map_or_else(|_| code.into(), Cow::from),
                     "markup-fmt-jinja-stmt" => format_stmt(code, &pretty_jinja_config)
                         .map(Cow::from)
                         .unwrap_or(code.into()),

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 
 use markup_fmt::config::{FormatOptions, LanguageOptions, LayoutOptions};
 use markup_fmt::{FormatError, Language, format_text};
+use pretty_jinja::{format_expr, format_stmt};
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tracing::{debug, error};
@@ -123,7 +124,17 @@ fn format_path(
                 // .map_err(anyhow::Error::from)
                 .map_or_else(|_| code.into(), Cow::from))
             } else {
-                Ok(code.into())
+                let pretty_jinja_config = pretty_jinja::config::FormatOptions::default();
+                Ok(match ext {
+                    "markup-fmt-jinja-expr" => format_expr(code, &pretty_jinja_config)
+                        .map(Cow::from)
+                        .unwrap_or(code.into()),
+                    "markup-fmt-jinja-stmt" => format_stmt(code, &pretty_jinja_config)
+                        .map(Cow::from)
+                        .unwrap_or(code.into()),
+                    _ => code.into(),
+                })
+
                 // dprint_plugin_biome::format_text(
                 //     &Path::new("file").with_extension(ext),
                 //     code,

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -9,7 +9,8 @@ use std::time::Instant;
 
 use markup_fmt::config::{FormatOptions, LanguageOptions, LayoutOptions};
 use markup_fmt::{FormatError, Language, format_text};
-use pretty_jinja::{format_expr, format_stmt};
+use pretty_jinja;
+use pretty_jinja::config::OperatorLineBreak;
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tracing::{debug, error};
@@ -124,13 +125,38 @@ fn format_path(
                 // .map_err(anyhow::Error::from)
                 .map_or_else(|_| code.into(), Cow::from))
             } else {
-                let pretty_jinja_config = pretty_jinja::config::FormatOptions::default();
+                let pretty_jinja_config = pretty_jinja::config::FormatOptions {
+                    layout: serde_json::from_value(serde_json::to_value(&format_options.layout)?)?,
+                    language: pretty_jinja::config::LanguageOptions {
+                        operator_linebreak: OperatorLineBreak::Before,
+                        trailing_comma: pretty_jinja::config::TrailingComma::OnlyMultiLine,
+                        args_trailing_comma: None,
+                        expr_dict_trailing_comma: None,
+                        expr_list_trailing_comma: None,
+                        expr_tuple_trailing_comma: None,
+                        params_trailing_comma: None,
+                        prefer_single_line: true,
+                        args_prefer_single_line: Some(true),
+                        expr_dict_prefer_single_line: Some(true),
+                        expr_list_prefer_single_line: Some(true),
+                        expr_tuple_prefer_single_line: Some(true),
+                        params_prefer_single_line: Some(true),
+                        brace_spacing: true,
+                        bracket_spacing: false,
+                        args_paren_spacing: false,
+                        params_paren_spacing: false,
+                        tuple_paren_spacing: false,
+                    },
+                };
                 Ok(match ext {
-                    "markup-fmt-jinja-expr" => format_expr(code, &pretty_jinja_config)
-                        .map_or_else(|_| code.into(), Cow::from),
-                    "markup-fmt-jinja-stmt" => format_stmt(code, &pretty_jinja_config)
-                        .map(Cow::from)
-                        .unwrap_or(code.into()),
+                    "markup-fmt-jinja-expr" => {
+                        pretty_jinja::format_expr(code, &pretty_jinja_config)
+                            .map_or_else(|_| code.into(), Cow::from)
+                    }
+                    "markup-fmt-jinja-stmt" => {
+                        pretty_jinja::format_stmt(code, &pretty_jinja_config)
+                            .map_or_else(|_| code.into(), Cow::from)
+                    }
                     _ => code.into(),
                 })
 

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -39,14 +39,20 @@ fn run_format_test(path: &Path, input: &str) -> String {
         },
     };
 
-    let output = format_text(input, Language::Django, &options, |code, _| {
+    let language = if path.components().any(|c| c.as_os_str() == "jinja") {
+        Language::Jinja
+    } else {
+        Language::Django
+    };
+
+    let output = format_text(input, language, &options, |code, _| {
         Ok::<_, ()>(Cow::from(code))
     })
     .map_err(|err| format!("failed to format '{}': {:?}", path.display(), err))
     .unwrap();
 
     // Stability test: format the output again and ensure it's the same
-    let regression_format = format_text(&output, Language::Django, &options, |code, _| {
+    let regression_format = format_text(&output, language, &options, |code, _| {
         Ok::<_, ()>(Cow::from(code))
     })
     .map_err(|err| {

--- a/tests/fmt/django/autoescape.html
+++ b/tests/fmt/django/autoescape.html
@@ -1,0 +1,12 @@
+<div>
+    {% autoescape on %}
+        <p>{{ user_input }}</p>
+        <p>{{ html_content|safe }}</p>
+    {% endautoescape %}
+
+    {% autoescape off %}
+        <p>{{ trusted_html }}</p>
+    {% endautoescape %}
+
+    <p>{{ dangerous_content|escape }}</p>
+</div>

--- a/tests/fmt/django/autoescape.snap
+++ b/tests/fmt/django/autoescape.snap
@@ -1,0 +1,15 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% autoescape on %}
+        <p>{{ user_input }}</p>
+        <p>{{ html_content|safe }}</p>
+    {% endautoescape %}
+
+    {% autoescape off %}
+        <p>{{ trusted_html }}</p>
+    {% endautoescape %}
+
+    <p>{{ dangerous_content|escape }}</p>
+</div>

--- a/tests/fmt/django/comments.html
+++ b/tests/fmt/django/comments.html
@@ -1,0 +1,15 @@
+<div>
+    {# This is a single-line comment #}
+
+    {% comment %}
+    This is a multi-line comment
+    that spans multiple lines
+    and can contain Django template syntax
+    {% endcomment %}
+
+    <p>{{ value }}</p> {# inline comment #}
+
+    {% comment "Optional note" %}
+    This comment has a note attached
+    {% endcomment %}
+</div>

--- a/tests/fmt/django/comments.snap
+++ b/tests/fmt/django/comments.snap
@@ -1,0 +1,17 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {# This is a single-line comment #}
+
+    {% comment %}
+        This is a multi-line comment that spans multiple lines and can contain Django template syntax
+    {% endcomment %}
+
+    <p>{{ value }}</p>
+    {# inline comment #}
+
+    {% comment "Optional note" %}
+        This comment has a note attached
+    {% endcomment %}
+</div>

--- a/tests/fmt/django/conditionals.html
+++ b/tests/fmt/django/conditionals.html
@@ -1,0 +1,17 @@
+<div>
+    {% if user.is_authenticated %}
+        <p>Welcome, {{ user.username }}!</p>
+    {% elif user.is_anonymous %}
+        <p>Please log in</p>
+    {% else %}
+        <p>Unknown user state</p>
+    {% endif %}
+
+    {% if items and items|length > 0 %}
+        <ul>
+            {% for item in items %}
+                <li>{{ item.name }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+</div>

--- a/tests/fmt/django/conditionals.snap
+++ b/tests/fmt/django/conditionals.snap
@@ -1,0 +1,20 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% if user.is_authenticated %}
+        <p>Welcome, {{ user.username }}!</p>
+    {% elif user.is_anonymous %}
+        <p>Please log in</p>
+    {% else %}
+        <p>Unknown user state</p>
+    {% endif %}
+
+    {% if items and items|length > 0 %}
+        <ul>
+            {% for item in items %}
+                <li>{{ item.name }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+</div>

--- a/tests/fmt/django/filter_chaining.html
+++ b/tests/fmt/django/filter_chaining.html
@@ -1,0 +1,8 @@
+<div>
+    {{ value | lower | capfirst }}
+    {{ text | striptags | truncatewords:20 | safe }}
+    {{ date | date:"Y-m-d" | default:"N/A" }}
+    {{ items | length | add:5 | default:0 }}
+    {{ content | linebreaks | safe | truncatechars:100 }}
+    {{ name | slugify | upper | cut:"-" }}
+</div>

--- a/tests/fmt/django/filter_chaining.snap
+++ b/tests/fmt/django/filter_chaining.snap
@@ -1,0 +1,11 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ value | lower | capfirst }}
+    {{ text | striptags | truncatewords:20 | safe }}
+    {{ date | date:"Y-m-d" | default:"N/A" }}
+    {{ items | length | add:5 | default:0 }}
+    {{ content | linebreaks | safe | truncatechars:100 }}
+    {{ name | slugify | upper | cut:"-" }}
+</div>

--- a/tests/fmt/django/filters.html
+++ b/tests/fmt/django/filters.html
@@ -1,0 +1,8 @@
+<div>
+    {{ article.title|upper }}
+    {{ user.name|default:"Anonymous"|truncatewords:10 }}
+    {{ post.content|safe|linebreaks }}
+    {{ date_value|date:"Y-m-d H:i:s" }}
+    {{ items|length }}
+    {{ text|slugify|lower }}
+</div>

--- a/tests/fmt/django/filters.snap
+++ b/tests/fmt/django/filters.snap
@@ -1,0 +1,11 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ article.title|upper }}
+    {{ user.name|default:"Anonymous"|truncatewords:10 }}
+    {{ post.content|safe|linebreaks }}
+    {{ date_value|date:"Y-m-d H:i:s" }}
+    {{ items|length }}
+    {{ text|slugify|lower }}
+</div>

--- a/tests/fmt/django/filters_with_spacing.html
+++ b/tests/fmt/django/filters_with_spacing.html
@@ -1,0 +1,11 @@
+<div>
+    {{ attrs.form | crispy }}
+    {{ value | default:"test" }}
+    {{ text | truncatewords:30 }}
+    {{ items | slice:":5" }}
+    {{ date | date:"Y-m-d" }}
+    {{ number | floatformat:2 }}
+    {{ list | join:", " }}
+    {{ value | add:10 }}
+    {{ text | cut:" " }}
+</div>

--- a/tests/fmt/django/filters_with_spacing.snap
+++ b/tests/fmt/django/filters_with_spacing.snap
@@ -1,0 +1,14 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ attrs.form | crispy }}
+    {{ value | default:"test" }}
+    {{ text | truncatewords:30 }}
+    {{ items | slice:":5" }}
+    {{ date | date:"Y-m-d" }}
+    {{ number | floatformat:2 }}
+    {{ list | join:", " }}
+    {{ value | add:10 }}
+    {{ text | cut:" " }}
+</div>

--- a/tests/fmt/django/long_strings_tag.html
+++ b/tests/fmt/django/long_strings_tag.html
@@ -1,0 +1,9 @@
+<div>
+    {% if user.is_authenticated and user.has_permission and user.profile.settings.allow_access and not user.is_banned %}
+        <p>Access granted</p>
+    {% endif %}
+
+    {% include "very/long/path/to/template/that/exceeds/normal/line/length/limits/component.html" %}
+
+    {% url 'very-long-url-name-that-should-be-handled' arg1=value1 arg2=value2 arg3=value3 arg4=value4 %}
+</div>

--- a/tests/fmt/django/long_strings_tag.snap
+++ b/tests/fmt/django/long_strings_tag.snap
@@ -1,0 +1,12 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% if user.is_authenticated and user.has_permission and user.profile.settings.allow_access and not user.is_banned %}
+        <p>Access granted</p>
+    {% endif %}
+
+    {% include "very/long/path/to/template/that/exceeds/normal/line/length/limits/component.html" %}
+
+    {% url 'very-long-url-name-that-should-be-handled' arg1=value1 arg2=value2 arg3=value3 arg4=value4 %}
+</div>

--- a/tests/fmt/django/long_strings_variable.html
+++ b/tests/fmt/django/long_strings_variable.html
@@ -1,0 +1,5 @@
+<div>
+    {{ "This is a very long string that should probably be wrapped or handled in some way because it exceeds the normal line length limits" }}
+    {{ user.profile.settings.preferences.notification.email.frequency.daily.digest.enabled }}
+    {{ very_long_variable_name_that_exceeds_line_length_and_should_be_handled_appropriately }}
+</div>

--- a/tests/fmt/django/long_strings_variable.snap
+++ b/tests/fmt/django/long_strings_variable.snap
@@ -1,0 +1,8 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ "This is a very long string that should probably be wrapped or handled in some way because it exceeds the normal line length limits" }}
+    {{ user.profile.settings.preferences.notification.email.frequency.daily.digest.enabled }}
+    {{ very_long_variable_name_that_exceeds_line_length_and_should_be_handled_appropriately }}
+</div>

--- a/tests/fmt/django/loops.html
+++ b/tests/fmt/django/loops.html
@@ -1,0 +1,16 @@
+<div>
+    {% for product in products %}
+        <div class="product">
+            <h3>{{ product.name }}</h3>
+            <p>{{ product.description }}</p>
+            <span>{{ product.price }}</span>
+        </div>
+    {% empty %}
+        <p>No products available</p>
+    {% endfor %}
+
+    {% for key, value in settings.items %}
+        <dt>{{ key }}</dt>
+        <dd>{{ value }}</dd>
+    {% endfor %}
+</div>

--- a/tests/fmt/django/loops.snap
+++ b/tests/fmt/django/loops.snap
@@ -1,0 +1,19 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% for product in products %}
+        <div class="product">
+            <h3>{{ product.name }}</h3>
+            <p>{{ product.description }}</p>
+            <span>{{ product.price }}</span>
+        </div>
+        {% empty %}
+        <p>No products available</p>
+    {% endfor %}
+
+    {% for key, value in settings.items %}
+        <dt>{{ key }}</dt>
+        <dd>{{ value }}</dd>
+    {% endfor %}
+</div>

--- a/tests/fmt/django/mixed_quotes.html
+++ b/tests/fmt/django/mixed_quotes.html
@@ -1,0 +1,17 @@
+<div>
+    {{ "double quotes" }}
+    {{ 'single quotes' }}
+    {{ "string with 'nested' quotes" }}
+    {{ 'string with "nested" quotes' }}
+
+    {% if value == "test" %}
+        <p>Double quotes in condition</p>
+    {% endif %}
+
+    {% if value == 'test' %}
+        <p>Single quotes in condition</p>
+    {% endif %}
+
+    <a href="{% url 'home' %}">Link</a>
+    <a href='{% url "home" %}'>Link</a>
+</div>

--- a/tests/fmt/django/mixed_quotes.snap
+++ b/tests/fmt/django/mixed_quotes.snap
@@ -1,0 +1,20 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ "double quotes" }}
+    {{ 'single quotes' }}
+    {{ "string with 'nested' quotes" }}
+    {{ 'string with "nested" quotes' }}
+
+    {% if value == "test" %}
+        <p>Double quotes in condition</p>
+    {% endif %}
+
+    {% if value == 'test' %}
+        <p>Single quotes in condition</p>
+    {% endif %}
+
+    <a href="{% url 'home' %}">Link</a>
+    <a href="{% url "home" %}">Link</a>
+</div>

--- a/tests/fmt/django/spaceless.html
+++ b/tests/fmt/django/spaceless.html
@@ -1,0 +1,18 @@
+<div>
+    {% spaceless %}
+        <p>
+            <a href="/home/">Home</a>
+        </p>
+        <p>
+            <a href="/about/">About</a>
+        </p>
+    {% endspaceless %}
+
+    <ul>
+        {% spaceless %}
+            <li><a href="#">Link 1</a></li>
+            <li><a href="#">Link 2</a></li>
+            <li><a href="#">Link 3</a></li>
+        {% endspaceless %}
+    </ul>
+</div>

--- a/tests/fmt/django/spaceless.snap
+++ b/tests/fmt/django/spaceless.snap
@@ -1,0 +1,21 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% spaceless %}
+        <p>
+            <a href="/home/">Home</a>
+        </p>
+        <p>
+            <a href="/about/">About</a>
+        </p>
+    {% endspaceless %}
+
+    <ul>
+        {% spaceless %}
+            <li><a href="#">Link 1</a></li>
+            <li><a href="#">Link 2</a></li>
+            <li><a href="#">Link 3</a></li>
+        {% endspaceless %}
+    </ul>
+</div>

--- a/tests/fmt/django/template_inheritance.html
+++ b/tests/fmt/django/template_inheritance.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}Page Title{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'css/custom.css' %}">
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <h1>{{ page.title }}</h1>
+        {% block inner_content %}
+            <p>Default inner content</p>
+        {% endblock %}
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    <script src="{% static 'js/custom.js' %}"></script>
+{% endblock %}

--- a/tests/fmt/django/template_inheritance.snap
+++ b/tests/fmt/django/template_inheritance.snap
@@ -1,0 +1,23 @@
+---
+source: tests/fmt.rs
+---
+{% extends "base.html" %}
+
+{% block title %}Page Title{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'css/custom.css' %}">
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <h1>{{ page.title }}</h1>
+        {% block inner_content %}
+            <p>Default inner content</p>
+        {% endblock %}
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    <script src="{% static 'js/custom.js' %}"></script>
+{% endblock %}

--- a/tests/fmt/django/template_tags.html
+++ b/tests/fmt/django/template_tags.html
@@ -1,0 +1,6 @@
+<div>
+    {% block content %}
+        <p>{% translate "Welcome to our site" %}</p>
+        {% include "partials/header.html" with title="Home" %}
+    {% endblock %}
+</div>

--- a/tests/fmt/django/template_tags.snap
+++ b/tests/fmt/django/template_tags.snap
@@ -1,0 +1,9 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% block content %}
+        <p>{% translate "Welcome to our site" %}</p>
+        {% include "partials/header.html" with title="Home" %}
+    {% endblock %}
+</div>

--- a/tests/fmt/django/url_tags.html
+++ b/tests/fmt/django/url_tags.html
@@ -1,0 +1,9 @@
+<div>
+    <a href="{% url 'home' %}">Home</a>
+    <a href="{% url 'article-detail' article.id %}">View Article</a>
+    <a href="{% url 'user-profile' username=user.username %}">Profile</a>
+    <form action="{% url 'form-submit' %}" method="post">
+        {% csrf_token %}
+        <button type="submit">Submit</button>
+    </form>
+</div>

--- a/tests/fmt/django/url_tags.snap
+++ b/tests/fmt/django/url_tags.snap
@@ -1,0 +1,12 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    <a href="{% url 'home' %}">Home</a>
+    <a href="{% url 'article-detail' article.id %}">View Article</a>
+    <a href="{% url 'user-profile' username=user.username %}">Profile</a>
+    <form action="{% url 'form-submit' %}" method="post">
+        {% csrf_token %}
+        <button type="submit">Submit</button>
+    </form>
+</div>

--- a/tests/fmt/django/whitespace_edge_cases.html
+++ b/tests/fmt/django/whitespace_edge_cases.html
@@ -1,0 +1,20 @@
+<div>
+    {{value}}
+    {{ value }}
+    {{  value  }}
+    {{value|filter}}
+    {{ value | filter }}
+    {{  value  |  filter  }}
+
+    {%if condition%}
+        <p>No spaces</p>
+    {%endif%}
+
+    {% if condition %}
+        <p>Normal spaces</p>
+    {% endif %}
+
+    {%  if  condition  %}
+        <p>Extra spaces</p>
+    {%  endif  %}
+</div>

--- a/tests/fmt/django/whitespace_edge_cases.snap
+++ b/tests/fmt/django/whitespace_edge_cases.snap
@@ -1,0 +1,23 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ value }}
+    {{ value }}
+    {{ value }}
+    {{ value|filter }}
+    {{ value | filter }}
+    {{ value  |  filter }}
+
+    {% if condition %}
+        <p>No spaces</p>
+    {% endif %}
+
+    {% if condition %}
+        <p>Normal spaces</p>
+    {% endif %}
+
+    {% if  condition %}
+        <p>Extra spaces</p>
+    {% endif %}
+</div>

--- a/tests/fmt/django/with_tag.html
+++ b/tests/fmt/django/with_tag.html
@@ -1,0 +1,14 @@
+<div>
+    {% with total=business.employees.count %}
+        <p>Total employees: {{ total }}</p>
+    {% endwith %}
+
+    {% with alpha=1 beta=2 gamma=3 %}
+        <p>{{ alpha }}, {{ beta }}, {{ gamma }}</p>
+    {% endwith %}
+
+    {% with user.profile.settings as settings %}
+        <p>Theme: {{ settings.theme }}</p>
+        <p>Language: {{ settings.language }}</p>
+    {% endwith %}
+</div>

--- a/tests/fmt/django/with_tag.snap
+++ b/tests/fmt/django/with_tag.snap
@@ -1,0 +1,17 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% with total=business.employees.count %}
+        <p>Total employees: {{ total }}</p>
+    {% endwith %}
+
+    {% with alpha=1 beta=2 gamma=3 %}
+        <p>{{ alpha }}, {{ beta }}, {{ gamma }}</p>
+    {% endwith %}
+
+    {% with user.profile.settings as settings %}
+        <p>Theme: {{ settings.theme }}</p>
+        <p>Language: {{ settings.language }}</p>
+    {% endwith %}
+</div>

--- a/tests/fmt/jinja/complex_expressions.html
+++ b/tests/fmt/jinja/complex_expressions.html
@@ -1,0 +1,8 @@
+<div>
+    {{ user.profile.settings.preferences.theme if user.is_authenticated else default_theme }}
+    {{ items | filter(lambda x: x.is_active and x.priority > 5) | map('name') | join(', ') }}
+    {% for item in collection if item.visible and item.published and not item.archived %}
+        <li>{{ item.title }}</li>
+    {% endfor %}
+    {{ calculate_total(prices, tax_rate, discount_percentage, shipping_cost, handling_fee) }}
+</div>

--- a/tests/fmt/jinja/complex_expressions.snap
+++ b/tests/fmt/jinja/complex_expressions.snap
@@ -1,0 +1,11 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ user.profile.settings.preferences.theme if user.is_authenticated else default_theme }}
+    {{ items | filter(lambda x: x.is_active and x.priority > 5) | map('name') | join(', ') }}
+    {% for item in collection if item.visible and item.published and not item.archived %}
+        <li>{{ item.title }}</li>
+    {% endfor %}
+    {{ calculate_total(prices, tax_rate, discount_percentage, shipping_cost, handling_fee) }}
+</div>

--- a/tests/fmt/jinja/filter_chaining.html
+++ b/tests/fmt/jinja/filter_chaining.html
@@ -1,0 +1,9 @@
+<div>
+    {{ value | lower | capitalize }}
+    {{ text | striptags | truncate(20) | safe }}
+    {{ items | length | default(0) }}
+    {{ content | safe | truncate(100) }}
+    {{ name | slugify | upper | replace("-", "_") }}
+    {{ data | tojson | safe }}
+    {{ list | map('upper') | join(', ') }}
+</div>

--- a/tests/fmt/jinja/filter_chaining.snap
+++ b/tests/fmt/jinja/filter_chaining.snap
@@ -1,0 +1,12 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ value | lower | capitalize }}
+    {{ text | striptags | truncate(20) | safe }}
+    {{ items | length | default(0) }}
+    {{ content | safe | truncate(100) }}
+    {{ name | slugify | upper | replace("-", "_") }}
+    {{ data | tojson | safe }}
+    {{ list | map('upper') | join(', ') }}
+</div>

--- a/tests/fmt/jinja/filters_with_spacing.html
+++ b/tests/fmt/jinja/filters_with_spacing.html
@@ -1,0 +1,10 @@
+<div>
+    {{ value | default("test") }}
+    {{ text | truncate(30) }}
+    {{ items | length }}
+    {{ list | join(", ") }}
+    {{ name | upper }}
+    {{ content | safe }}
+    {{ number | round(2) }}
+    {{ text | replace("old", "new") }}
+</div>

--- a/tests/fmt/jinja/filters_with_spacing.snap
+++ b/tests/fmt/jinja/filters_with_spacing.snap
@@ -1,0 +1,13 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ value | default("test") }}
+    {{ text | truncate(30) }}
+    {{ items | length }}
+    {{ list | join(", ") }}
+    {{ name | upper }}
+    {{ content | safe }}
+    {{ number | round(2) }}
+    {{ text | replace("old", "new") }}
+</div>

--- a/tests/fmt/jinja/long_strings_tag.html
+++ b/tests/fmt/jinja/long_strings_tag.html
@@ -1,0 +1,13 @@
+<div>
+    {% if user.is_authenticated and user.has_permission and user.profile.settings.allow_access and not user.is_banned %}
+        <p>Access granted</p>
+    {% endif %}
+
+    {% include "very/long/path/to/template/that/exceeds/normal/line/length/limits/component.html" %}
+
+    {% set very_long_variable_name_that_exceeds_normal_limits = some_function(arg1, arg2, arg3, arg4, arg5) %}
+
+    {% for item in collection if item.is_active and item.published and item.visible and not item.archived %}
+        <li>{{ item.name }}</li>
+    {% endfor %}
+</div>

--- a/tests/fmt/jinja/long_strings_tag.snap
+++ b/tests/fmt/jinja/long_strings_tag.snap
@@ -1,0 +1,16 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {% if user.is_authenticated and user.has_permission and user.profile.settings.allow_access and not user.is_banned %}
+        <p>Access granted</p>
+    {% endif %}
+
+    {% include "very/long/path/to/template/that/exceeds/normal/line/length/limits/component.html" %}
+
+    {% set very_long_variable_name_that_exceeds_normal_limits = some_function(arg1, arg2, arg3, arg4, arg5) %}
+
+    {% for item in collection if item.is_active and item.published and item.visible and not item.archived %}
+        <li>{{ item.name }}</li>
+    {% endfor %}
+</div>

--- a/tests/fmt/jinja/long_strings_variable.html
+++ b/tests/fmt/jinja/long_strings_variable.html
@@ -1,0 +1,6 @@
+<div>
+    {{ "This is a very long string that should probably be wrapped or handled in some way because it exceeds the normal line length limits" }}
+    {{ user.profile.settings.preferences.notification.email.frequency.daily.digest.enabled }}
+    {{ very_long_variable_name_that_exceeds_line_length_and_should_be_handled_appropriately }}
+    {{ config.api.endpoints.production.url.base + config.api.endpoints.production.url.version }}
+</div>

--- a/tests/fmt/jinja/long_strings_variable.snap
+++ b/tests/fmt/jinja/long_strings_variable.snap
@@ -1,0 +1,11 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{
+        "This is a very long string that should probably be wrapped or handled in some way because it exceeds the normal line length limits"
+    }}
+    {{ user.profile.settings.preferences.notification.email.frequency.daily.digest.enabled }}
+    {{ very_long_variable_name_that_exceeds_line_length_and_should_be_handled_appropriately }}
+    {{ config.api.endpoints.production.url.base + config.api.endpoints.production.url.version }}
+</div>

--- a/tests/fmt/jinja/mixed_quotes.html
+++ b/tests/fmt/jinja/mixed_quotes.html
@@ -1,0 +1,19 @@
+<div>
+    {{ "double quotes" }}
+    {{ 'single quotes' }}
+    {{ "string with 'nested' quotes" }}
+    {{ 'string with "nested" quotes' }}
+
+    {% if value == "test" %}
+        <p>Double quotes in condition</p>
+    {% endif %}
+
+    {% if value == 'test' %}
+        <p>Single quotes in condition</p>
+    {% endif %}
+
+    {% set name = "John" %}
+    {% set name = 'Jane' %}
+
+    {{ func("arg1", 'arg2', "arg3") }}
+</div>

--- a/tests/fmt/jinja/mixed_quotes.snap
+++ b/tests/fmt/jinja/mixed_quotes.snap
@@ -1,0 +1,22 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ "double quotes" }}
+    {{ 'single quotes' }}
+    {{ "string with 'nested' quotes" }}
+    {{ 'string with "nested" quotes' }}
+
+    {% if value == "test" %}
+        <p>Double quotes in condition</p>
+    {% endif %}
+
+    {% if value == 'test' %}
+        <p>Single quotes in condition</p>
+    {% endif %}
+
+    {% set name = "John" %}
+    {% set name = 'Jane' %}
+
+    {{ func("arg1", 'arg2', "arg3") }}
+</div>

--- a/tests/fmt/jinja/nested_structures.html
+++ b/tests/fmt/jinja/nested_structures.html
@@ -1,0 +1,6 @@
+<div>
+    {{ {'user': {'name': user.name, 'email': user.email, 'settings': {'theme': 'dark', 'lang': 'en'}}} }}
+    {{ [[1, 2, 3], [4, 5, 6], [7, 8, 9]] }}
+    {{ function(nested_function(inner_arg1, inner_arg2), another_arg) }}
+    {% set config = {'api': {'endpoint': 'https://api.example.com', 'version': 'v2', 'timeout': 30}} %}
+</div>

--- a/tests/fmt/jinja/nested_structures.snap
+++ b/tests/fmt/jinja/nested_structures.snap
@@ -1,0 +1,9 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ {'user': {'name': user.name, 'email': user.email, 'settings': {'theme': 'dark', 'lang': 'en'}}} }}
+    {{ [[1, 2, 3], [4, 5, 6], [7, 8, 9]] }}
+    {{ function(nested_function(inner_arg1, inner_arg2), another_arg) }}
+    {% set config = {'api': {'endpoint': 'https://api.example.com', 'version': 'v2', 'timeout': 30}} %}
+</div>

--- a/tests/fmt/jinja/operator_linebreak.html
+++ b/tests/fmt/jinja/operator_linebreak.html
@@ -1,0 +1,7 @@
+<div>
+    {{ very_long_variable_name + another_long_variable + yet_another_variable + one_more_variable }}
+    {{ condition_one and condition_two and condition_three or condition_four }}
+    {% if user.is_authenticated and user.has_permission and user.is_active %}
+        <p>Welcome</p>
+    {% endif %}
+</div>

--- a/tests/fmt/jinja/operator_linebreak.snap
+++ b/tests/fmt/jinja/operator_linebreak.snap
@@ -1,0 +1,10 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ very_long_variable_name + another_long_variable + yet_another_variable + one_more_variable }}
+    {{ condition_one and condition_two and condition_three or condition_four }}
+    {% if user.is_authenticated and user.has_permission and user.is_active %}
+        <p>Welcome</p>
+    {% endif %}
+</div>

--- a/tests/fmt/jinja/prefer_single_line.html
+++ b/tests/fmt/jinja/prefer_single_line.html
@@ -1,0 +1,9 @@
+<div>
+    {{ simple_function(a, b, c) }}
+    {{ another_function(x, y, z) }}
+    {{ short_dict['a']['b']['c'] }}
+    {{ [1, 2, 3, 4, 5] }}
+    {% if condition %}
+        <p>Content</p>
+    {% endif %}
+</div>

--- a/tests/fmt/jinja/prefer_single_line.snap
+++ b/tests/fmt/jinja/prefer_single_line.snap
@@ -1,0 +1,12 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ simple_function(a, b, c) }}
+    {{ another_function(x, y, z) }}
+    {{ short_dict['a']['b']['c'] }}
+    {{ [1, 2, 3, 4, 5] }}
+    {% if condition %}
+        <p>Content</p>
+    {% endif %}
+</div>

--- a/tests/fmt/jinja/spacing_braces.html
+++ b/tests/fmt/jinja/spacing_braces.html
@@ -1,0 +1,5 @@
+<div>
+    {{ {key1: value1, key2: value2, key3: value3} }}
+    {{ {'name': 'John', 'age': 30, 'city': 'NYC'} }}
+    {% set my_dict = {a: 1, b: 2, c: 3} %}
+</div>

--- a/tests/fmt/jinja/spacing_braces.snap
+++ b/tests/fmt/jinja/spacing_braces.snap
@@ -1,0 +1,8 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ {key1: value1, key2: value2, key3: value3} }}
+    {{ {'name': 'John', 'age': 30, 'city': 'NYC'} }}
+    {% set my_dict = {a: 1, b: 2, c: 3} %}
+</div>

--- a/tests/fmt/jinja/spacing_brackets.html
+++ b/tests/fmt/jinja/spacing_brackets.html
@@ -1,0 +1,6 @@
+<div>
+    {{ [1, 2, 3, 4, 5] }}
+    {{ ['apple', 'banana', 'cherry'] }}
+    {{ my_list[0][1][2] }}
+    {% set items = [a, b, c, d] %}
+</div>

--- a/tests/fmt/jinja/spacing_brackets.snap
+++ b/tests/fmt/jinja/spacing_brackets.snap
@@ -1,0 +1,9 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ [1, 2, 3, 4, 5] }}
+    {{ ['apple', 'banana', 'cherry'] }}
+    {{ my_list[0][1][2] }}
+    {% set items = [a, b, c, d] %}
+</div>

--- a/tests/fmt/jinja/spacing_parens.html
+++ b/tests/fmt/jinja/spacing_parens.html
@@ -1,0 +1,8 @@
+<div>
+    {{ function(arg1, arg2, arg3) }}
+    {{ method(param1, param2) }}
+    {{ (tuple_value1, tuple_value2, tuple_value3) }}
+    {% macro my_macro(param1, param2, param3) %}
+        <p>{{ param1 }}</p>
+    {% endmacro %}
+</div>

--- a/tests/fmt/jinja/spacing_parens.snap
+++ b/tests/fmt/jinja/spacing_parens.snap
@@ -1,0 +1,11 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ function(arg1, arg2, arg3) }}
+    {{ method(param1, param2) }}
+    {{ (tuple_value1, tuple_value2, tuple_value3) }}
+    {% macro my_macro(param1, param2, param3) %}
+        <p>{{ param1 }}</p>
+    {% endmacro %}
+</div>

--- a/tests/fmt/jinja/trailing_comma.html
+++ b/tests/fmt/jinja/trailing_comma.html
@@ -1,0 +1,6 @@
+<div>
+    {{ my_function(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) }}
+    {{ my_dict['key1']['key2']['key3']['key4']['key5']['key6']['key7'] }}
+    {{ [item1, item2, item3, item4, item5, item6, item7, item8, item9, item10] }}
+    {{ (value1, value2, value3, value4, value5, value6, value7, value8) }}
+</div>

--- a/tests/fmt/jinja/trailing_comma.snap
+++ b/tests/fmt/jinja/trailing_comma.snap
@@ -1,0 +1,9 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ my_function(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) }}
+    {{ my_dict['key1']['key2']['key3']['key4']['key5']['key6']['key7'] }}
+    {{ [item1, item2, item3, item4, item5, item6, item7, item8, item9, item10] }}
+    {{ (value1, value2, value3, value4, value5, value6, value7, value8) }}
+</div>

--- a/tests/fmt/jinja/whitespace_edge_cases.html
+++ b/tests/fmt/jinja/whitespace_edge_cases.html
@@ -1,0 +1,28 @@
+<div>
+    {{value}}
+    {{ value }}
+    {{  value  }}
+    {{value|filter}}
+    {{ value | filter }}
+    {{  value  |  filter  }}
+
+    {%if condition%}
+        <p>No spaces</p>
+    {%endif%}
+
+    {% if condition %}
+        <p>Normal spaces</p>
+    {% endif %}
+
+    {%  if  condition  %}
+        <p>Extra spaces</p>
+    {%  endif  %}
+
+    {{- value -}}
+    {{- value }}
+    {{ value -}}
+
+    {%- if condition -%}
+        <p>Whitespace control</p>
+    {%- endif -%}
+</div>

--- a/tests/fmt/jinja/whitespace_edge_cases.snap
+++ b/tests/fmt/jinja/whitespace_edge_cases.snap
@@ -1,0 +1,31 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    {{ value }}
+    {{ value }}
+    {{ value }}
+    {{ value|filter }}
+    {{ value | filter }}
+    {{ value  |  filter }}
+
+    {% if condition %}
+        <p>No spaces</p>
+    {% endif %}
+
+    {% if condition %}
+        <p>Normal spaces</p>
+    {% endif %}
+
+    {% if  condition %}
+        <p>Extra spaces</p>
+    {% endif %}
+
+    {{ - value - }}
+    {{ - value }}
+    {{ value - }}
+
+    {%- if condition -%}
+        <p>Whitespace control</p>
+    {%- endif -%}
+</div>


### PR DESCRIPTION
Try the https://github.com/g-plane/pretty_jinja integration

With markup_fmt v0.25, there is no default formatting so adding pretty_jinja should also fix these formatting:

```diff
 <div class="portico-pricing showing-cloud">
     {% with %}
-        {% set rendering_page = "cloud" %}
+        {% set rendering_page="cloud" %}
         {% include "corporate/pricing_model.html" %}
     {% endwith %}
 </div>
```

Todos:
- ensure it cannot create invalid multiline or filters