### PR TITLE
Align violation structs with owned-data convention

### DIFF
--- a/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
@@ -39,8 +39,8 @@ use crate::violation::Violation;
 #[derive(Debug, PartialEq, Eq)]
 pub struct InvalidAttrValue {
     pub value: String,
-    pub attribute: String,
-    pub allowed: Vec<String>,
+    pub attribute: &'static str,
+    pub allowed: &'static [&'static str],
 }
 
 impl Violation for InvalidAttrValue {
@@ -87,13 +87,13 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
                 continue;
             }
 
-            let allowed = ["get", "post", "dialog"];
+            let allowed: &[&str] = &["get", "post", "dialog"];
             if !allowed.iter().any(|v| v.eq_ignore_ascii_case(value_str)) {
                 checker.report_diagnostic(
                     &InvalidAttrValue {
                         value: (*value_str).to_string(),
-                        attribute: "method".to_string(),
-                        allowed: allowed.iter().map(|s| (*s).to_string()).collect(),
+                        attribute: "method",
+                        allowed,
                     },
                     (*offset, value_str.len()).into(),
                 );

--- a/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
+++ b/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
@@ -36,12 +36,12 @@ use crate::violation::Violation;
 /// - [Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html#type_Attributes)
 /// - [HTML spec: the script element](https://html.spec.whatwg.org/multipage/scripting.html#the-script-element)
 #[derive(Debug, PartialEq, Eq)]
-pub struct RedundantTypeAttr<'a> {
-    pub tag: &'a str,
-    pub type_value: &'a str,
+pub struct RedundantTypeAttr {
+    pub tag: String,
+    pub type_value: String,
 }
 
-impl Violation for RedundantTypeAttr<'_> {
+impl Violation for RedundantTypeAttr {
     const RULE: Rule = Rule::RedundantTypeAttr;
     const CATEGORY: RuleCategory = RuleCategory::Style;
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
@@ -100,8 +100,8 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
 
         let mut guard = checker.report_diagnostic(
             &RedundantTypeAttr {
-                tag,
-                type_value: value_str,
+                tag: tag.to_string(),
+                type_value: (*value_str).to_string(),
             },
             (*offset, value_str.len()).into(),
         );


### PR DESCRIPTION
Don't use lifetime for lint rule structs.
I'm not sure it's really usefull and I would life to keep thing simple and consistant