### PR TITLE
always swap wrapping quotes if attribute contains one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.25.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=a00a7e4da502b92dc2d19f6d15f1c4bdfeccdfed#a00a7e4da502b92dc2d19f6d15f1c4bdfeccdfed"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=v0.25.3.0#365ff0f8fb7cbc6dad3df36d99574da5aff4b1dc"
 dependencies = [
  "aho-corasick",
  "css_dataset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ divan = { package = "codspeed-divan-compat", version = "*" }
 insta = { version = "=1.46.3", features = ["glob", "yaml"] }
 insta-cmd = { version = "=0.6.0" }
 malva = { version = "0.15.1", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "a00a7e4da502b92dc2d19f6d15f1c4bdfeccdfed" }
+markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "v0.25.3.0" }
 miette = { version = "7.6.0", features = ["fancy"] }
 rayon = { version = "1.11.0" }
 rstest = { version = "=0.26.1" }


### PR DESCRIPTION
Bring upstream improvements:
- [feat: format event handler inlined in attributes](https://github.com/g-plane/markup_fmt/commit/0ca9201884f63c52a9ed375633f80aff34798b69)
- [feat: support old JSON content type](https://github.com/g-plane/markup_fmt/commit/d62c1a52b5e89e860453e732fb6ba4f912e596d0)
- [format](https://github.com/g-plane/markup_fmt/commit/8714dca5c9966b6a7279b44954b527c44396b36b) [accept](https://github.com/g-plane/markup_fmt/commit/8714dca5c9966b6a7279b44954b527c44396b36b) [attr value as comma-separated string](https://github.com/g-plane/markup_fmt/commit/8714dca5c9966b6a7279b44954b527c44396b36b)
- [feat: always swap wrapping quotes if attribute contains one](https://github.com/g-plane/markup_fmt/commit/0b0aa9534aaef6024385357ec8df17bbd1654d3f)




Fixes #179

<details><summary>Outdated</summary>
<p>


### TODOS

- [x] Investigate perf regression -> I mesure 1% regression on my usual test repo so it's ok
- [x] Add a just recipe for benchmarking dev vs system djangofmt on a provided git folder  -> https://github.com/UnknownPlatypus/djangofmt/pull/181
- [x] Investigate formatting change for script tag ld+json (saleor/saleor) -> expected, it was previously wrongly formatted as javscript. It does showcase the indent issue however
```diff
<script type="application/ld+json">
-        {{{{raw}}}}{{schema_markup}}{{{{/raw}}}}
+    {{{{raw}}}}{{schema_markup}}{{{{/raw}}}}
     </script>
```
- [x] And for `text/json` ([stability issue](https://github.com/UnknownPlatypus/djangofmt/actions/runs/21430781052)) -> was incorrectly formatted as javascript, fixed in later commit


</p>
</details> 
