### PR TITLE
Add `missing-html-lang` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -105,6 +105,10 @@ impl<'a> Checker<'a> {
             rules::style::uppercase_form_method::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::MissingHtmlLang) {
+            rules::accessibility::missing_html_lang::check(element, self);
+        }
+
         for attr in &element.attrs {
             self.visit_attribute(attr);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -19,6 +19,8 @@ pub enum RuleCategory {
     Style,
     /// Code that is overly complex.
     Complexity,
+    /// Code that creates accessibility (a11y) barriers.
+    Accessibility,
     /// New rules that are not yet stable.
     Nursery,
 }
@@ -126,4 +128,5 @@ define_rules! {
     (RedundantTypeAttr, rules::style::redundant_type_attr::RedundantTypeAttr),
     (JavascriptUrl, rules::suspicious::javascript_url::JavascriptUrl),
     (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
+    (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
@@ -1,0 +1,75 @@
+use markup_fmt::ast::{Attribute, Element, JinjaBlock, JinjaTagOrChildren};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::Violation;
+
+/// ## What it does
+/// Checks for `<html>` tags that do not declare a `lang` attribute.
+///
+/// ## Why is this bad?
+/// The `lang` attribute on `<html>` declares the primary language of the document. Screen readers
+/// use it to select the correct pronunciation rules, and search engines use it to index the page
+/// for the right audience.
+///
+/// A `lang` attribute wrapped in a Jinja conditional (e.g. `{% if %}lang="en"{% endif %}`) is
+/// treated as present, to avoid false positives on dynamic templates.
+///
+/// ## Example
+/// ```html
+/// <html>
+/// </html>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <html lang="en">
+/// </html>
+/// ```
+///
+/// ## References
+/// - [MDN: HTML `lang` global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+/// - [WCAG 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html)
+#[derive(Debug, PartialEq, Eq)]
+pub struct MissingHtmlLang;
+
+impl Violation for MissingHtmlLang {
+    const RULE: Rule = Rule::MissingHtmlLang;
+    const CATEGORY: RuleCategory = RuleCategory::Accessibility;
+
+    fn message(&self) -> String {
+        "`<html>` tag should declare a `lang` attribute.".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Add `lang=\"en\"` (or the appropriate language code).".to_string())
+    }
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if !element.tag_name.eq_ignore_ascii_case("html") {
+        return;
+    }
+
+    if element.attrs.iter().any(attr_declares_lang) {
+        return;
+    }
+
+    let offset = checker.source_offset(element.tag_name);
+    checker.report_diagnostic(&MissingHtmlLang, (offset, element.tag_name.len()).into());
+}
+
+fn attr_declares_lang(attr: &Attribute<'_>) -> bool {
+    match attr {
+        Attribute::Native(native) => native.name.eq_ignore_ascii_case("lang"),
+        Attribute::JinjaBlock(block) => jinja_block_declares_lang(block),
+        _ => false,
+    }
+}
+
+fn jinja_block_declares_lang(block: &JinjaBlock<'_, Attribute<'_>>) -> bool {
+    block.body.iter().any(|item| match item {
+        JinjaTagOrChildren::Children(children) => children.iter().any(attr_declares_lang),
+        JinjaTagOrChildren::Tag(_) => false,
+    })
+}

--- a/crates/djangofmt_lint/src/rules/accessibility/mod.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/mod.rs
@@ -1,0 +1,1 @@
+pub mod missing_html_lang;

--- a/crates/djangofmt_lint/src/rules/mod.rs
+++ b/crates/djangofmt_lint/src/rules/mod.rs
@@ -1,3 +1,4 @@
+pub mod accessibility;
 pub mod correctness;
 pub mod helpers;
 pub mod style;

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.html
@@ -1,0 +1,27 @@
+<!-- No attributes at all -->
+<html>
+</html>
+
+<!-- Has other attributes but no lang -->
+<html class="no-js" dir="ltr">
+</html>
+
+<!-- Case-insensitive tag name -->
+<HTML>
+</HTML>
+
+<!-- Nested in a Jinja block -->
+{% if base_template %}
+    <html>
+    </html>
+{% endif %}
+
+<!-- Multi-line opening tag with no lang -->
+<html
+    xmlns="http://www.w3.org/1999/xhtml"
+    class="no-js">
+</html>
+
+<!-- XHTML `xml:lang` alone: HTML5 ignores it; screen readers need `lang` -->
+<html xml:lang="en">
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.snap
@@ -1,0 +1,70 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 6 lint error(s)
+
+Error: 
+  × `<html>` tag should declare a `lang` attribute.
+   ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:2:2]
+ 1 │ <!-- No attributes at all -->
+ 2 │ <html>
+   ·  ──┬─
+   ·    ╰── here
+ 3 │ </html>
+   ╰────
+  help: Add `lang="en"` (or the appropriate language code).
+
+Error: 
+  × `<html>` tag should declare a `lang` attribute.
+   ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:6:2]
+ 5 │ <!-- Has other attributes but no lang -->
+ 6 │ <html class="no-js" dir="ltr">
+   ·  ──┬─
+   ·    ╰── here
+ 7 │ </html>
+   ╰────
+  help: Add `lang="en"` (or the appropriate language code).
+
+Error: 
+  × `<html>` tag should declare a `lang` attribute.
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:10:2]
+  9 │ <!-- Case-insensitive tag name -->
+ 10 │ <HTML>
+    ·  ──┬─
+    ·    ╰── here
+ 11 │ </HTML>
+    ╰────
+  help: Add `lang="en"` (or the appropriate language code).
+
+Error: 
+  × `<html>` tag should declare a `lang` attribute.
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:15:6]
+ 14 │ {% if base_template %}
+ 15 │     <html>
+    ·      ──┬─
+    ·        ╰── here
+ 16 │     </html>
+    ╰────
+  help: Add `lang="en"` (or the appropriate language code).
+
+Error: 
+  × `<html>` tag should declare a `lang` attribute.
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:20:2]
+ 19 │ <!-- Multi-line opening tag with no lang -->
+ 20 │ <html
+    ·  ──┬─
+    ·    ╰── here
+ 21 │     xmlns="http://www.w3.org/1999/xhtml"
+    ╰────
+  help: Add `lang="en"` (or the appropriate language code).
+
+Error: 
+  × `<html>` tag should declare a `lang` attribute.
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:26:2]
+ 25 │ <!-- XHTML `xml:lang` alone: HTML5 ignores it; screen readers need `lang` -->
+ 26 │ <html xml:lang="en">
+    ·  ──┬─
+    ·    ╰── here
+ 27 │ </html>
+    ╰────
+  help: Add `lang="en"` (or the appropriate language code).

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.valid.html
@@ -1,0 +1,37 @@
+<!-- Plain `lang` attribute -->
+<html lang="en">
+</html>
+
+<!-- Case-insensitive attribute name -->
+<html LANG="en">
+</html>
+
+<!-- `lang` alongside other attributes -->
+<html lang="fr" class="no-js">
+</html>
+
+<!-- Interpolated `lang` value -->
+<html lang="{{ language }}">
+</html>
+
+<!-- Non-html tags are not checked -->
+<div></div>
+<body></body>
+
+<!-- `lang` declared inside a Jinja conditional -->
+<html {% if rtl %}lang="ar"{% else %}lang="en"{% endif %}>
+</html>
+
+<!-- XHTML dual-attribute form: `lang` is what matters -->
+<html lang="en" xml:lang="en">
+</html>
+
+<!-- Multi-line opening tag -->
+<html
+    lang="en"
+    class="no-js">
+</html>
+
+<!-- Boolean `lang` (no value) -->
+<html lang>
+</html>


### PR DESCRIPTION
## What it does
Checks for `<html>` tags that do not declare a `lang` attribute.

## Why is this bad?
The `lang` attribute on `<html>` declares the primary language of the document. Screen readers use it to select the correct pronunciation rules, and search engines use it to index the page for the right audience.

A `lang` attribute wrapped in a Jinja conditional (e.g. `{% if %}lang="en"{% endif %}`) is treated as present, to avoid false positives on dynamic templates.

## Example
```html
<html>
</html>
```

Use instead:
```html
<html lang="en">
</html>
```

## References
- [MDN: HTML `lang` global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
- [WCAG 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html)

Part of #231 