### PR TITLE
Add `uppercase-form-method` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -101,6 +101,10 @@ impl<'a> Checker<'a> {
             rules::suspicious::javascript_url::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::UppercaseFormMethod) {
+            rules::style::uppercase_form_method::check(element, self);
+        }
+
         for attr in &element.attrs {
             self.visit_attribute(attr);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -125,4 +125,5 @@ define_rules! {
     (UntrimmedBlocktranslate, rules::correctness::untrimmed_blocktranslate::UntrimmedBlocktranslate),
     (RedundantTypeAttr, rules::style::redundant_type_attr::RedundantTypeAttr),
     (JavascriptUrl, rules::suspicious::javascript_url::JavascriptUrl),
+    (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
 }

--- a/crates/djangofmt_lint/src/rules/style/mod.rs
+++ b/crates/djangofmt_lint/src/rules/style/mod.rs
@@ -1,1 +1,2 @@
 pub mod redundant_type_attr;
+pub mod uppercase_form_method;

--- a/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
+++ b/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
@@ -1,0 +1,98 @@
+use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+
+use crate::Checker;
+use crate::fix::{Edit, Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::contains_interpolation;
+use crate::violation::Violation;
+
+/// ## What it does
+/// Checks for non-lowercase `method` attribute values on `<form>` elements.
+///
+/// ## Why is this bad?
+/// HTML form `method` values are case-insensitive, but the HTML spec and
+/// conventional usage write them in lowercase (`get`, `post`, `dialog`).
+/// Uppercase or mixed-case values are stylistically inconsistent.
+///
+/// Values containing template interpolation are skipped.
+///
+/// ## Example
+/// ```html
+/// <form method="POST"></form>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <form method="post"></form>
+/// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as safe: the HTML spec defines form `method` as a
+/// case-insensitive enumerated attribute, so lowercasing preserves runtime
+/// semantics.
+///
+/// ## References
+/// - [HTML spec: form submission method](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method)
+#[derive(Debug, PartialEq, Eq)]
+pub struct UppercaseFormMethod<'a> {
+    pub value: &'a str,
+}
+
+impl Violation for UppercaseFormMethod<'_> {
+    const RULE: Rule = Rule::UppercaseFormMethod;
+    const CATEGORY: RuleCategory = RuleCategory::Style;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    fn message(&self) -> String {
+        format!("Form method `{}` should be lowercase.", self.value)
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(format!(
+            "Use `{}` instead.",
+            self.value.to_ascii_lowercase()
+        ))
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Lowercase `method` value".to_string())
+    }
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if !element.tag_name.eq_ignore_ascii_case("form") {
+        return;
+    }
+
+    for attr in &element.attrs {
+        let Attribute::Native(NativeAttribute { name, value, .. }) = attr else {
+            continue;
+        };
+
+        if !name.eq_ignore_ascii_case("method") {
+            continue;
+        }
+
+        let Some((value_str, offset)) = value else {
+            continue;
+        };
+
+        if contains_interpolation(value_str) {
+            continue;
+        }
+
+        if !value_str.chars().any(|c| c.is_ascii_uppercase()) {
+            continue;
+        }
+
+        let mut guard = checker.report_diagnostic(
+            &UppercaseFormMethod { value: value_str },
+            (*offset, value_str.len()).into(),
+        );
+
+        guard.set_fix(Fix::safe_edit(Edit::replacement(
+            value_str.to_ascii_lowercase(),
+            (*offset, value_str.len()).into(),
+        )));
+    }
+}

--- a/crates/djangofmt_lint/tests/check/form_method/form_method.valid.html
+++ b/crates/djangofmt_lint/tests/check/form_method/form_method.valid.html
@@ -2,8 +2,6 @@
 <form method="get">Submit</form>
 <form method="post">Submit</form>
 <form method="dialog">Submit</form>
-<form method="GET">Submit</form>
-<form method="POST">Submit</form>
 
 <!-- Interpolation - dynamic values should be skipped -->
 <form method="{{ method }}">Submit</form>

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.fixed.snap
@@ -1,0 +1,29 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+<!-- Uppercase method -->
+<form method="post"></form>
+<form method="get"></form>
+
+<!-- Mixed case -->
+<form method="post"></form>
+<form method="get"></form>
+
+<!-- Case-insensitive tag name -->
+<forM method="post"></forM>
+<FORM method="post"></FORM>
+
+<!-- Single-quoted and unquoted values -->
+<form method='post'></form>
+<form method=post></form>
+
+<!-- Multiline form with uppercase method -->
+<form
+    action="/submit/"
+    method="post"
+></form>
+
+<!-- Nested in Jinja block -->
+{% if show_form %}
+    <form method="get"></form>
+{% endif %}

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.html
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.html
@@ -1,0 +1,26 @@
+<!-- Uppercase method -->
+<form method="POST"></form>
+<form method="GET"></form>
+
+<!-- Mixed case -->
+<form method="Post"></form>
+<form method="Get"></form>
+
+<!-- Case-insensitive tag name -->
+<forM method="Post"></forM>
+<FORM method="POST"></FORM>
+
+<!-- Single-quoted and unquoted values -->
+<form method='POST'></form>
+<form method=POST></form>
+
+<!-- Multiline form with uppercase method -->
+<form
+    action="/submit/"
+    method="POST"
+></form>
+
+<!-- Nested in Jinja block -->
+{% if show_form %}
+    <form method="GET"></form>
+{% endif %}

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.snap
@@ -1,0 +1,114 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 10 lint error(s)
+
+Error: 
+  × Form method `POST` should be lowercase.
+   ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:2:15]
+ 1 │ <!-- Uppercase method -->
+ 2 │ <form method="POST"></form>
+   ·               ──┬─
+   ·                 ╰── here
+ 3 │ <form method="GET"></form>
+   ╰────
+  help: Use `post` instead.
+
+Error: 
+  × Form method `GET` should be lowercase.
+   ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:3:15]
+ 2 │ <form method="POST"></form>
+ 3 │ <form method="GET"></form>
+   ·               ─┬─
+   ·                ╰── here
+ 4 │ 
+   ╰────
+  help: Use `get` instead.
+
+Error: 
+  × Form method `Post` should be lowercase.
+   ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:6:15]
+ 5 │ <!-- Mixed case -->
+ 6 │ <form method="Post"></form>
+   ·               ──┬─
+   ·                 ╰── here
+ 7 │ <form method="Get"></form>
+   ╰────
+  help: Use `post` instead.
+
+Error: 
+  × Form method `Get` should be lowercase.
+   ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:7:15]
+ 6 │ <form method="Post"></form>
+ 7 │ <form method="Get"></form>
+   ·               ─┬─
+   ·                ╰── here
+ 8 │ 
+   ╰────
+  help: Use `get` instead.
+
+Error: 
+  × Form method `Post` should be lowercase.
+    ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:10:15]
+  9 │ <!-- Case-insensitive tag name -->
+ 10 │ <forM method="Post"></forM>
+    ·               ──┬─
+    ·                 ╰── here
+ 11 │ <FORM method="POST"></FORM>
+    ╰────
+  help: Use `post` instead.
+
+Error: 
+  × Form method `POST` should be lowercase.
+    ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:11:15]
+ 10 │ <forM method="Post"></forM>
+ 11 │ <FORM method="POST"></FORM>
+    ·               ──┬─
+    ·                 ╰── here
+ 12 │ 
+    ╰────
+  help: Use `post` instead.
+
+Error: 
+  × Form method `POST` should be lowercase.
+    ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:14:15]
+ 13 │ <!-- Single-quoted and unquoted values -->
+ 14 │ <form method='POST'></form>
+    ·               ──┬─
+    ·                 ╰── here
+ 15 │ <form method=POST></form>
+    ╰────
+  help: Use `post` instead.
+
+Error: 
+  × Form method `POST` should be lowercase.
+    ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:15:14]
+ 14 │ <form method='POST'></form>
+ 15 │ <form method=POST></form>
+    ·              ──┬─
+    ·                ╰── here
+ 16 │ 
+    ╰────
+  help: Use `post` instead.
+
+Error: 
+  × Form method `POST` should be lowercase.
+    ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:20:13]
+ 19 │     action="/submit/"
+ 20 │     method="POST"
+    ·             ──┬─
+    ·               ╰── here
+ 21 │ ></form>
+    ╰────
+  help: Use `post` instead.
+
+Error: 
+  × Form method `GET` should be lowercase.
+    ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:25:19]
+ 24 │ {% if show_form %}
+ 25 │     <form method="GET"></form>
+    ·                   ─┬─
+    ·                    ╰── here
+ 26 │ {% endif %}
+    ╰────
+  help: Use `get` instead.

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.valid.html
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.valid.html
@@ -1,0 +1,29 @@
+<!-- Lowercase methods are valid -->
+<form method="get"></form>
+<form method="post"></form>
+<form method="dialog"></form>
+<forM method="post"></forM>
+
+<!-- Non-form tags are not checked -->
+<a method="POST">Link</a>
+<div method="GET"></div>
+
+<!-- Interpolation - dynamic values should be skipped -->
+<form method="{{ method }}"></form>
+<form method="{% if x %}POST{% else %}GET{% endif %}"></form>
+
+<!-- No value -->
+<form method></form>
+
+<!-- Single-quoted and unquoted lowercase values -->
+<form method='post'></form>
+<form method=post></form>
+
+<!-- No method attribute -->
+<form action="/submit/"></form>
+
+<!-- Multiline with lowercase method -->
+<form
+    action="/submit/"
+    method="post"
+></form>


### PR DESCRIPTION
## What it does
Checks for non-lowercase `method` attribute values on `<form>` elements.

## Why is this bad?
HTML form `method` values are case-insensitive, but the HTML spec and conventional usage write them in lowercase (`get`, `post`, `dialog`). Uppercase or mixed-case values are stylistically inconsistent.

Values containing template interpolation are skipped.

## Example
```html
<form method="POST"></form>
```

Use instead:
```html
<form method="post"></form>
```

## Fix safety
This rule's fix is marked as safe: the HTML spec defines form `method` as a case-insensitive enumerated attribute, so lowercasing preserves runtime semantics.

## References
- [HTML spec: form submission method](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method)

Part of #231 