### PR TITLE
Try jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "serial_test",
  "similar-asserts",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -1385,6 +1386,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ wasm-bindgen = { version = "0.2" }
 # Benchmarking
 divan = { package = "codspeed-divan-compat", version = "*" }
 
+# Perf
+# This has to be kept in sync with src/main.rs where the allocator for the program is set.
+tikv-jemallocator = { version = "0.6.1" }
+
 # Dev dependencies
 gag = { version = "=1.0.0" }
 insta = { version = "=1.44.3", features = ["yaml", "glob"] }

--- a/crates/djangofmt/Cargo.toml
+++ b/crates/djangofmt/Cargo.toml
@@ -29,6 +29,9 @@ tracing-tree = { workspace = true }
 miette = { workspace = true }
 thiserror = { workspace = true }
 
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "aix"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64")))'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
+
 [dev-dependencies]
 gag = { workspace = true }
 insta = { workspace = true }
@@ -36,6 +39,10 @@ insta-cmd = { workspace = true }
 rstest = { workspace = true }
 serial_test = { workspace = true }
 similar-asserts = { workspace = true }
+
+[features]
+use-jemalloc = ["tikv-jemallocator"]
+default = ["use-jemalloc"]
 
 [lints]
 workspace = true

--- a/crates/djangofmt/src/main.rs
+++ b/crates/djangofmt/src/main.rs
@@ -6,6 +6,24 @@ use colored::Colorize;
 use djangofmt::args::{Args, Commands};
 use djangofmt::{ExitStatus, run};
 
+// We use jemalloc for performance reasons.
+// This has to be kept in sync with the Cargo.toml file section that declares a dependency on tikv-jemallocator.
+#[cfg(all(
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(target_os = "openbsd"),
+    not(target_os = "aix"),
+    not(target_os = "android"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "powerpc64",
+        target_arch = "riscv64"
+    ),
+    feature = "use-jemalloc"
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[must_use]
 pub fn main() -> ExitCode {
     let args = Args::parse();


### PR DESCRIPTION
Local benchmark shows up to a 30% perf improvement

```bash
Benchmark 1: cat /home/thibaut/greenday/mysite/files | xargs --max-procs=0 ./target/release/djangofmt-jemalloc --profile django --line-length 120 --quiet
  Time (mean ± σ):      32.5 ms ±   1.8 ms    [User: 251.7 ms, System: 84.0 ms]
  Range (min … max):    28.4 ms …  38.2 ms    1000 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: cat /home/thibaut/greenday/mysite/files | xargs --max-procs=0 ./target/release/djangofmt-no-jemalloc --profile django --line-length 120 --quiet
  Time (mean ± σ):      42.4 ms ±   1.5 ms    [User: 268.2 ms, System: 105.3 ms]
  Range (min … max):    37.5 ms …  47.9 ms    1000 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  cat /home/thibaut/greenday/mysite/files | xargs --max-procs=0 ./target/release/djangofmt-jemalloc --profile django --line-length 120 --quiet ran
    1.31 ± 0.09 times faster than cat /home/thibaut/greenday/mysite/files | xargs --max-procs=0 ./target/release/djangofmt-no-jemalloc --profile django --line-length 120 --quiet
```

Fixes #45