### PR TITLE
ci(perf): include all rust-related files in changed_files detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
               - crates/**
               - .github/workflows/ci.yml
               - Cargo.toml
+              - Cargo.lock
+              - rust-toolchain.toml
+              - rustfmt.toml
+              - clippy.toml
 
   build-and-compare:
     name: "Ecosystem check"


### PR DESCRIPTION
Cargo.lock, rust-toolchain.toml, rustfmt.toml, and clippy.toml all influence Rust build/lint output; changes to them should trigger the ecosystem, shear, and test jobs.