### PR TITLE
Add cargo-bloat

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -1,0 +1,50 @@
+# Run `cargo bloat` for finding out what takes most of the space in your executable.
+name: Cargo Bloat
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name"
+        required: true
+        default: "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bloat:
+    name: Cargo Bloat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          persist-credentials: false
+      - uses: cargo-bins/cargo-binstall@ea60fcf749c6a52a729e0eaabb5eb33391d44823 # v1.16.4
+      - run: cargo binstall --no-confirm cargo-bloat
+      - name: Run
+        env:
+          RUSTFLAGS: "-C debuginfo=2 -C strip=none"
+        shell: bash
+        run: |
+          {
+            echo "# Bloat Summary"
+            echo
+            echo "## Largest functions"
+            echo '```'
+            echo
+            cargo bloat --release -p djangofmt -n 15 2> /dev/null
+            echo
+            echo '```'
+            echo
+            echo "## Largest crates"
+            echo '```'
+            echo
+            cargo bloat --release -p djangofmt --crates -n 15 2> /dev/null
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adapted from [oxc action](https://github.com/oxc-project/oxc/blob/main/.github/workflows/bloat.yml)

Only with the workflow dispatch trigger since I think it's wasteful to run it all the time because it will usually not be very actionable. This is intended to be used when we add a new dependency