### PR TITLE
Add custom `<!-- djangofmt:ignore -->` directive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,11 +249,13 @@ dependencies = [
  "colored",
  "derive_more",
  "dprint_plugin_markup",
+ "insta",
  "insta-cmd",
  "malva",
  "markup_fmt",
  "rayon",
  "serde_json",
+ "similar-asserts",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -300,6 +313,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,14 +350,16 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.43.1"
+version = "1.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
 dependencies = [
  "console",
+ "globset",
  "once_cell",
  "serde",
  "similar",
+ "walkdir",
 ]
 
 [[package]]
@@ -505,6 +533,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +567,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -581,6 +635,20 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+dependencies = [
+ "console",
+ "similar",
+]
 
 [[package]]
 name = "smallvec"
@@ -710,6 +778,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +806,25 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ tracing-tree = "0.4.0"
 derive_more = { version = "2.0.1", features = ["from", "display"] }
 
 [dev-dependencies]
+insta = { version = "1.44.2", features = ["yaml", "glob"] }
 insta-cmd = "=0.6.0"
+similar-asserts = "1.7"
 
 [profile.release]
 # See python/benchmark_cargo_profiles.py

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -43,6 +43,9 @@ pub fn format(args: FormatCommand, global_options: &GlobalConfigArgs) -> Result<
             prefer_attrs_single_line: false,
             // Parse some additional custom blocks, for ex "stage,cache,flatblock,section,csp_compress"
             custom_blocks: args.custom_blocks,
+            // Custom ignore comment directives for djangofmt
+            ignore_comment_directive: "djangofmt:ignore".into(),
+            ignore_file_comment_directive: "djangofmt:ignore".into(),
             ..LanguageOptions::default()
         },
     };

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -1,0 +1,80 @@
+use insta::{Settings, assert_snapshot, glob};
+use markup_fmt::{
+    Language,
+    config::{FormatOptions, LanguageOptions, LayoutOptions},
+    format_text,
+};
+use std::{borrow::Cow, fs, path::Path};
+
+#[test]
+fn fmt_snapshot() {
+    let pattern = "fmt/**/*.html";
+    glob!(pattern, |path| {
+        let input = fs::read_to_string(path).unwrap();
+        let output = run_format_test(path, &input);
+        build_settings(path).bind(|| {
+            let name = path.file_stem().unwrap().to_str().unwrap();
+            assert_snapshot!(name, output);
+        });
+    });
+}
+
+fn run_format_test(path: &Path, input: &str) -> String {
+    let options = FormatOptions {
+        layout: LayoutOptions {
+            print_width: 120,
+            indent_width: 4,
+            ..LayoutOptions::default()
+        },
+        language: LanguageOptions {
+            html_void_self_closing: Some(false),
+            svg_self_closing: Some(true),
+            mathml_self_closing: Some(true),
+            html_normal_self_closing: Some(false),
+            prefer_attrs_single_line: false,
+            custom_blocks: None,
+            ignore_comment_directive: "djangofmt:ignore".into(),
+            ignore_file_comment_directive: "djangofmt:ignore".into(),
+            ..LanguageOptions::default()
+        },
+    };
+
+    let output = format_text(input, Language::Django, &options, |code, _| {
+        Ok::<_, ()>(Cow::from(code))
+    })
+    .map_err(|err| format!("failed to format '{}': {:?}", path.display(), err))
+    .unwrap();
+
+    // Stability test: format the output again and ensure it's the same
+    let regression_format = format_text(&output, Language::Django, &options, |code, _| {
+        Ok::<_, ()>(Cow::from(code))
+    })
+    .map_err(|err| {
+        format!(
+            "syntax error in stability test '{}': {:?}",
+            path.display(),
+            err
+        )
+    })
+    .unwrap();
+
+    similar_asserts::assert_eq!(
+        output,
+        regression_format,
+        "'{}' format is unstable",
+        path.display()
+    );
+
+    output
+}
+
+fn build_settings(path: &Path) -> Settings {
+    let mut settings = Settings::clone_current();
+    settings.set_snapshot_path(path.parent().unwrap());
+    settings.remove_snapshot_suffix();
+    settings.set_prepend_module_to_snapshot(false);
+    settings.remove_input_file();
+    settings.set_omit_expression(true);
+    settings.remove_info();
+    settings
+}

--- a/tests/fmt/ignore/ignore_comment_directive.html
+++ b/tests/fmt/ignore/ignore_comment_directive.html
@@ -1,0 +1,6 @@
+<div>
+    <!-- djangofmt:ignore -->
+    <p     class="unformatted"      >This should not be formatted</p>
+    <!-- end djangofmt:ignore -->
+</div>
+<p     class="formatted"     >This should be formatted</p>

--- a/tests/fmt/ignore/ignore_comment_directive.snap
+++ b/tests/fmt/ignore/ignore_comment_directive.snap
@@ -1,0 +1,9 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    <!-- djangofmt:ignore -->
+    <p     class="unformatted"      >This should not be formatted</p>
+    <!-- end djangofmt:ignore -->
+</div>
+<p class="formatted">This should be formatted</p>

--- a/tests/fmt/ignore/ignore_file_comment_directive.html
+++ b/tests/fmt/ignore/ignore_file_comment_directive.html
@@ -1,0 +1,4 @@
+<!-- djangofmt:ignore -->
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>

--- a/tests/fmt/ignore/ignore_file_comment_directive.snap
+++ b/tests/fmt/ignore/ignore_file_comment_directive.snap
@@ -1,0 +1,7 @@
+---
+source: tests/fmt.rs
+---
+<!-- djangofmt:ignore -->
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>

--- a/tests/fmt/ignore/without_ignore_directive.html
+++ b/tests/fmt/ignore/without_ignore_directive.html
@@ -1,0 +1,3 @@
+<div>
+    <p     class="should-format"      >This should be formatted</p>
+</div>

--- a/tests/fmt/ignore/without_ignore_directive.snap
+++ b/tests/fmt/ignore/without_ignore_directive.snap
@@ -1,0 +1,6 @@
+---
+source: tests/fmt.rs
+---
+<div>
+    <p class="should-format">This should be formatted</p>
+</div>


### PR DESCRIPTION
Allows this:
```diff
<div>
    <!-- djangofmt:ignore -->
    <p     class="unformatted"      >This should not be formatted</p>
    <!-- end djangofmt:ignore -->
</div>
-<p     class="formatted"     >This should be formatted</p>
+<p class="formatted">This should be formatted</p>
```