### PR TITLE
Fix: dprint pre-commit hook is using hardcoded binary path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,7 +87,8 @@ repos:
     hooks:
       - id: dprint-fmt
         name: dprint
-        entry: /home/thibaut/.dprint/bin/dprint fmt --config dprint.json --allow-no-files
+        entry: dprint
+        args: [fmt, --config, dprint.json, --allow-no-files]
         language: system
         require_serial: true
         types: [text]


### PR DESCRIPTION
# Description of the issue
When cloning the repo and installing/running pre-commit hooks, the current configuration fails because of hardcoded binary path usage for dprint : `/home/thibaut/.dprint/bin/dprint`

# Suggestion
Changed `entry`  to `dprint` to rely on host sytem binary resolution thanks to `$PATH` variable.
Contributors will have to add their `dprint` installation path to the global env variable `$PATH`.

Also maybe it will require to add documentation to install `dprint` as a requirement in `CONTRIBUTING.md`. Not sure on how you would like to do it, I preferred relying on your vision for that.