### PR TITLE
Fixes extra indent for `{% plural %}` inside `blocktranslate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.26.0"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=e1fae95c866b7bd755ade01353ee90f630afc3e7#e1fae95c866b7bd755ade01353ee90f630afc3e7"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=d1bf5412aa630f9e9f1c908b86a425534c7fedfe#d1bf5412aa630f9e9f1c908b86a425534c7fedfe"
 dependencies = [
  "aho-corasick",
  "css_dataset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ dprint-plugin-json = { version = "0.21.1" }
 insta = { version = "1.46.3", features = ["glob", "yaml"] }
 insta-cmd = { version = "0.6.0" }
 malva = { version = "0.15.2", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "e1fae95c866b7bd755ade01353ee90f630afc3e7" }
+markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "d1bf5412aa630f9e9f1c908b86a425534c7fedfe" }
 miette = { version = "7.6.0", features = ["fancy"] }
 rayon = { version = "1.11.0" }
 rstest = { version = "=0.26.1" }


### PR DESCRIPTION
Fixes #197