### PR TITLE
Add autofix framework to the `djangofmt check` command (+ one rule `blocktranslate-no-trimmed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "miette",
  "rayon",
  "rstest",
+ "rustc-hash",
  "serde",
  "similar-asserts",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
 name = "djangofmt_lint"
 version = "0.2.7"
 dependencies = [
+ "anyhow",
  "insta",
  "markup_fmt",
  "miette",
@@ -430,6 +431,7 @@ dependencies = [
  "serde",
  "strum",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/UnknownPlatypus/djangofmt"
 license = "MIT"
 
 [workspace.dependencies]
+anyhow = { version = "1.0.100" }
 clap = { version = "4.5.57", features = ["derive", "wrap_help"] }
 clap_complete_command = { version = "0.6.1" }
 divan = { package = "codspeed-divan-compat", version = "*" }

--- a/crates/djangofmt/Cargo.toml
+++ b/crates/djangofmt/Cargo.toml
@@ -24,6 +24,7 @@ markup_fmt = { workspace = true }
 # Error reporting
 miette = { workspace = true }
 rayon = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -149,7 +149,6 @@ impl From<Profile> for Language {
 #[derive(Debug, clap::Subcommand)]
 pub enum Commands {
     /// Check files for lint errors
-    #[clap(hide = true)]
     Check(CheckCommand),
     /// Generate shell completions
     #[clap(hide = true)]
@@ -168,6 +167,16 @@ pub struct CheckCommand {
     /// Template language profile to use [default: django]
     #[arg(long, value_enum)]
     pub profile: Option<Profile>,
+    /// Apply safe fixes automatically.
+    #[arg(long)]
+    pub fix: bool,
+    /// Include unsafe fixes when applying with --fix. Without --fix,
+    /// diagnostics from unsafe fixes are still reported as fixable.
+    #[arg(long)]
+    pub unsafe_fixes: bool,
+    /// List per-rule fix counts after applying.
+    #[arg(long)]
+    pub show_fixes: bool,
     #[clap(flatten)]
     pub file_selection: FileSelectionArgs,
 }
@@ -225,6 +234,13 @@ mod tests {
         A fast, HTML aware, Django template formatter, written in Rust.
 
         Usage: djangofmt [OPTIONS] <FILES>...
+               djangofmt [OPTIONS] [FILES]... <COMMAND>
+
+        Commands:
+          check
+                  Check files for lint errors
+          help
+                  Print this message or the help of the given subcommand(s)
 
         Arguments:
           <FILES>...

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,73 +1,180 @@
-use djangofmt_lint::{FileDiagnostics, Settings, check_ast};
+use djangofmt_lint::{
+    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings, check_ast, lint_fix,
+};
 use markup_fmt::FormatError;
 use markup_fmt::parser::Parser;
 use miette::NamedSource;
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rustc_hash::FxHashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::ExitStatus;
 use crate::args::{CheckCommand, Profile};
 use crate::error::{CommandError, ParseError, Result};
+
+/// Per-file outcome of `check_path`.
+struct CheckResult {
+    /// Owning path for display.
+    path: PathBuf,
+    /// Diagnostics still present after any fixes were applied.
+    file_diagnostics: FileDiagnostics,
+    /// Total fixes applied to this file (0 when `--fix` is off).
+    applied_count: usize,
+    /// Per-rule applied summaries, for `--show-fixes`.
+    fixes_by_rule: FxHashMap<String, RuleFixSummary>,
+}
 
 /// Check the given source code for linting errors.
 pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
     let resolved = super::resolve_command(&args.files, args.profile, &args.file_selection)?;
 
     let settings = Settings::default();
+    let threshold = if args.unsafe_fixes {
+        Applicability::Unsafe
+    } else {
+        Applicability::Safe
+    };
 
     let start = Instant::now();
-    let (file_diagnostics, mut parse_errors): (Vec<_>, Vec<_>) = resolved
+    let (results, mut parse_errors): (Vec<_>, Vec<_>) = resolved
         .files
         .par_iter()
-        .map(|path| check_path(path, resolved.profile, &settings))
+        .map(|path| check_path(path, resolved.profile, &settings, args.fix, threshold))
         .partition_map(|result| match result {
-            Ok(diags) => Left(diags),
+            Ok(r) => Left(r),
             Err(err) => Right(err),
         });
 
     let duration = start.elapsed();
     debug!("Checked {} files in {:.2?}", resolved.files.len(), duration);
 
-    // Report on any parsing errors.
     parse_errors.sort_unstable_by(|a, b| a.path().cmp(&b.path()));
     let error_count = parse_errors.len();
-    for error in parse_errors {
-        error!("{:?}", miette::Report::new(*error));
+    for err in parse_errors {
+        error!("{:?}", miette::Report::new(*err));
     }
     if error_count > 0 {
         error!("Couldn't check {} files!", error_count);
     }
 
-    // Filter out files with no diagnostics and count total
-    let file_diagnostics: Vec<_> = file_diagnostics
-        .into_iter()
-        .filter(|fd| !fd.is_empty())
-        .collect();
-    let total_diagnostics: usize = file_diagnostics.iter().map(FileDiagnostics::len).sum();
+    let mut total_diagnostics = 0usize;
+    let mut total_applied = 0usize;
+    let mut total_safe_fixable = 0usize;
+    let mut total_unsafe_fixable = 0usize;
+    for result in &results {
+        total_diagnostics += result.file_diagnostics.len();
+        total_applied += result.applied_count;
+        for diag in &result.file_diagnostics.related {
+            let Some(fix) = diag.fix.as_ref() else {
+                continue;
+            };
+            if fix.applies(Applicability::Safe) {
+                total_safe_fixable += 1;
+            } else if fix.applies(Applicability::Unsafe) {
+                total_unsafe_fixable += 1;
+            }
+        }
+    }
+    if args.unsafe_fixes {
+        total_unsafe_fixable = 0;
+    }
+
+    for result in &results {
+        if !result.file_diagnostics.is_empty() {
+            error!("{:?}", miette::Report::new(result.file_diagnostics.clone()));
+        }
+    }
+
+    print_summary(
+        total_diagnostics,
+        total_applied,
+        total_safe_fixable,
+        total_unsafe_fixable,
+        args.fix,
+        error_count,
+    );
+
+    if args.show_fixes && total_applied > 0 {
+        print_show_fixes(&results, total_applied);
+    }
 
     if total_diagnostics == 0 && error_count == 0 {
         return Ok(ExitStatus::Success);
     }
-
-    // Report diagnostics per file
-    for file_diag in file_diagnostics {
-        error!("{:?}", miette::Report::new(file_diag));
-    }
-
     Ok(ExitStatus::Failure)
 }
 
+fn print_summary(
+    total: usize,
+    applied: usize,
+    safe_fixable: usize,
+    unsafe_fixable: usize,
+    apply_to_disk: bool,
+    parse_errors: usize,
+) {
+    if total == 0 && applied == 0 {
+        if parse_errors == 0 {
+            info!("All checks passed!");
+        }
+        return;
+    }
+
+    if apply_to_disk {
+        let found = applied + total;
+        info!("Found {found} errors ({applied} fixed, {total} remaining).");
+    } else if safe_fixable > 0 {
+        let suffix = if unsafe_fixable > 0 {
+            format!(" ({unsafe_fixable} hidden fixes can be enabled with --unsafe-fixes)")
+        } else {
+            String::new()
+        };
+        info!("Found {total} errors. [*] {safe_fixable} fixable with the --fix option.{suffix}");
+    } else if unsafe_fixable > 0 {
+        info!(
+            "Found {total} errors. ({unsafe_fixable} hidden fixes can be enabled with --unsafe-fixes)"
+        );
+    } else {
+        info!("Found {total} errors.");
+    }
+}
+
+fn print_show_fixes(results: &[CheckResult], total_applied: usize) {
+    info!("Fixed {total_applied} errors:");
+    for result in results {
+        if result.applied_count == 0 {
+            continue;
+        }
+        info!("- {}:", result.path.display());
+        let mut entries: Vec<_> = result.fixes_by_rule.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+        for (rule, summary) in entries {
+            let count = summary.count;
+            if let Some(title) = summary.fix_title.as_deref() {
+                info!("    {count} × {rule} ({title})");
+            } else {
+                info!("    {count} × {rule}");
+            }
+        }
+    }
+}
+
 /// Check the file at the given [`Path`] for linting issues.
-#[tracing::instrument(level = "debug", skip_all, fields(path = %path.display()))]
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(path = %path.display())
+)]
 fn check_path(
     path: &Path,
     profile: Option<Profile>,
     settings: &Settings,
-) -> std::result::Result<FileDiagnostics, Box<CommandError>> {
+    fix: bool,
+    threshold: Applicability,
+) -> std::result::Result<CheckResult, Box<CommandError>> {
     let profile = profile
         .or_else(|| Profile::from_path(path))
         .unwrap_or_default();
@@ -86,13 +193,57 @@ fn check_path(
         }
     };
 
-    let diagnostics = check_ast(&source, &ast, settings);
+    if fix {
+        match lint_fix(&source, settings, profile.into(), threshold) {
+            Ok(result) => {
+                if result.applied_count > 0 && result.source != source {
+                    fs::write(path, &result.source)
+                        .map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
+                }
 
-    if diagnostics.is_empty() {
-        return Ok(FileDiagnostics::empty());
+                let file_diagnostics = if result.remaining_diagnostics.is_empty() {
+                    FileDiagnostics::empty()
+                } else {
+                    FileDiagnostics::new(
+                        NamedSource::new(path.to_string_lossy(), result.source),
+                        result.remaining_diagnostics,
+                    )
+                };
+
+                return Ok(CheckResult {
+                    path: path.to_path_buf(),
+                    file_diagnostics,
+                    applied_count: result.applied_count,
+                    fixes_by_rule: result.applied_by_rule,
+                });
+            }
+            Err(FixerError::SyntaxRegression {
+                iteration,
+                error: _,
+            }) => {
+                error!(
+                    "Fix introduced a syntax error in {} at iteration {iteration}, leaving file unchanged",
+                    path.display()
+                );
+                // Fall through to the no-fix path on the original AST.
+            }
+        }
     }
-    Ok(FileDiagnostics::new(
-        NamedSource::new(path.to_string_lossy(), source),
-        diagnostics,
-    ))
+
+    let diagnostics = check_ast(&source, &ast, settings);
+    let file_diagnostics = if diagnostics.is_empty() {
+        FileDiagnostics::empty()
+    } else {
+        FileDiagnostics::new(
+            NamedSource::new(path.to_string_lossy(), source),
+            diagnostics,
+        )
+    };
+
+    Ok(CheckResult {
+        path: path.to_path_buf(),
+        file_diagnostics,
+        applied_count: 0,
+        fixes_by_rule: FxHashMap::default(),
+    })
 }

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -80,7 +80,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
             }
         }
     }
-    if args.unsafe_fixes {
+    if args.fix && args.unsafe_fixes {
         total_unsafe_fixable = 0;
     }
 
@@ -96,6 +96,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         total_safe_fixable,
         total_unsafe_fixable,
         args.fix,
+        args.unsafe_fixes,
         error_count,
     );
 
@@ -115,6 +116,7 @@ fn print_summary(
     safe_fixable: usize,
     unsafe_fixable: usize,
     apply_to_disk: bool,
+    unsafe_fixes_enabled: bool,
     parse_errors: usize,
 ) {
     if total == 0 && applied == 0 {
@@ -127,17 +129,34 @@ fn print_summary(
     if apply_to_disk {
         let found = applied + total;
         info!("Found {found} errors ({applied} fixed, {total} remaining).");
-    } else if safe_fixable > 0 {
-        let suffix = if unsafe_fixable > 0 {
-            format!(" ({unsafe_fixable} hidden fixes can be enabled with --unsafe-fixes)")
+        return;
+    }
+
+    // With `--unsafe-fixes` set (but no `--fix`), unsafe fixes count toward
+    // what `--fix` would apply; without it they are reported as hidden.
+    let fixable_with_fix = safe_fixable
+        + if unsafe_fixes_enabled {
+            unsafe_fixable
+        } else {
+            0
+        };
+    let hidden = if unsafe_fixes_enabled {
+        0
+    } else {
+        unsafe_fixable
+    };
+
+    if fixable_with_fix > 0 {
+        let suffix = if hidden > 0 {
+            format!(" ({hidden} hidden fixes can be enabled with --unsafe-fixes)")
         } else {
             String::new()
         };
-        info!("Found {total} errors. [*] {safe_fixable} fixable with the --fix option.{suffix}");
-    } else if unsafe_fixable > 0 {
         info!(
-            "Found {total} errors. ({unsafe_fixable} hidden fixes can be enabled with --unsafe-fixes)"
+            "Found {total} errors. [*] {fixable_with_fix} fixable with the --fix option.{suffix}"
         );
+    } else if hidden > 0 {
+        info!("Found {total} errors. ({hidden} hidden fixes can be enabled with --unsafe-fixes)");
     } else {
         info!("Found {total} errors.");
     }
@@ -244,4 +263,103 @@ fn check_path(
         applied_count: 0,
         fixes_by_rule: FxHashMap::default(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print_summary;
+    use tracing_test::traced_test;
+
+    #[test]
+    #[traced_test]
+    fn summary_all_passed() {
+        print_summary(0, 0, 0, 0, false, false, 0);
+        assert!(logs_contain("All checks passed!"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_silent_when_only_parse_errors() {
+        print_summary(0, 0, 0, 0, false, false, 2);
+        assert!(!logs_contain("All checks passed!"));
+        assert!(!logs_contain("Found"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_apply_to_disk_reports_fixed_and_remaining() {
+        print_summary(2, 3, 0, 0, true, false, 0);
+        assert!(logs_contain("Found 5 errors (3 fixed, 2 remaining)."));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_apply_to_disk_ignores_fixable_counts() {
+        // Under `--fix`, fixable counts shouldn't leak into the message.
+        print_summary(2, 3, 4, 5, true, true, 0);
+        assert!(logs_contain("Found 5 errors (3 fixed, 2 remaining)."));
+        assert!(!logs_contain("fixable with"));
+        assert!(!logs_contain("hidden"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_check_only_safe_fixable() {
+        print_summary(7, 0, 2, 0, false, false, 0);
+        assert!(logs_contain(
+            "Found 7 errors. [*] 2 fixable with the --fix option."
+        ));
+        assert!(!logs_contain("hidden"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_check_only_safe_and_unsafe_hidden() {
+        print_summary(7, 0, 2, 3, false, false, 0);
+        assert!(logs_contain(
+            "Found 7 errors. [*] 2 fixable with the --fix option. \
+             (3 hidden fixes can be enabled with --unsafe-fixes)"
+        ));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_check_only_unsafe_hidden() {
+        print_summary(7, 0, 0, 3, false, false, 0);
+        assert!(logs_contain(
+            "Found 7 errors. (3 hidden fixes can be enabled with --unsafe-fixes)"
+        ));
+        assert!(!logs_contain("fixable with"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_check_with_unsafe_fixes_enabled_combines_counts() {
+        // `--unsafe-fixes` set, but no `--fix`: unsafe fixes are now reportable
+        // as fixable, not hidden.
+        print_summary(7, 0, 2, 3, false, true, 0);
+        assert!(logs_contain(
+            "Found 7 errors. [*] 5 fixable with the --fix option."
+        ));
+        assert!(!logs_contain("hidden"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_check_with_unsafe_fixes_enabled_only_unsafe() {
+        print_summary(7, 0, 0, 3, false, true, 0);
+        assert!(logs_contain(
+            "Found 7 errors. [*] 3 fixable with the --fix option."
+        ));
+        assert!(!logs_contain("hidden"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn summary_check_no_fixes_available() {
+        print_summary(5, 0, 0, 0, false, false, 0);
+        assert!(logs_contain("Found 5 errors."));
+        assert!(!logs_contain("fixable with"));
+        assert!(!logs_contain("hidden"));
+    }
 }

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -15,6 +15,7 @@ use tracing::{debug, error, info};
 use crate::ExitStatus;
 use crate::args::{CheckCommand, Profile};
 use crate::error::{CommandError, ParseError, Result};
+use crate::fs::relativize_path;
 
 /// Per-file outcome of `check_path`.
 struct CheckResult {
@@ -148,7 +149,7 @@ fn print_show_fixes(results: &[CheckResult], total_applied: usize) {
         if result.applied_count == 0 {
             continue;
         }
-        info!("- {}:", result.path.display());
+        info!("- {}:", relativize_path(&result.path));
         let mut entries: Vec<_> = result.fixes_by_rule.iter().collect();
         entries.sort_by(|a, b| a.0.cmp(b.0));
         for (rule, summary) in entries {
@@ -205,7 +206,7 @@ fn check_path(
                     FileDiagnostics::empty()
                 } else {
                     FileDiagnostics::new(
-                        NamedSource::new(path.to_string_lossy(), result.source),
+                        NamedSource::new(relativize_path(path), result.source),
                         result.remaining_diagnostics,
                     )
                 };
@@ -234,10 +235,7 @@ fn check_path(
     let file_diagnostics = if diagnostics.is_empty() {
         FileDiagnostics::empty()
     } else {
-        FileDiagnostics::new(
-            NamedSource::new(path.to_string_lossy(), source),
-            diagnostics,
-        )
+        FileDiagnostics::new(NamedSource::new(relativize_path(path), source), diagnostics)
     };
 
     Ok(CheckResult {

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -3,6 +3,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+use crate::fs::relativize_path;
+
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Debug, Error, Diagnostic)]
@@ -23,7 +25,7 @@ pub enum Error {
 
 #[must_use]
 pub fn path_display(path: Option<&PathBuf>) -> String {
-    path.map_or_else(|| "<unknown>".to_string(), |p| p.display().to_string())
+    path.map_or_else(|| "<unknown>".to_string(), relativize_path)
 }
 
 #[derive(Debug, Diagnostic, Error)]

--- a/crates/djangofmt/src/fs.rs
+++ b/crates/djangofmt/src/fs.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Return the current working directory, cached after the first call.
+///
+/// On WASM (where `std::env::current_dir` is unsupported) and on the unlikely
+/// event of a read failure, falls back to `.`.
+pub fn get_cwd() -> &'static Path {
+    static CWD: OnceLock<PathBuf> = OnceLock::new();
+    CWD.get_or_init(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+        .as_path()
+}
+
+/// Convert an absolute path to be relative to the current working directory.
+pub fn relativize_path<P: AsRef<Path>>(path: P) -> String {
+    let path = path.as_ref();
+    let cwd = get_cwd();
+    if let Ok(stripped) = path.strip_prefix(cwd) {
+        return stripped.display().to_string();
+    }
+    path.display().to_string()
+}

--- a/crates/djangofmt/src/lib.rs
+++ b/crates/djangofmt/src/lib.rs
@@ -5,6 +5,7 @@ use std::process::ExitCode;
 pub mod args;
 pub mod commands;
 pub mod error;
+pub mod fs;
 pub mod line_width;
 mod logging;
 pub mod pyproject;

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -111,6 +111,7 @@ fn check_clean_file() {
     success: true
     exit_code: 0
     ----- stdout -----
+    All checks passed!
 
     ----- stderr -----
     "#);

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -142,3 +142,111 @@ fn check_nonexistent_file() {
       Error: Path does not exist: /nonexistent/path.html
     "#);
 }
+
+#[test]
+fn check_fixable_file_without_fix() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.html");
+    let original = "{% blocktranslate %}Hello{% endblocktranslate %}\n";
+    std::fs::write(&file, original).unwrap();
+    let output = cli().arg("check").arg(file.as_os_str()).output().unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Found 1 errors. [*] 1 fixable with the --fix option."),
+        "summary missing or wrong, got:\n{stdout}"
+    );
+    // Ensure we didn't apply anything without --fix.
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(after, original);
+}
+
+#[test]
+fn check_fixable_file_with_fix() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.html");
+    let original = "{% blocktranslate %}Hello{% endblocktranslate %}\n";
+    std::fs::write(&file, original).unwrap();
+    let output = cli()
+        .args(["check", "--fix"])
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "expected success exit, got {output:?}"
+    );
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Found 1 errors (1 fixed, 0 remaining)."),
+        "summary missing or wrong, got:\n{stdout}"
+    );
+    // Ensure file was mutated.
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        after,
+        "{% blocktranslate trimmed %}Hello{% endblocktranslate %}\n"
+    );
+}
+
+#[test]
+fn check_fixable_file_with_show_fixes() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.html");
+    let original = "{% blocktranslate %}Hello{% endblocktranslate %}\n";
+    std::fs::write(&file, original).unwrap();
+    let output = cli()
+        .args(["check", "--fix", "--show-fixes"])
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "expected success exit, got {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Found 1 errors (1 fixed, 0 remaining)."),
+        "summary missing or wrong, got:\n{stdout}"
+    );
+    assert!(stdout.contains("Fixed 1 errors:"), "got:\n{stdout}");
+    // Per-rule line must include rule code AND fix_title.
+    assert!(
+        stdout.contains("1 × untrimmed-blocktranslate (Add trimmed)"),
+        "per-rule line missing fix_title, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn check_malformed_file_with_fix_surfaces_parse_error() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.html");
+    std::fs::write(&file, "{% if x %}\n  unclosed\n").unwrap();
+    let output = cli()
+        .args(["check", "--fix"])
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    // Parse errors must surface even with --fix.
+    assert!(
+        !output.status.success(),
+        "expected failure exit, got {output:?}"
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("unclosed {% if %} block"),
+        "expected parse error rendering, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Couldn't check 1 files!"),
+        "expected error count line, got:\n{stdout}"
+    );
+    // Must NOT claim success.
+    assert!(
+        !stdout.contains("All checks passed!"),
+        "must not claim success when parse errors occurred, got:\n{stdout}"
+    );
+}

--- a/crates/djangofmt_lint/Cargo.toml
+++ b/crates/djangofmt_lint/Cargo.toml
@@ -6,16 +6,15 @@ rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 
-[lib]
-test = false
-
 [dependencies]
+anyhow = { workspace = true }
 markup_fmt = { workspace = true }
 miette = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -3,28 +3,28 @@ use miette::SourceSpan;
 
 use crate::LintDiagnostic;
 use crate::Settings;
+use crate::lint_context::{DiagnosticGuard, LintContext};
 use crate::registry::Rule;
 use crate::rules;
 use crate::violation::Violation;
 
 /// AST visitor that collects lint diagnostics.
-///
-/// The `Checker` traverses the `markup_fmt` AST and runs lint rules at each node.
-/// Rules report diagnostics via [`Checker::report`].
 pub struct Checker<'a> {
-    source: &'a str,
-    settings: &'a Settings,
-    diagnostics: Vec<LintDiagnostic>,
+    context: LintContext<'a>,
 }
 
 impl<'a> Checker<'a> {
     #[must_use]
     pub const fn new(source: &'a str, settings: &'a Settings) -> Self {
         Self {
-            source,
-            settings,
-            diagnostics: Vec::new(),
+            context: LintContext::new(source, settings),
         }
+    }
+
+    /// Borrow the underlying [`LintContext`].
+    #[must_use]
+    pub const fn context(&self) -> &LintContext<'a> {
+        &self.context
     }
 
     /// Compute the byte offset of a string slice within the source.
@@ -33,52 +33,44 @@ impl<'a> Checker<'a> {
     ///
     /// # Panics
     ///
-    /// Panics if `slice` is not fully contained within `self.source`.
+    /// Panics if `slice` is not fully contained within the source.
     #[must_use]
     pub fn source_offset(&self, slice: &str) -> usize {
-        let src_start = self.source.as_ptr() as usize;
-        let src_end = src_start + self.source.len();
-        let slice_start = slice.as_ptr() as usize;
-        let slice_end = slice_start + slice.len();
-
-        assert!(
-            slice_start >= src_start && slice_end <= src_end,
-            "slice must be a subslice of self.source"
-        );
-
-        slice_start - src_start
+        self.context.source_offset(slice)
     }
 
     /// Returns whether the given rule should be checked.
     #[must_use]
     #[inline]
     pub fn is_rule_enabled(&self, rule: Rule) -> bool {
-        self.settings.is_enabled(rule)
+        self.context.is_rule_enabled(rule)
     }
 
-    /// Report a lint diagnostic.
-    ///
-    /// The rule is inferred from the violation's `RULE` constant.
-    /// This ensures violations are always reported with the correct rule.
-    ///
-    /// Note: The caller should check `is_rule_enabled()` before calling the
-    /// rule's check function for performance reasons.
-    #[inline]
-    pub fn report<V: Violation>(&mut self, violation: &V, span: SourceSpan) {
-        self.diagnostics.push(LintDiagnostic {
-            code: V::RULE.to_string(),
-            message: violation.message(),
-            span,
-            help: violation.help(),
-            fix: None,
-            fix_title: None,
-        });
+    /// Report a diagnostic for a rule the caller has already gated on
+    /// [`Self::is_rule_enabled`]. Returns a guard whose Drop pushes the
+    /// diagnostic into the underlying context.
+    pub fn report_diagnostic<V: Violation>(
+        &self,
+        violation: &V,
+        span: SourceSpan,
+    ) -> DiagnosticGuard<'_, 'a> {
+        self.context.report_diagnostic(violation, span)
+    }
+
+    /// Report a diagnostic only if the rule is enabled. Returns `None`
+    /// otherwise.
+    pub fn report_diagnostic_if_enabled<V: Violation>(
+        &self,
+        violation: &V,
+        span: SourceSpan,
+    ) -> Option<DiagnosticGuard<'_, 'a>> {
+        self.context.report_diagnostic_if_enabled(violation, span)
     }
 
     /// Consume the checker and return all collected diagnostics.
     #[must_use]
     pub fn into_diagnostics(self) -> Vec<LintDiagnostic> {
-        self.diagnostics
+        self.context.into_diagnostics()
     }
 
     /// Visit the root of the AST and run all lint rules.

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -70,6 +70,8 @@ impl<'a> Checker<'a> {
             message: violation.message(),
             span,
             help: violation.help(),
+            fix: None,
+            fix_title: None,
         });
     }
 

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -109,6 +109,10 @@ impl<'a> Checker<'a> {
     }
 
     fn visit_jinja_block(&mut self, block: &JinjaBlock<'_, Node<'_>>) {
+        if self.is_rule_enabled(Rule::UntrimmedBlocktranslate) {
+            rules::correctness::untrimmed_blocktranslate::check(block, self);
+        }
+
         for item in &block.body {
             if let JinjaTagOrChildren::Children(children) = item {
                 for child in children {

--- a/crates/djangofmt_lint/src/fix/apply.rs
+++ b/crates/djangofmt_lint/src/fix/apply.rs
@@ -1,0 +1,499 @@
+//! Fix applier and re-lint loop.
+//!
+//! [`apply_fixes`] runs a single forward pass over the source, applying
+//! non-overlapping, non-isolation-conflicted fixes from the supplied
+//! diagnostic list. [`lint_fix`] drives the multi-pass cascade (parse,
+//! lint, apply, re-parse) up to [`MAX_FIX_ITERATIONS`].
+
+use std::borrow::Cow;
+
+use markup_fmt::SyntaxError;
+use markup_fmt::ast::Root;
+use markup_fmt::parser::Parser;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::LintDiagnostic;
+use crate::Settings;
+use crate::check_ast;
+use crate::fix::{Applicability, IsolationLevel};
+
+/// Metadata about a single applied fix, captured for `--show-fixes`.
+#[derive(Debug, Clone)]
+pub struct AppliedFix {
+    /// Rule code of the diagnostic the fix came from.
+    pub code: String,
+    /// Short imperative summary of the fix, if the rule provided one.
+    pub fix_title: Option<String>,
+}
+
+/// Result of a single fix-application pass.
+#[derive(Debug)]
+pub struct ApplyResult {
+    /// The fixed source.
+    pub output: String,
+    /// Number of fixes applied.
+    pub applied_count: usize,
+    /// Number of fixes that were filtered out (overlap, isolation, applicability).
+    pub skipped_count: usize,
+    /// Source map mapping byte offsets in the original source to offsets in
+    /// the output.
+    pub source_map: SourceMap,
+    /// Metadata for each applied fix, in application order.
+    ///
+    /// Used by the CLI's `--show-fixes` to render per-rule counts.
+    pub applied_fixes: Vec<AppliedFix>,
+}
+
+/// Sequence of [`SourceMarker`]s describing the offset transformation from
+/// the original source to the fixed output.
+#[derive(Debug, Default)]
+pub struct SourceMap {
+    pub markers: Vec<SourceMarker>,
+}
+
+/// A start/end pair of byte offsets pinning a region in the original source
+/// to its image in the output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceMarker {
+    /// Byte offset in the original source.
+    pub source: usize,
+    /// Byte offset in the output.
+    pub dest: usize,
+}
+
+/// Maximum number of fix iterations before giving up.
+pub const MAX_FIX_ITERATIONS: usize = 10;
+
+/// Apply all fixes from `diagnostics` whose applicability is at least
+/// `threshold` to `source`.
+///
+/// See the spec §5.1 for the algorithm. Strict `<` is used for overlap
+/// detection (so two adjacent insertions at the same byte offset can both
+/// apply).
+#[must_use]
+pub fn apply_fixes(
+    source: &str,
+    diagnostics: &[LintDiagnostic],
+    threshold: Applicability,
+) -> ApplyResult {
+    let mut fixable: Vec<&LintDiagnostic> = diagnostics
+        .iter()
+        .filter(|d| d.fix.as_ref().is_some_and(|f| f.applies(threshold)))
+        .collect();
+
+    fixable.sort_by_key(|d| {
+        d.fix
+            .as_ref()
+            .and_then(crate::fix::Fix::min_start)
+            .unwrap_or(usize::MAX)
+    });
+
+    let mut output = String::with_capacity(source.len());
+    let mut markers: Vec<SourceMarker> = Vec::new();
+    let mut last_pos: usize = 0;
+    let mut applied_count = 0usize;
+    let mut skipped_count = 0usize;
+    let mut applied_groups: FxHashSet<u32> = FxHashSet::default();
+    let mut applied_fixes: Vec<AppliedFix> = Vec::new();
+
+    for diag in fixable {
+        let Some(fix) = diag.fix.as_ref() else {
+            continue;
+        };
+        let edits = fix.edits();
+        let Some(first) = edits.first() else {
+            continue;
+        };
+
+        if let IsolationLevel::Group(id) = fix.isolation()
+            && applied_groups.contains(&id)
+        {
+            skipped_count += 1;
+            continue;
+        }
+
+        // Strict `<` so adjacent insertions at the same offset can both apply.
+        if first.start() < last_pos {
+            skipped_count += 1;
+            continue;
+        }
+
+        for edit in edits {
+            output.push_str(&source[last_pos..edit.start()]);
+            markers.push(SourceMarker {
+                source: edit.start(),
+                dest: output.len(),
+            });
+            if let Some(content) = edit.content() {
+                output.push_str(content);
+            }
+            markers.push(SourceMarker {
+                source: edit.end(),
+                dest: output.len(),
+            });
+            last_pos = edit.end();
+        }
+
+        if let IsolationLevel::Group(id) = fix.isolation() {
+            applied_groups.insert(id);
+        }
+        applied_count += 1;
+        applied_fixes.push(AppliedFix {
+            code: diag.code.clone(),
+            fix_title: diag.fix_title.clone(),
+        });
+    }
+
+    output.push_str(&source[last_pos..]);
+
+    ApplyResult {
+        output,
+        applied_count,
+        skipped_count,
+        source_map: SourceMap { markers },
+        applied_fixes,
+    }
+}
+
+/// Single-iteration helper: lint `ast` and apply the fixes in one pass.
+#[must_use]
+pub fn fix_ast(
+    source: &str,
+    ast: &Root<'_>,
+    settings: &Settings,
+    threshold: Applicability,
+) -> ApplyResult {
+    let diagnostics = check_ast(source, ast, settings);
+    apply_fixes(source, &diagnostics, threshold)
+}
+
+/// Per-rule summary for `--show-fixes` output.
+#[derive(Debug, Clone, Default)]
+pub struct RuleFixSummary {
+    /// Number of fixes applied for this rule across all iterations.
+    pub count: usize,
+    /// Short imperative summary of the fix, if the rule provided one.
+    pub fix_title: Option<String>,
+}
+
+/// Result of [`lint_fix`].
+#[derive(Debug)]
+pub struct FixerResult {
+    /// The (possibly fixed) source.
+    pub source: String,
+    /// Diagnostics remaining after the final iteration.
+    pub remaining_diagnostics: Vec<LintDiagnostic>,
+    /// Total fixes applied across iterations.
+    pub applied_count: usize,
+    /// Total fixes skipped (overlap, isolation, applicability).
+    pub skipped_count: usize,
+    /// Number of fix iterations that ran.
+    pub iterations: usize,
+    /// Per-rule applied summaries, used by `--show-fixes`.
+    pub applied_by_rule: rustc_hash::FxHashMap<String, RuleFixSummary>,
+}
+
+/// Errors from [`lint_fix`].
+#[derive(Debug)]
+pub enum FixerError {
+    /// A fix introduced a syntax error in source that previously parsed.
+    SyntaxRegression {
+        iteration: usize,
+        error: SyntaxError,
+    },
+}
+
+/// Run the lint-and-fix loop on `source`.
+///
+/// Mirrors `ruff::linter::lint_fix`:
+///
+/// 1. Parse → lint → apply.
+/// 2. If anything was applied, re-parse and repeat up to
+///    [`MAX_FIX_ITERATIONS`].
+/// 3. Bail with [`FixerError::SyntaxRegression`] if a fix introduced a
+///    syntax error in source that previously parsed.
+/// 4. On convergence-failure (iteration limit reached with more fixes
+///    pending), log a warning and return the work done so far.
+pub fn lint_fix(
+    source: &str,
+    settings: &Settings,
+    profile: markup_fmt::Language,
+    threshold: Applicability,
+) -> Result<FixerResult, FixerError> {
+    let mut current: Cow<'_, str> = Cow::Borrowed(source);
+    let mut total_applied = 0usize;
+    let mut total_skipped = 0usize;
+    let mut iterations = 0usize;
+    let mut had_valid_first_parse = false;
+    let mut applied_by_rule: FxHashMap<String, RuleFixSummary> = FxHashMap::default();
+
+    loop {
+        let mut parser = Parser::new(&current, profile, vec![]);
+        let ast = match parser.parse_root() {
+            Ok(ast) => {
+                if iterations == 0 {
+                    had_valid_first_parse = true;
+                }
+                ast
+            }
+            Err(err) if had_valid_first_parse => {
+                return Err(FixerError::SyntaxRegression {
+                    iteration: iterations,
+                    error: err,
+                });
+            }
+            Err(_) => {
+                return Ok(FixerResult {
+                    source: current.into_owned(),
+                    remaining_diagnostics: Vec::new(),
+                    applied_count: total_applied,
+                    skipped_count: total_skipped,
+                    iterations,
+                    applied_by_rule,
+                });
+            }
+        };
+
+        let diagnostics = check_ast(&current, &ast, settings);
+        let result = apply_fixes(&current, &diagnostics, threshold);
+        total_skipped += result.skipped_count;
+        for applied in &result.applied_fixes {
+            let entry = applied_by_rule.entry(applied.code.clone()).or_default();
+            entry.count += 1;
+            if entry.fix_title.is_none() {
+                entry.fix_title.clone_from(&applied.fix_title);
+            }
+        }
+
+        if result.applied_count == 0 {
+            return Ok(FixerResult {
+                source: current.into_owned(),
+                remaining_diagnostics: diagnostics,
+                applied_count: total_applied,
+                skipped_count: total_skipped,
+                iterations,
+                applied_by_rule,
+            });
+        }
+
+        if iterations >= MAX_FIX_ITERATIONS {
+            tracing::warn!(
+                "Fix iteration limit reached; remaining diagnostics may be fixable on a second run."
+            );
+            return Ok(FixerResult {
+                source: result.output,
+                remaining_diagnostics: diagnostics,
+                applied_count: total_applied + result.applied_count,
+                skipped_count: total_skipped,
+                iterations,
+                applied_by_rule,
+            });
+        }
+
+        total_applied += result.applied_count;
+        current = Cow::Owned(result.output);
+        iterations += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miette::SourceSpan;
+
+    use super::*;
+    use crate::fix::{Edit, Fix};
+
+    fn span(start: usize, len: usize) -> SourceSpan {
+        SourceSpan::new(start.into(), len)
+    }
+
+    fn diag_with_fix(fix: Fix) -> LintDiagnostic {
+        LintDiagnostic {
+            code: "test-rule".to_string(),
+            message: "test".to_string(),
+            span: span(0, 0),
+            help: None,
+            fix: Some(fix),
+            fix_title: None,
+        }
+    }
+
+    fn diag_without_fix() -> LintDiagnostic {
+        LintDiagnostic {
+            code: "test-rule".to_string(),
+            message: "test".to_string(),
+            span: span(0, 0),
+            help: None,
+            fix: None,
+            fix_title: None,
+        }
+    }
+
+    #[test]
+    fn single_replacement() {
+        let source = "hello world";
+        let diags = vec![diag_with_fix(Fix::safe_edit(Edit::replacement(
+            "Rust",
+            span(6, 5),
+        )))];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        assert_eq!(result.output, "hello Rust");
+        assert_eq!(result.applied_count, 1);
+        assert_eq!(result.skipped_count, 0);
+    }
+
+    #[test]
+    fn multiple_non_overlapping() {
+        let source = "abcdefghij";
+        let diags = vec![
+            diag_with_fix(Fix::safe_edit(Edit::replacement("X", span(0, 1)))),
+            diag_with_fix(Fix::safe_edit(Edit::replacement("Y", span(5, 1)))),
+        ];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        assert_eq!(result.output, "Xbcde Yghij".replace(' ', ""));
+        // (Use plain string to avoid confusion.)
+        assert_eq!(result.output, "XbcdeYghij");
+        assert_eq!(result.applied_count, 2);
+    }
+
+    #[test]
+    fn overlap_rejected() {
+        let source = "abcdefghij";
+        let diags = vec![
+            diag_with_fix(Fix::safe_edit(Edit::replacement("XX", span(0, 5)))),
+            diag_with_fix(Fix::safe_edit(Edit::replacement("YY", span(2, 5)))),
+        ];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        // First one applied, second overlaps and is skipped.
+        assert_eq!(result.output, "XXfghij");
+        assert_eq!(result.applied_count, 1);
+        assert_eq!(result.skipped_count, 1);
+    }
+
+    #[test]
+    fn isolation_groups() {
+        let source = "abcdefghij";
+        let diags = vec![
+            diag_with_fix(
+                Fix::safe_edit(Edit::replacement("X", span(0, 1)))
+                    .isolate(IsolationLevel::Group(1)),
+            ),
+            diag_with_fix(
+                Fix::safe_edit(Edit::replacement("Y", span(5, 1)))
+                    .isolate(IsolationLevel::Group(1)),
+            ),
+        ];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        // Only the first fix in group 1 applies.
+        assert_eq!(result.output, "Xbcdefghij");
+        assert_eq!(result.applied_count, 1);
+        assert_eq!(result.skipped_count, 1);
+    }
+
+    #[test]
+    fn applicability_filtering() {
+        let source = "abcdefghij";
+        let diags = vec![
+            diag_with_fix(Fix::safe_edit(Edit::replacement("S", span(0, 1)))),
+            diag_with_fix(Fix::unsafe_edit(Edit::replacement("U", span(2, 1)))),
+            diag_with_fix(Fix::display_only_edit(Edit::replacement("D", span(4, 1)))),
+        ];
+
+        // Safe threshold: only the safe fix applies.
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        assert_eq!(result.output, "Sbcdefghij");
+        assert_eq!(result.applied_count, 1);
+
+        // Unsafe threshold: safe + unsafe apply.
+        let result = apply_fixes(source, &diags, Applicability::Unsafe);
+        assert_eq!(result.output, "SbUdefghij");
+        assert_eq!(result.applied_count, 2);
+
+        // DisplayOnly threshold: all apply.
+        let result = apply_fixes(source, &diags, Applicability::DisplayOnly);
+        assert_eq!(result.output, "SbUdDfghij");
+        assert_eq!(result.applied_count, 3);
+    }
+
+    #[test]
+    fn deletion() {
+        let source = "abcdefghij";
+        let diags = vec![diag_with_fix(Fix::safe_edit(Edit::deletion(span(2, 3))))];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        assert_eq!(result.output, "abfghij");
+        assert_eq!(result.applied_count, 1);
+    }
+
+    #[test]
+    fn insertion_at_same_offset() {
+        // Two adjacent insertions at the same byte offset can both apply
+        // (strict `<` overlap semantics).
+        let source = "abc";
+        let diags = vec![
+            diag_with_fix(Fix::safe_edit(Edit::insertion("X", 1))),
+            diag_with_fix(Fix::safe_edit(Edit::insertion("Y", 1))),
+        ];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        assert_eq!(result.output, "aXYbc");
+        assert_eq!(result.applied_count, 2);
+    }
+
+    #[test]
+    fn ignores_diagnostics_without_fix() {
+        let source = "abc";
+        let diags = vec![
+            diag_without_fix(),
+            diag_with_fix(Fix::safe_edit(Edit::replacement("X", span(0, 1)))),
+        ];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        assert_eq!(result.output, "Xbc");
+        assert_eq!(result.applied_count, 1);
+    }
+
+    #[test]
+    fn empty_diagnostics() {
+        let source = "abc";
+        let result = apply_fixes(source, &[], Applicability::Safe);
+        assert_eq!(result.output, "abc");
+        assert_eq!(result.applied_count, 0);
+        assert_eq!(result.skipped_count, 0);
+    }
+
+    #[test]
+    fn source_map_markers() {
+        let source = "hello world";
+        let diags = vec![diag_with_fix(Fix::safe_edit(Edit::replacement(
+            "Rust",
+            span(6, 5),
+        )))];
+        let result = apply_fixes(source, &diags, Applicability::Safe);
+        assert_eq!(result.source_map.markers.len(), 2);
+        assert_eq!(
+            result.source_map.markers[0],
+            SourceMarker { source: 6, dest: 6 }
+        );
+        assert_eq!(
+            result.source_map.markers[1],
+            SourceMarker {
+                source: 11,
+                dest: 10
+            }
+        );
+    }
+
+    #[test]
+    fn lint_fix_no_op_returns_no_iterations() {
+        let source = "<div></div>";
+        let settings = Settings::default();
+        let result = lint_fix(
+            source,
+            &settings,
+            markup_fmt::Language::Django,
+            Applicability::Safe,
+        )
+        .expect("lint_fix");
+        assert_eq!(result.source, source);
+        assert_eq!(result.applied_count, 0);
+        assert_eq!(result.iterations, 0);
+    }
+}

--- a/crates/djangofmt_lint/src/fix/apply.rs
+++ b/crates/djangofmt_lint/src/fix/apply.rs
@@ -228,6 +228,23 @@ pub fn lint_fix(
     let mut applied_by_rule: FxHashMap<String, RuleFixSummary> = FxHashMap::default();
 
     loop {
+        if iterations >= MAX_FIX_ITERATIONS {
+            tracing::warn!(
+                "Fix iteration limit reached; remaining diagnostics may be fixable on a second run."
+            );
+            return Ok(FixerResult {
+                source: current.into_owned(),
+                // Diagnostics from the previous iteration are span-aligned to
+                // the pre-apply source, not to `current`; rather than return
+                // mismatched spans, drop them. A re-run will re-derive them.
+                remaining_diagnostics: Vec::new(),
+                applied_count: total_applied,
+                skipped_count: total_skipped,
+                iterations,
+                applied_by_rule,
+            });
+        }
+
         let mut parser = Parser::new(&current, profile, vec![]);
         let ast = match parser.parse_root() {
             Ok(ast) => {
@@ -270,20 +287,6 @@ pub fn lint_fix(
                 source: current.into_owned(),
                 remaining_diagnostics: diagnostics,
                 applied_count: total_applied,
-                skipped_count: total_skipped,
-                iterations,
-                applied_by_rule,
-            });
-        }
-
-        if iterations >= MAX_FIX_ITERATIONS {
-            tracing::warn!(
-                "Fix iteration limit reached; remaining diagnostics may be fixable on a second run."
-            );
-            return Ok(FixerResult {
-                source: result.output,
-                remaining_diagnostics: diagnostics,
-                applied_count: total_applied + result.applied_count,
                 skipped_count: total_skipped,
                 iterations,
                 applied_by_rule,

--- a/crates/djangofmt_lint/src/fix/mod.rs
+++ b/crates/djangofmt_lint/src/fix/mod.rs
@@ -53,8 +53,10 @@ pub enum IsolationLevel {
 /// equivalent to ruff's `TextRange`).
 ///
 /// `content` uses [`Option<Box<str>>`] to distinguish pure deletion ([`None`])
-/// from replacement-with-empty-string ([`Some("")`]) and to keep the niche
-/// optimization (same size as `Box<str>`).
+/// from non-empty replacement ([`Some(...)`]) while preserving the niche
+/// optimization (same size as `Box<str>`). Empty replacement content is
+/// rejected by [`Edit::replacement`] and [`Edit::insertion`] via a
+/// `debug_assert!`; use [`Edit::deletion`] for the empty case.
 #[derive(Clone, Debug)]
 pub struct Edit {
     range: SourceSpan,

--- a/crates/djangofmt_lint/src/fix/mod.rs
+++ b/crates/djangofmt_lint/src/fix/mod.rs
@@ -1,0 +1,440 @@
+//! Fix data model.
+//!
+//! Mirrors ruff's autofix model: a [`Fix`] is one or more non-overlapping
+//! [`Edit`]s tagged with an [`Applicability`] threshold and an [`IsolationLevel`].
+//!
+//! Rules attach a [`Fix`] to a [`crate::LintDiagnostic`] via the diagnostic guard
+//! returned from [`crate::LintContext::report_diagnostic_if_enabled`]. The applier
+//! ([`apply::apply_fixes`]) gates by applicability, sorts by start position, and
+//! resolves overlap conflicts in a single forward pass.
+
+pub mod apply;
+
+use std::cmp::Ordering;
+
+use miette::SourceSpan;
+
+/// Forward-looking declaration of fix availability for a rule.
+///
+/// Carried on the [`crate::violation::Violation`] trait so rule authors declare
+/// fix availability upfront.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixAvailability {
+    Sometimes,
+    Always,
+    None,
+}
+
+/// Three-tier safety classification for fixes, ordered ascending so `>=`
+/// reads as a "minimum required" applicability check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Applicability {
+    /// Likely incorrect; surfaced in diagnostics but never applied automatically.
+    DisplayOnly,
+    /// May change runtime behavior; applied only with `--unsafe-fixes`.
+    Unsafe,
+    /// Preserves exact semantics; applied with `--fix`.
+    Safe,
+}
+
+/// Isolation level for a [`Fix`]. Used when two rules can produce mutually
+/// exclusive fixes (e.g. "remove attr X" vs "rewrite attr X to Y").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IsolationLevel {
+    #[default]
+    NonOverlapping,
+    /// Only one fix in this group is applied per pass; first-wins by sort order.
+    Group(u32),
+}
+
+/// A single text mutation.
+///
+/// `range` is a [`miette::SourceSpan`] for codebase consistency (semantically
+/// equivalent to ruff's `TextRange`).
+///
+/// `content` uses [`Option<Box<str>>`] to distinguish pure deletion ([`None`])
+/// from replacement-with-empty-string ([`Some("")`]) and to keep the niche
+/// optimization (same size as `Box<str>`).
+#[derive(Clone, Debug)]
+pub struct Edit {
+    range: SourceSpan,
+    content: Option<Box<str>>,
+}
+
+impl Edit {
+    /// Replace `range` with `content`.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `content` is empty. Use [`Edit::deletion`]
+    /// for pure deletions.
+    #[must_use]
+    pub fn replacement(content: impl Into<Box<str>>, range: SourceSpan) -> Self {
+        let content = content.into();
+        debug_assert!(
+            !content.is_empty(),
+            "use `Edit::deletion` for empty replacement content"
+        );
+        Self {
+            range,
+            content: Some(content),
+        }
+    }
+
+    /// Insert `content` at byte offset `at`.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `content` is empty.
+    #[must_use]
+    pub fn insertion(content: impl Into<Box<str>>, at: usize) -> Self {
+        let content = content.into();
+        debug_assert!(
+            !content.is_empty(),
+            "use `Edit::deletion` for empty insertion content"
+        );
+        Self {
+            range: SourceSpan::new(at.into(), 0),
+            content: Some(content),
+        }
+    }
+
+    /// Delete the bytes in `range`.
+    #[must_use]
+    pub const fn deletion(range: SourceSpan) -> Self {
+        Self {
+            range,
+            content: None,
+        }
+    }
+
+    /// Start offset (inclusive).
+    #[must_use]
+    pub const fn start(&self) -> usize {
+        self.range.offset()
+    }
+
+    /// End offset (exclusive).
+    #[must_use]
+    pub const fn end(&self) -> usize {
+        self.range.offset() + self.range.len()
+    }
+
+    /// Replacement / insertion content, or [`None`] for pure deletion.
+    #[must_use]
+    pub fn content(&self) -> Option<&str> {
+        self.content.as_deref()
+    }
+}
+
+impl PartialEq for Edit {
+    fn eq(&self, other: &Self) -> bool {
+        self.start() == other.start() && self.end() == other.end() && self.content == other.content
+    }
+}
+
+impl Eq for Edit {}
+
+impl Ord for Edit {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.start()
+            .cmp(&other.start())
+            .then_with(|| self.end().cmp(&other.end()))
+            .then_with(|| self.content.cmp(&other.content))
+    }
+}
+
+impl PartialOrd for Edit {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A grouped set of [`Edit`]s applied atomically.
+///
+/// Multi-edit constructors sort edits by `(start, end)` and **debug-assert**
+/// that no two edits within a single [`Fix`] overlap. This is a precondition:
+/// violations within a fix indicate a rule bug.
+#[derive(Debug, Clone)]
+pub struct Fix {
+    edits: Vec<Edit>,
+    applicability: Applicability,
+    isolation_level: IsolationLevel,
+}
+
+impl Fix {
+    fn single(edit: Edit, applicability: Applicability) -> Self {
+        Self {
+            edits: vec![edit],
+            applicability,
+            isolation_level: IsolationLevel::default(),
+        }
+    }
+
+    fn multi<I>(first: Edit, rest: I, applicability: Applicability) -> Self
+    where
+        I: IntoIterator<Item = Edit>,
+    {
+        let mut edits: Vec<Edit> = std::iter::once(first).chain(rest).collect();
+        edits.sort();
+
+        debug_assert!(
+            edits
+                .windows(2)
+                .all(|window| window[0].end() <= window[1].start()),
+            "edits within a `Fix` must be non-overlapping"
+        );
+
+        Self {
+            edits,
+            applicability,
+            isolation_level: IsolationLevel::default(),
+        }
+    }
+
+    /// Single-edit safe fix.
+    #[must_use]
+    pub fn safe_edit(edit: Edit) -> Self {
+        Self::single(edit, Applicability::Safe)
+    }
+
+    /// Single-edit unsafe fix.
+    #[must_use]
+    pub fn unsafe_edit(edit: Edit) -> Self {
+        Self::single(edit, Applicability::Unsafe)
+    }
+
+    /// Single-edit display-only fix.
+    #[must_use]
+    pub fn display_only_edit(edit: Edit) -> Self {
+        Self::single(edit, Applicability::DisplayOnly)
+    }
+
+    /// Multi-edit safe fix.
+    #[must_use]
+    pub fn safe_edits<I>(first: Edit, rest: I) -> Self
+    where
+        I: IntoIterator<Item = Edit>,
+    {
+        Self::multi(first, rest, Applicability::Safe)
+    }
+
+    /// Multi-edit unsafe fix.
+    #[must_use]
+    pub fn unsafe_edits<I>(first: Edit, rest: I) -> Self
+    where
+        I: IntoIterator<Item = Edit>,
+    {
+        Self::multi(first, rest, Applicability::Unsafe)
+    }
+
+    /// Multi-edit display-only fix.
+    #[must_use]
+    pub fn display_only_edits<I>(first: Edit, rest: I) -> Self
+    where
+        I: IntoIterator<Item = Edit>,
+    {
+        Self::multi(first, rest, Applicability::DisplayOnly)
+    }
+
+    /// Set the isolation level (builder).
+    #[must_use]
+    pub const fn isolate(mut self, level: IsolationLevel) -> Self {
+        self.isolation_level = level;
+        self
+    }
+
+    /// Override the applicability (builder).
+    #[must_use]
+    pub const fn with_applicability(mut self, applicability: Applicability) -> Self {
+        self.applicability = applicability;
+        self
+    }
+
+    #[must_use]
+    pub fn edits(&self) -> &[Edit] {
+        &self.edits
+    }
+
+    #[must_use]
+    pub const fn applicability(&self) -> Applicability {
+        self.applicability
+    }
+
+    #[must_use]
+    pub const fn isolation(&self) -> IsolationLevel {
+        self.isolation_level
+    }
+
+    /// First edit's start offset, used for sorting.
+    #[must_use]
+    pub fn min_start(&self) -> Option<usize> {
+        self.edits.first().map(Edit::start)
+    }
+
+    /// True iff this fix's applicability meets `threshold`.
+    #[must_use]
+    pub fn applies(&self, threshold: Applicability) -> bool {
+        self.applicability >= threshold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(start: usize, len: usize) -> SourceSpan {
+        SourceSpan::new(start.into(), len)
+    }
+
+    #[test]
+    fn edit_replacement() {
+        let edit = Edit::replacement("hello", span(0, 5));
+        assert_eq!(edit.start(), 0);
+        assert_eq!(edit.end(), 5);
+        assert_eq!(edit.content(), Some("hello"));
+    }
+
+    #[test]
+    fn edit_insertion() {
+        let edit = Edit::insertion("xyz", 4);
+        assert_eq!(edit.start(), 4);
+        assert_eq!(edit.end(), 4);
+        assert_eq!(edit.content(), Some("xyz"));
+    }
+
+    #[test]
+    fn edit_deletion() {
+        let edit = Edit::deletion(span(2, 3));
+        assert_eq!(edit.start(), 2);
+        assert_eq!(edit.end(), 5);
+        assert_eq!(edit.content(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Edit::deletion")]
+    fn edit_replacement_empty_panics_in_debug() {
+        let _ = Edit::replacement("", span(0, 0));
+    }
+
+    #[test]
+    #[should_panic(expected = "Edit::deletion")]
+    fn edit_insertion_empty_panics_in_debug() {
+        let _ = Edit::insertion("", 0);
+    }
+
+    #[test]
+    fn edit_ord_by_start_then_end_then_content() {
+        let mut edits = [
+            Edit::replacement("c", span(2, 1)),
+            Edit::replacement("a", span(0, 1)),
+            Edit::replacement("b", span(0, 1)),
+            Edit::deletion(span(2, 2)),
+        ];
+        edits.sort();
+        assert_eq!(edits[0].content(), Some("a"));
+        assert_eq!(edits[1].content(), Some("b"));
+        assert_eq!(edits[2].start(), 2);
+        assert_eq!(edits[2].end(), 3);
+        assert_eq!(edits[3].start(), 2);
+        assert_eq!(edits[3].end(), 4);
+    }
+
+    #[test]
+    fn fix_safe_edit() {
+        let fix = Fix::safe_edit(Edit::insertion("x", 5));
+        assert_eq!(fix.applicability(), Applicability::Safe);
+        assert_eq!(fix.edits().len(), 1);
+        assert_eq!(fix.min_start(), Some(5));
+        assert_eq!(fix.isolation(), IsolationLevel::NonOverlapping);
+    }
+
+    #[test]
+    fn fix_unsafe_edit() {
+        let fix = Fix::unsafe_edit(Edit::insertion("x", 5));
+        assert_eq!(fix.applicability(), Applicability::Unsafe);
+    }
+
+    #[test]
+    fn fix_display_only_edit() {
+        let fix = Fix::display_only_edit(Edit::insertion("x", 5));
+        assert_eq!(fix.applicability(), Applicability::DisplayOnly);
+    }
+
+    #[test]
+    fn fix_safe_edits_sorts() {
+        let fix = Fix::safe_edits(
+            Edit::insertion("late", 10),
+            [Edit::insertion("early", 0), Edit::insertion("mid", 5)],
+        );
+        let starts: Vec<usize> = fix.edits().iter().map(Edit::start).collect();
+        assert_eq!(starts, vec![0, 5, 10]);
+        assert_eq!(fix.min_start(), Some(0));
+    }
+
+    #[test]
+    #[should_panic(expected = "non-overlapping")]
+    fn fix_safe_edits_overlap_panics_in_debug() {
+        let _ = Fix::safe_edits(
+            Edit::replacement("a", span(0, 5)),
+            [Edit::replacement("b", span(3, 5))],
+        );
+    }
+
+    #[test]
+    fn fix_unsafe_edits() {
+        let fix = Fix::unsafe_edits(Edit::insertion("a", 0), [Edit::insertion("b", 5)]);
+        assert_eq!(fix.applicability(), Applicability::Unsafe);
+        assert_eq!(fix.edits().len(), 2);
+    }
+
+    #[test]
+    fn fix_display_only_edits() {
+        let fix = Fix::display_only_edits(Edit::insertion("a", 0), [Edit::insertion("b", 5)]);
+        assert_eq!(fix.applicability(), Applicability::DisplayOnly);
+    }
+
+    #[test]
+    fn fix_isolate_builder() {
+        let fix = Fix::safe_edit(Edit::insertion("x", 0)).isolate(IsolationLevel::Group(7));
+        assert!(matches!(fix.isolation(), IsolationLevel::Group(7)));
+    }
+
+    #[test]
+    fn fix_with_applicability_builder() {
+        let fix = Fix::safe_edit(Edit::insertion("x", 0)).with_applicability(Applicability::Unsafe);
+        assert_eq!(fix.applicability(), Applicability::Unsafe);
+    }
+
+    #[test]
+    fn fix_applies_threshold_semantics() {
+        let safe = Fix::safe_edit(Edit::insertion("x", 0));
+        let unsafe_ = Fix::unsafe_edit(Edit::insertion("x", 0));
+        let display = Fix::display_only_edit(Edit::insertion("x", 0));
+
+        // threshold = Safe admits only Safe
+        assert!(safe.applies(Applicability::Safe));
+        assert!(!unsafe_.applies(Applicability::Safe));
+        assert!(!display.applies(Applicability::Safe));
+
+        // threshold = Unsafe admits Safe + Unsafe
+        assert!(safe.applies(Applicability::Unsafe));
+        assert!(unsafe_.applies(Applicability::Unsafe));
+        assert!(!display.applies(Applicability::Unsafe));
+
+        // threshold = DisplayOnly admits everything
+        assert!(safe.applies(Applicability::DisplayOnly));
+        assert!(unsafe_.applies(Applicability::DisplayOnly));
+        assert!(display.applies(Applicability::DisplayOnly));
+    }
+
+    #[test]
+    fn fix_safe_edits_adjacent_allowed() {
+        // Adjacent edits (end of one == start of next) are allowed.
+        let fix = Fix::safe_edits(
+            Edit::replacement("a", span(0, 3)),
+            [Edit::replacement("b", span(3, 2))],
+        );
+        assert_eq!(fix.edits().len(), 2);
+    }
+}

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -18,12 +18,20 @@
 //! ```
 
 mod checker;
+pub mod fix;
+pub mod lint_context;
 pub mod registry;
 mod rules;
 pub mod settings;
 mod violation;
 
 pub use checker::Checker;
+pub use fix::apply::{
+    AppliedFix, ApplyResult, FixerError, FixerResult, MAX_FIX_ITERATIONS, RuleFixSummary,
+    SourceMap, SourceMarker, apply_fixes, fix_ast, lint_fix,
+};
+pub use fix::{Applicability, Edit, Fix, FixAvailability, IsolationLevel};
+pub use lint_context::{DiagnosticGuard, LintContext};
 pub use registry::{Rule, RuleCategory};
 pub use settings::Settings;
 
@@ -34,7 +42,7 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 ///
 /// Source code is added later via [`FileDiagnostics`] to avoid cloning
 /// the entire file content for each diagnostic.
-#[derive(Debug, Diagnostic, thiserror::Error)]
+#[derive(Debug, Clone, Diagnostic, thiserror::Error)]
 #[error("{message}")]
 pub struct LintDiagnostic {
     /// Rule code (e.g., "invalid-attr-value").
@@ -48,13 +56,22 @@ pub struct LintDiagnostic {
     /// Optional help text with suggestions.
     #[help]
     pub help: Option<String>,
+    /// Optional fix attached to the diagnostic.
+    ///
+    /// Stored on the diagnostic; applicability gating happens at apply time.
+    pub fix: Option<Fix>,
+    /// Optional short imperative summary of the fix.
+    ///
+    /// Stored separately from `help` so the renderer can mark it as fix-related
+    /// (and so a rule's `help()` and `fix_title()` don't fight for the same field).
+    pub fix_title: Option<String>,
 }
 
 /// A collection of lint diagnostics for a single file.
 ///
 /// This struct holds the source code once and references it for all diagnostics,
 /// avoiding the need to clone the source for each individual diagnostic.
-#[derive(Debug, Diagnostic, thiserror::Error)]
+#[derive(Debug, Clone, Diagnostic, thiserror::Error)]
 #[error("Found {} lint error(s)", self.related.len())]
 pub struct FileDiagnostics {
     /// The source code of the file.

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -1,0 +1,189 @@
+//! [`LintContext`] and [`DiagnosticGuard`].
+//!
+//! The `LintContext` owns the diagnostic buffer and is shared by reference
+//! through the AST visitor. Reporting a diagnostic returns a guard that
+//! buffers a partial diagnostic; on Drop the guard pushes it into the
+//! context's buffer. Mirrors ruff's `LintContext` / `Checker` split.
+
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+
+use miette::SourceSpan;
+
+use crate::LintDiagnostic;
+use crate::Settings;
+use crate::fix::Fix;
+use crate::registry::Rule;
+use crate::violation::Violation;
+
+/// A type for collecting diagnostics in a given file.
+///
+/// [`LintContext::report_diagnostic`] can be used to obtain a [`DiagnosticGuard`], which will push
+/// a [`Violation`] to the contained [`Diagnostic`] collection on `Drop`.
+pub struct LintContext<'a> {
+    diagnostics: RefCell<Vec<LintDiagnostic>>,
+    source: &'a str,
+    settings: &'a Settings,
+}
+
+impl<'a> LintContext<'a> {
+    #[must_use]
+    pub const fn new(source: &'a str, settings: &'a Settings) -> Self {
+        Self {
+            source,
+            settings,
+            diagnostics: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// The source code being linted.
+    #[must_use]
+    pub const fn source(&self) -> &'a str {
+        self.source
+    }
+
+    /// The settings active for this run.
+    #[must_use]
+    pub const fn settings(&self) -> &'a Settings {
+        self.settings
+    }
+
+    /// Returns whether the given rule should be checked.
+    #[must_use]
+    #[inline]
+    pub fn is_rule_enabled(&self, rule: Rule) -> bool {
+        self.settings.is_enabled(rule)
+    }
+
+    /// Compute the byte offset of `slice` within the source.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is not a subslice of the source.
+    #[must_use]
+    pub fn source_offset(&self, slice: &str) -> usize {
+        let src_start = self.source.as_ptr() as usize;
+        let src_end = src_start + self.source.len();
+        let slice_start = slice.as_ptr() as usize;
+        let slice_end = slice_start + slice.len();
+
+        assert!(
+            slice_start >= src_start && slice_end <= src_end,
+            "slice must be a subslice of self.source"
+        );
+
+        slice_start - src_start
+    }
+
+    /// Build a guard for an enabled rule. Returns `None` if the rule is disabled.
+    pub fn report_diagnostic_if_enabled<V: Violation>(
+        &self,
+        violation: &V,
+        span: SourceSpan,
+    ) -> Option<DiagnosticGuard<'_, 'a>> {
+        if !self.is_rule_enabled(V::RULE) {
+            return None;
+        }
+        Some(self.report_diagnostic(violation, span))
+    }
+
+    /// Build a guard for a rule the caller has already gated with
+    /// [`Self::is_rule_enabled`].
+    pub fn report_diagnostic<V: Violation>(
+        &self,
+        violation: &V,
+        span: SourceSpan,
+    ) -> DiagnosticGuard<'_, 'a> {
+        DiagnosticGuard {
+            context: self,
+            diagnostic: Some(LintDiagnostic {
+                code: V::RULE.to_string(),
+                message: violation.message(),
+                span,
+                help: violation.help(),
+                fix: None,
+                fix_title: violation.fix_title(),
+            }),
+            rule: V::RULE,
+        }
+    }
+
+    /// Consume the context and return the collected diagnostics.
+    #[must_use]
+    pub fn into_diagnostics(self) -> Vec<LintDiagnostic> {
+        self.diagnostics.into_inner()
+    }
+}
+
+/// Guard that holds a partially-built diagnostic and pushes it on Drop.
+///
+/// Implements [`Deref`] / [`DerefMut`] to the underlying [`LintDiagnostic`]
+/// so callers can override fields like `help` or `fix_title` if needed.
+pub struct DiagnosticGuard<'ctx, 'a> {
+    context: &'ctx LintContext<'a>,
+    diagnostic: Option<LintDiagnostic>,
+    /// Rule the diagnostic was reported for. Used for tracing on fallible fixes.
+    rule: Rule,
+}
+
+impl DiagnosticGuard<'_, '_> {
+    /// Attach a fix. Stored on the diagnostic; applicability gating happens
+    /// at apply time.
+    pub fn set_fix(&mut self, fix: Fix) {
+        if let Some(diag) = self.diagnostic.as_mut() {
+            diag.fix = Some(fix);
+        }
+    }
+
+    /// Compute a fix fallibly; on `Err`, log at debug and skip attachment.
+    pub fn try_set_fix(&mut self, f: impl FnOnce() -> anyhow::Result<Fix>) {
+        match f() {
+            Ok(fix) => self.set_fix(fix),
+            Err(err) => {
+                tracing::debug!(rule = %self.rule, "failed to compute fix: {err}");
+            }
+        }
+    }
+
+    /// Compute an optional fix fallibly; on `Ok(None)`, skip; on `Err`, log
+    /// and skip.
+    pub fn try_set_optional_fix(&mut self, f: impl FnOnce() -> anyhow::Result<Option<Fix>>) {
+        match f() {
+            Ok(Some(fix)) => self.set_fix(fix),
+            Ok(None) => {}
+            Err(err) => {
+                tracing::debug!(rule = %self.rule, "failed to compute optional fix: {err}");
+            }
+        }
+    }
+}
+
+impl Deref for DiagnosticGuard<'_, '_> {
+    type Target = LintDiagnostic;
+
+    fn deref(&self) -> &Self::Target {
+        self.diagnostic
+            .as_ref()
+            .expect("diagnostic accessed during Drop")
+    }
+}
+
+impl DerefMut for DiagnosticGuard<'_, '_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.diagnostic
+            .as_mut()
+            .expect("diagnostic accessed during Drop")
+    }
+}
+
+impl Drop for DiagnosticGuard<'_, '_> {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            // Don't push half-built diagnostics if we're unwinding.
+            return;
+        }
+        if let Some(diag) = self.diagnostic.take() {
+            self.context.diagnostics.borrow_mut().push(diag);
+        }
+    }
+}

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -121,6 +121,6 @@ define_rules {
 // Example: InvalidAttrValue -> "invalid-attr-value"
 
 define_rules! {
-    /// Validates attribute values against allowed values (e.g., `<form method>`).
     (InvalidAttrValue, rules::correctness::invalid_attr_value::InvalidAttrValue),
+    (UntrimmedBlocktranslate, rules::correctness::untrimmed_blocktranslate::UntrimmedBlocktranslate),
 }

--- a/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
@@ -50,7 +50,7 @@ impl Violation for InvalidAttrValue {
 }
 
 /// Check an element's attributes for invalid enum values.
-pub fn check(element: &Element<'_>, checker: &mut Checker<'_>) {
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     // Pending implementation of djangofmt_html_spec.
     // Currently only checks for <form method="...">.
     if !element.tag_name.eq_ignore_ascii_case("form") {
@@ -75,7 +75,7 @@ pub fn check(element: &Element<'_>, checker: &mut Checker<'_>) {
 
             let allowed = ["get", "post", "dialog"];
             if !allowed.iter().any(|v| v.eq_ignore_ascii_case(value_str)) {
-                checker.report(
+                checker.report_diagnostic(
                     &InvalidAttrValue {
                         value: (*value_str).to_string(),
                         attribute: "method".to_string(),

--- a/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
@@ -1,16 +1,3 @@
-//! invalid-attr-value: Invalid attribute value.
-//!
-//! Validates attribute values against the HTML specification.
-//! Currently only validates enum-type attributes (e.g., `<input type>`, `<button type>`).
-//!
-//! Also validates HTMX attributes (`hx-boost`, `hx-swap`, etc.) and Alpine.js attributes.
-//!
-//! ## Skipped cases
-//!
-//! - **Interpolation**: Values containing `{{` or `{%` are skipped (dynamic values)
-//! - **Unknown elements**: Web components and custom elements are skipped
-//! - **Unknown attributes**: Attributes not in the spec are skipped
-
 use markup_fmt::ast::{Attribute, Element, NativeAttribute};
 
 use crate::Checker;
@@ -18,10 +5,37 @@ use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::contains_interpolation;
 use crate::violation::Violation;
 
-/// Violation for invalid HTML attribute values.
+/// ## What it does
+/// Checks for HTML attributes whose value is not in the set allowed by the
+/// HTML specification (and supported framework dialects such as HTMX or
+/// Alpine.js).
 ///
-/// Reports when an attribute has a value that doesn't match the allowed values
-/// for that attribute (e.g., `<form method="put">` is invalid).
+/// Currently only validates enum-type attributes (e.g., `<form method>`,
+/// `<input type>`, `<button type>`).
+///
+/// ## Why is this bad?
+/// Browsers silently ignore unknown values for enum attributes and fall back
+/// to a default, which usually does not match the author's intent. The
+/// resulting bug is easy to miss because the page still renders.
+///
+/// Values containing template interpolation (`{{ ... }}` or `{% ... %}`),
+/// unknown elements (web components, custom tags), and unknown attributes
+/// are skipped.
+///
+/// ## Example
+///
+/// ```html
+/// <form method="put"></form>
+/// ```
+///
+/// Use instead:
+///
+/// ```html
+/// <form method="post"></form>
+/// ```
+///
+/// ## References
+/// - [HTML Living Standard: `form.method`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method)
 #[derive(Debug, PartialEq, Eq)]
 pub struct InvalidAttrValue {
     pub value: String,

--- a/crates/djangofmt_lint/src/rules/correctness/mod.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/mod.rs
@@ -1,1 +1,2 @@
 pub mod invalid_attr_value;
+pub mod untrimmed_blocktranslate;

--- a/crates/djangofmt_lint/src/rules/correctness/untrimmed_blocktranslate.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/untrimmed_blocktranslate.rs
@@ -1,0 +1,96 @@
+use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node};
+use markup_fmt::parser::parse_jinja_tag_name;
+
+use crate::Checker;
+use crate::fix::{Edit, Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::Violation;
+
+/// ## What it does
+/// Checks for `{% blocktranslate %}` / `{% blocktrans %}` blocks that omit
+/// the `trimmed` option.
+///
+/// ## Why is this bad?
+/// Without `trimmed`, indentation and whitespace inside the block become part
+/// of the translation string in `.po` files. Reformatting the template then
+/// reorders bytes inside translatable strings, producing noisy translation
+/// diffs on every reformat.
+///
+/// ## Example
+///
+/// ```html
+/// {% blocktranslate %}This string will have {{ value }} inside.{% endblocktranslate %}
+/// ```
+///
+/// Use instead:
+///
+/// ```html
+/// {% blocktranslate trimmed %}This string will have {{ value }} inside.{% endblocktranslate %}
+/// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as safe: it inserts ` trimmed` immediately after
+/// the tag name in the opening tag without altering the translatable content.
+///
+/// ## References
+/// - [Django documentation: `blocktranslate`](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#std-templatetag-blocktranslate)
+#[derive(Debug, PartialEq, Eq)]
+pub struct UntrimmedBlocktranslate;
+
+impl Violation for UntrimmedBlocktranslate {
+    const RULE: Rule = Rule::UntrimmedBlocktranslate;
+    const CATEGORY: RuleCategory = RuleCategory::Correctness;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    fn message(&self) -> String {
+        "`{% blocktranslate %}` should declare `trimmed` to avoid leaking \
+         indentation into translation strings."
+            .to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(
+            "Add `trimmed` to the opening tag, e.g. \
+             `{% blocktranslate trimmed %}...{% endblocktranslate %}`."
+                .to_string(),
+        )
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Add trimmed".to_string())
+    }
+}
+
+/// Inspect the opening tag of a Jinja block and report a diagnostic if it
+/// is a `blocktranslate` / `blocktrans` block missing the `trimmed` keyword.
+pub fn check(block: &JinjaBlock<'_, Node<'_>>, checker: &Checker<'_>) {
+    let Some(JinjaTagOrChildren::Tag(open_tag)) = block.body.first() else {
+        return;
+    };
+
+    let tag_name = parse_jinja_tag_name(open_tag);
+    if tag_name != "blocktranslate" && tag_name != "blocktrans" {
+        return;
+    }
+
+    if open_tag
+        .content
+        .split_ascii_whitespace()
+        .any(|w| w == "trimmed")
+    {
+        return;
+    }
+
+    let span = (open_tag.start, open_tag.content.len()).into();
+    let Some(mut guard) = checker.report_diagnostic_if_enabled(&UntrimmedBlocktranslate, span)
+    else {
+        return;
+    };
+
+    let local_offset = open_tag
+        .content
+        .find(tag_name)
+        .expect("tag_name was extracted from tag.content by parse_jinja_tag_name");
+    let insertion_at = open_tag.start + local_offset + tag_name.len();
+    guard.set_fix(Fix::safe_edit(Edit::insertion(" trimmed", insertion_at)));
+}

--- a/crates/djangofmt_lint/src/violation.rs
+++ b/crates/djangofmt_lint/src/violation.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use crate::fix::FixAvailability;
 use crate::registry::{Rule, RuleCategory};
 
 /// A trait for lint violations.
@@ -12,6 +13,9 @@ use crate::registry::{Rule, RuleCategory};
 /// - Compile-time verification that every violation has a registered rule
 ///
 /// The `CATEGORY` constant declares the functional grouping (e.g., Correctness, Style).
+///
+/// The `FIX_AVAILABILITY` constant declares whether (and how often) the rule
+/// produces a fix. Default is [`FixAvailability::None`] for fixless rules.
 pub trait Violation: Debug {
     /// The rule for this violation (e.g., `Rule::InvalidAttrValue`).
     const RULE: Rule;
@@ -19,11 +23,21 @@ pub trait Violation: Debug {
     /// The category for this violation (e.g., `RuleCategory::Correctness`).
     const CATEGORY: RuleCategory;
 
+    /// Whether this rule produces a fix, and if so how often.
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
     /// The message to be displayed to the user.
     fn message(&self) -> String;
 
     /// Optional help text with suggestions for fixing the issue.
     fn help(&self) -> Option<String> {
+        None
+    }
+
+    /// A short, imperative summary of what the fix does (e.g. `"Add trimmed"`).
+    ///
+    /// Set on the diagnostic by [`crate::LintContext::report_diagnostic`].
+    fn fix_title(&self) -> Option<String> {
         None
     }
 }

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -2,7 +2,9 @@
 mod common;
 
 use common::build_settings;
-use djangofmt_lint::{FileDiagnostics, LintDiagnostic, Settings, check_ast};
+use djangofmt_lint::{
+    Applicability, FileDiagnostics, LintDiagnostic, Settings, check_ast, fix_ast,
+};
 
 use insta::{assert_snapshot, glob};
 use markup_fmt::Language;
@@ -11,6 +13,7 @@ use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use std::fs;
 use std::path::Path;
 
+/// Asserts every `*.valid.html` fixture produces zero diagnostics.
 #[test]
 fn check_valid() {
     glob!("**/*.valid.html", |path| {
@@ -28,6 +31,7 @@ fn check_valid() {
     });
 }
 
+/// Snapshots the rendered diagnostics produced for each `*.invalid.html` fixture.
 #[test]
 fn check_invalid() {
     glob!("**/*.invalid.html", |path| {
@@ -41,6 +45,27 @@ fn check_invalid() {
         build_settings(path).bind(|| {
             let name = path.file_stem().unwrap().to_str().unwrap();
             assert_snapshot!(name, output);
+        });
+    });
+}
+
+/// Snapshots the post-fix source for each `*.invalid.html` fixture whose rule applies a safe fix.
+#[test]
+fn fix_snapshot() {
+    glob!("**/*.invalid.html", |path| {
+        let input = fs::read_to_string(path).unwrap();
+        let mut parser = Parser::new(&input, Language::Django, vec![]);
+        let Ok(ast) = parser.parse_root() else {
+            return;
+        };
+        let result = fix_ast(&input, &ast, &Settings::default(), Applicability::Safe);
+        if result.applied_count == 0 {
+            return;
+        }
+        build_settings(path).bind(|| {
+            let stem = path.file_stem().unwrap().to_str().unwrap();
+            let name = format!("{stem}.fixed");
+            assert_snapshot!(name, result.output);
         });
     });
 }

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -73,7 +73,7 @@ fn fix_snapshot() {
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
 fn collect_diagnostics(input: &str) -> Vec<LintDiagnostic> {
-    let mut parser = Parser::new(input, Language::Jinja, vec![]);
+    let mut parser = Parser::new(input, Language::Django, vec![]);
     let ast = parser.parse_root().expect("Failed to parse AST in test");
     let settings = Settings::default();
     check_ast(input, &ast, &settings)

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -55,9 +55,9 @@ fn fix_snapshot() {
     glob!("**/*.invalid.html", |path| {
         let input = fs::read_to_string(path).unwrap();
         let mut parser = Parser::new(&input, Language::Django, vec![]);
-        let Ok(ast) = parser.parse_root() else {
-            return;
-        };
+        let ast = parser
+            .parse_root()
+            .unwrap_or_else(|err| panic!("Failed to parse {}: {err:?}", path.display()));
         let result = fix_ast(&input, &ast, &Settings::default(), Applicability::Safe);
         if result.applied_count == 0 {
             return;

--- a/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.fixed.snap
@@ -1,0 +1,81 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+<!-- Simple interpolation -->
+{% blocktranslate trimmed %}This string will have {{ value }} inside.{% endblocktranslate %}
+
+<!-- with clause -->
+{% blocktranslate trimmed with amount=article.price %}
+That will cost $ {{ amount }}.
+{% endblocktranslate %}
+
+<!-- multiple with -->
+{% blocktranslate trimmed with book_t=book|title author_t=author|title %}
+This is {{ book_t }} by {{ author_t }}
+{% endblocktranslate %}
+
+<!-- count + plural -->
+{% blocktranslate trimmed count counter=list|length %}
+There is {{ counter }} {{ name }} object.
+{% plural %}
+There are {{ counter }} {{ name }} objects.
+{% endblocktranslate %}
+
+<!-- with + count + plural -->
+{% blocktranslate trimmed with amount=article.price count years=i.length %}
+That will cost $ {{ amount }} per year.
+{% plural %}
+That will cost $ {{ amount }} per {{ years }} years.
+{% endblocktranslate %}
+
+<!-- asvar -->
+{% blocktranslate trimmed asvar the_title %}The title is {{ title }}.{% endblocktranslate %}
+
+<!-- context (with literal) -->
+{% blocktranslate trimmed with name=user.username context "greeting" %}Hi {{ name }}{% endblocktranslate %}
+
+<!-- Django test: context-only with literal -->
+{% blocktranslate trimmed context "month name" %}May{% endblocktranslate %}
+
+<!-- Django test: context with runtime variable -->
+{% blocktranslate trimmed context message_context %}May{% endblocktranslate %}
+
+<!-- Django test: count + context (count first, no `with`) -->
+{% blocktranslate trimmed count number=1 context "super search" %}
+{{ number }} super result
+{% plural %}
+{{ number }} super results
+{% endblocktranslate %}
+
+<!-- Legacy `count ... as` syntax -->
+{% blocktranslate trimmed count number as counter %}
+{{ counter }} result
+{% plural %}
+{{ counter }} results
+{% endblocktranslate %}
+
+<!-- Legacy `with ... as` + `and` (multi-binding) -->
+{% blocktranslate trimmed with anton as a and berta as b %}{{ a }} + {{ b }}{% endblocktranslate %}
+
+<!-- Legacy blocktrans -->
+{% blocktrans trimmed %}Some text{% endblocktrans %}
+
+<!-- Whitespace control -->
+{%- blocktranslate trimmed %}Some text{% endblocktranslate %}
+
+<!-- Nested in if block -->
+{% if show %}
+    {% blocktranslate trimmed %}Nested text{% endblocktranslate %}
+{% endif %}
+
+<!-- Article: HTML-wrapped multi-line content (leaks indentation) -->
+<p>{% blocktranslate trimmed %}
+  With leading and trailing whitespace.
+{% endblocktranslate %}</p>
+
+<!-- Article: nested HTML indentation -->
+<div>
+  <p>{% blocktranslate trimmed %}
+    Nested indentation problem.
+  {% endblocktranslate %}</p>
+</div>

--- a/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html
+++ b/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html
@@ -1,0 +1,78 @@
+<!-- Simple interpolation -->
+{% blocktranslate %}This string will have {{ value }} inside.{% endblocktranslate %}
+
+<!-- with clause -->
+{% blocktranslate with amount=article.price %}
+That will cost $ {{ amount }}.
+{% endblocktranslate %}
+
+<!-- multiple with -->
+{% blocktranslate with book_t=book|title author_t=author|title %}
+This is {{ book_t }} by {{ author_t }}
+{% endblocktranslate %}
+
+<!-- count + plural -->
+{% blocktranslate count counter=list|length %}
+There is {{ counter }} {{ name }} object.
+{% plural %}
+There are {{ counter }} {{ name }} objects.
+{% endblocktranslate %}
+
+<!-- with + count + plural -->
+{% blocktranslate with amount=article.price count years=i.length %}
+That will cost $ {{ amount }} per year.
+{% plural %}
+That will cost $ {{ amount }} per {{ years }} years.
+{% endblocktranslate %}
+
+<!-- asvar -->
+{% blocktranslate asvar the_title %}The title is {{ title }}.{% endblocktranslate %}
+
+<!-- context (with literal) -->
+{% blocktranslate with name=user.username context "greeting" %}Hi {{ name }}{% endblocktranslate %}
+
+<!-- Django test: context-only with literal -->
+{% blocktranslate context "month name" %}May{% endblocktranslate %}
+
+<!-- Django test: context with runtime variable -->
+{% blocktranslate context message_context %}May{% endblocktranslate %}
+
+<!-- Django test: count + context (count first, no `with`) -->
+{% blocktranslate count number=1 context "super search" %}
+{{ number }} super result
+{% plural %}
+{{ number }} super results
+{% endblocktranslate %}
+
+<!-- Legacy `count ... as` syntax -->
+{% blocktranslate count number as counter %}
+{{ counter }} result
+{% plural %}
+{{ counter }} results
+{% endblocktranslate %}
+
+<!-- Legacy `with ... as` + `and` (multi-binding) -->
+{% blocktranslate with anton as a and berta as b %}{{ a }} + {{ b }}{% endblocktranslate %}
+
+<!-- Legacy blocktrans -->
+{% blocktrans %}Some text{% endblocktrans %}
+
+<!-- Whitespace control -->
+{%- blocktranslate %}Some text{% endblocktranslate %}
+
+<!-- Nested in if block -->
+{% if show %}
+    {% blocktranslate %}Nested text{% endblocktranslate %}
+{% endif %}
+
+<!-- Article: HTML-wrapped multi-line content (leaks indentation) -->
+<p>{% blocktranslate %}
+  With leading and trailing whitespace.
+{% endblocktranslate %}</p>
+
+<!-- Article: nested HTML indentation -->
+<div>
+  <p>{% blocktranslate %}
+    Nested indentation problem.
+  {% endblocktranslate %}</p>
+</div>

--- a/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.snap
@@ -1,0 +1,191 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 17 lint error(s)
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+   ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:2:3]
+ 1 │ <!-- Simple interpolation -->
+ 2 │ {% blocktranslate %}This string will have {{ value }} inside.{% endblocktranslate %}
+   ·   ────────┬───────
+   ·           ╰── here
+ 3 │ 
+   ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+   ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:5:3]
+ 4 │ <!-- with clause -->
+ 5 │ {% blocktranslate with amount=article.price %}
+   ·   ─────────────────────┬────────────────────
+   ·                        ╰── here
+ 6 │ That will cost $ {{ amount }}.
+   ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:10:3]
+  9 │ <!-- multiple with -->
+ 10 │ {% blocktranslate with book_t=book|title author_t=author|title %}
+    ·   ──────────────────────────────┬──────────────────────────────
+    ·                                 ╰── here
+ 11 │ This is {{ book_t }} by {{ author_t }}
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:15:3]
+ 14 │ <!-- count + plural -->
+ 15 │ {% blocktranslate count counter=list|length %}
+    ·   ─────────────────────┬────────────────────
+    ·                        ╰── here
+ 16 │ There is {{ counter }} {{ name }} object.
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:22:3]
+ 21 │ <!-- with + count + plural -->
+ 22 │ {% blocktranslate with amount=article.price count years=i.length %}
+    ·   ───────────────────────────────┬───────────────────────────────
+    ·                                  ╰── here
+ 23 │ That will cost $ {{ amount }} per year.
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:29:3]
+ 28 │ <!-- asvar -->
+ 29 │ {% blocktranslate asvar the_title %}The title is {{ title }}.{% endblocktranslate %}
+    ·   ────────────────┬───────────────
+    ·                   ╰── here
+ 30 │ 
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:32:3]
+ 31 │ <!-- context (with literal) -->
+ 32 │ {% blocktranslate with name=user.username context "greeting" %}Hi {{ name }}{% endblocktranslate %}
+    ·   ─────────────────────────────┬─────────────────────────────
+    ·                                ╰── here
+ 33 │ 
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:35:3]
+ 34 │ <!-- Django test: context-only with literal -->
+ 35 │ {% blocktranslate context "month name" %}May{% endblocktranslate %}
+    ·   ──────────────────┬──────────────────
+    ·                     ╰── here
+ 36 │ 
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:38:3]
+ 37 │ <!-- Django test: context with runtime variable -->
+ 38 │ {% blocktranslate context message_context %}May{% endblocktranslate %}
+    ·   ────────────────────┬───────────────────
+    ·                       ╰── here
+ 39 │ 
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:41:3]
+ 40 │ <!-- Django test: count + context (count first, no `with`) -->
+ 41 │ {% blocktranslate count number=1 context "super search" %}
+    ·   ───────────────────────────┬──────────────────────────
+    ·                              ╰── here
+ 42 │ {{ number }} super result
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:48:3]
+ 47 │ <!-- Legacy `count ... as` syntax -->
+ 48 │ {% blocktranslate count number as counter %}
+    ·   ────────────────────┬───────────────────
+    ·                       ╰── here
+ 49 │ {{ counter }} result
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:55:3]
+ 54 │ <!-- Legacy `with ... as` + `and` (multi-binding) -->
+ 55 │ {% blocktranslate with anton as a and berta as b %}{{ a }} + {{ b }}{% endblocktranslate %}
+    ·   ───────────────────────┬───────────────────────
+    ·                          ╰── here
+ 56 │ 
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:58:3]
+ 57 │ <!-- Legacy blocktrans -->
+ 58 │ {% blocktrans %}Some text{% endblocktrans %}
+    ·   ──────┬─────
+    ·         ╰── here
+ 59 │ 
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:61:3]
+ 60 │ <!-- Whitespace control -->
+ 61 │ {%- blocktranslate %}Some text{% endblocktranslate %}
+    ·   ────────┬────────
+    ·           ╰── here
+ 62 │ 
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:65:7]
+ 64 │ {% if show %}
+ 65 │     {% blocktranslate %}Nested text{% endblocktranslate %}
+    ·       ────────┬───────
+    ·               ╰── here
+ 66 │ {% endif %}
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:69:6]
+ 68 │ <!-- Article: HTML-wrapped multi-line content (leaks indentation) -->
+ 69 │ <p>{% blocktranslate %}
+    ·      ────────┬───────
+    ·              ╰── here
+ 70 │   With leading and trailing whitespace.
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.
+
+Error: 
+  × `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    ╭─[tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.invalid.html:75:8]
+ 74 │ <div>
+ 75 │   <p>{% blocktranslate %}
+    ·        ────────┬───────
+    ·                ╰── here
+ 76 │     Nested indentation problem.
+    ╰────
+  help: Add `trimmed` to the opening tag, e.g. `{% blocktranslate trimmed %}...{% endblocktranslate %}`.

--- a/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.valid.html
+++ b/crates/djangofmt_lint/tests/check/untrimmed_blocktranslate/untrimmed_blocktranslate.valid.html
@@ -1,0 +1,46 @@
+<!-- Already trimmed -->
+{% blocktranslate trimmed %}
+  First sentence.
+  Second paragraph.
+{% endblocktranslate %}
+
+<!-- Legacy blocktrans already trimmed -->
+{% blocktrans trimmed %}Some text{% endblocktrans %}
+
+<!-- trimmed with other args -->
+{% blocktranslate trimmed count counter=list|length %}
+There is {{ counter }} object.
+{% plural %}
+There are {{ counter }} objects.
+{% endblocktranslate %}
+
+<!-- trimmed positioned at the end (after count) -->
+{% blocktranslate count counter=list|length trimmed %}
+  There is {{ counter }} object.
+{% plural %}
+  There are {{ counter }} objects.
+{% endblocktranslate %}
+
+<!-- Django test: with + context + trimmed (trimmed last) -->
+{% blocktranslate with num_comments=5 context "comment count" trimmed %}
+  There are {{ num_comments }} comments.
+{% endblocktranslate %}
+
+<!-- Django test: context + count + trimmed (trimmed last) -->
+{% blocktranslate context "super search" count number=2 trimmed %}
+  {{ number }} super result
+{% plural %}
+  {{ number }} super results
+{% endblocktranslate %}
+
+<!-- Whitespace control on both ends + trimmed -->
+<p>{%- blocktranslate trimmed -%}
+  Whitespace stripped on both sides.
+{%- endblocktranslate -%}</p>
+
+<!-- Nested in HTML, with trimmed (article example) -->
+<div>
+  <p>{% blocktranslate trimmed %}
+    Still trimmed inside nested HTML.
+  {% endblocktranslate %}</p>
+</div>


### PR DESCRIPTION
## Summary

  Introduces an autofix framework to `djangofmt check`, modeled on Ruff's design, and ships the first autofixable rule.

  - New `LintContext` / `DiagnosticGuard` plumbing replaces the previous `Checker` wiring so rules can attach fixes to diagnostics
  - Adds `--fix`, `--unsafe-fixes`, and `--show-fixes` flags; unhides the `check` subcommand
  - New rule `untrimmed-blocktranslate` with a safe autofix
  - Diagnostic paths are now relative to the current working dir for less verbose output

TODO:
- [ ] Need to expose new cli flags in the pyproject config
