### PR TITLE
Add support for Django template partials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,8 +813,8 @@ dependencies = [
 
 [[package]]
 name = "markup_fmt"
-version = "0.26.0"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=d1bf5412aa630f9e9f1c908b86a425534c7fedfe#d1bf5412aa630f9e9f1c908b86a425534c7fedfe"
+version = "0.27.0"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=8fdba327b76dd601fe8e7120a501db262b0c6030#8fdba327b76dd601fe8e7120a501db262b0c6030"
 dependencies = [
  "aho-corasick",
  "css_dataset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.0"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=8fdba327b76dd601fe8e7120a501db262b0c6030#8fdba327b76dd601fe8e7120a501db262b0c6030"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=096b0c6a8cf35aae960fef4c2988fbdaae93f872#096b0c6a8cf35aae960fef4c2988fbdaae93f872"
 dependencies = [
  "aho-corasick",
  "css_dataset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ignore = { version = "0.4.25" }
 insta = { version = "1.46.3", features = ["glob", "yaml"] }
 insta-cmd = { version = "0.6.0" }
 malva = { version = "0.15.2", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "d1bf5412aa630f9e9f1c908b86a425534c7fedfe" }
+markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "8fdba327b76dd601fe8e7120a501db262b0c6030" }
 miette = { version = "7.6.0", features = ["fancy"] }
 rayon = { version = "1.11.0" }
 rstest = { version = "=0.26.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ignore = { version = "0.4.25" }
 insta = { version = "1.46.3", features = ["glob", "yaml"] }
 insta-cmd = { version = "0.6.0" }
 malva = { version = "0.15.2", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "8fdba327b76dd601fe8e7120a501db262b0c6030" }
+markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "096b0c6a8cf35aae960fef4c2988fbdaae93f872" }
 miette = { version = "7.6.0", features = ["fancy"] }
 rayon = { version = "1.11.0" }
 rstest = { version = "=0.26.1" }


### PR DESCRIPTION
Adds parser support for the [Django template partials](https://docs.djangoproject.com/en/6.0/ref/templates/language/#template-partials)
                                                                                                                                                                
  - `{% partialdef name %}…{% endpartialdef %}` is now treated as a block, so its contents are indented like `{% block %}`.                                     
  - `{% partial name %}` is recognized as a tag