### PR TITLE
feat(lint): Add `form-action-whitespace` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -109,6 +109,10 @@ impl<'a> Checker<'a> {
             rules::style::uppercase_form_method::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::FormActionWhitespace) {
+            rules::style::form_action_whitespace::check(element, self);
+        }
+
         if self.is_rule_enabled(Rule::MissingHtmlLang) {
             rules::accessibility::missing_html_lang::check(element, self);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -246,5 +246,6 @@ define_rules! {
     (RedundantTypeAttr, rules::style::redundant_type_attr::RedundantTypeAttr),
     (JavascriptUrl, rules::suspicious::javascript_url::JavascriptUrl),
     (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
+    (FormActionWhitespace, rules::style::form_action_whitespace::FormActionWhitespace),
     (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),
 }

--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -82,15 +82,14 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
             continue;
         }
 
-        let trimmed = value_str.trim();
+        let trimmed = value_str.trim_ascii();
         if trimmed.len() == value_str.len() {
             continue;
         }
 
-        let mut guard =
-            checker.report_diagnostic(&FormActionWhitespace, (*offset, value_str.len()).into());
-
         let span = (*offset, value_str.len()).into();
+        let mut guard = checker.report_diagnostic(&FormActionWhitespace, span);
+
         let edit = if trimmed.is_empty() {
             Edit::deletion(span)
         } else {

--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -1,0 +1,101 @@
+use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+
+use crate::Checker;
+use crate::fix::{Edit, Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::contains_interpolation;
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for leading or trailing whitespace in the `action` attribute of `<form>` elements.
+///
+/// ## Why is this bad?
+/// The URL parser strips leading and trailing ASCII whitespace when resolving an HTML URL
+/// attribute, so the spaces are inert at runtime and only add noise to the source. They are
+/// commonly an accidental artefact of inserting a template tag inside the quotes.
+///
+/// Values containing template interpolation are skipped: the surrounding whitespace is usually
+/// intentional padding around a `{% url %}` tag and cannot be safely trimmed without knowing the
+/// rendered output. Only the `action` attribute is checked; sibling attributes such as
+/// `data-action` may legitimately span multiple lines.
+///
+/// ## Example
+/// ```html
+/// <form action=" /submit/ "></form>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <form action="/submit/"></form>
+/// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as safe: the URL parser strips leading and trailing ASCII
+/// whitespace from URL attribute values, so trimming the literal source preserves runtime
+/// semantics.
+///
+/// ## References
+/// - [URL Standard: basic URL parser](https://url.spec.whatwg.org/#concept-basic-url-parser)
+/// - [HTML spec: the form element](https://html.spec.whatwg.org/multipage/forms.html#the-form-element)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct FormActionWhitespace;
+
+impl Violation for FormActionWhitespace {
+    const RULE: Rule = Rule::FormActionWhitespace;
+    const CATEGORY: RuleCategory = RuleCategory::Style;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Extra whitespace found in form `action`.".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Remove leading and trailing whitespace from the `action` value.".to_string())
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Trim whitespace from `action` value".to_string())
+    }
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if !element.tag_name.eq_ignore_ascii_case("form") {
+        return;
+    }
+
+    for attr in &element.attrs {
+        let Attribute::Native(NativeAttribute { name, value, .. }) = attr else {
+            continue;
+        };
+
+        if !name.eq_ignore_ascii_case("action") {
+            continue;
+        }
+
+        let Some((value_str, offset)) = value else {
+            continue;
+        };
+
+        if contains_interpolation(value_str) {
+            continue;
+        }
+
+        let trimmed = value_str.trim();
+        if trimmed.len() == value_str.len() {
+            continue;
+        }
+
+        let mut guard =
+            checker.report_diagnostic(&FormActionWhitespace, (*offset, value_str.len()).into());
+
+        let span = (*offset, value_str.len()).into();
+        let edit = if trimmed.is_empty() {
+            Edit::deletion(span)
+        } else {
+            Edit::replacement(trimmed.to_string(), span)
+        };
+        guard.set_fix(Fix::safe_edit(edit));
+    }
+}

--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -32,7 +32,10 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// ## Fix safety
 /// This rule's fix is marked as safe: the URL parser strips leading and trailing ASCII
 /// whitespace from URL attribute values, so trimming the literal source preserves runtime
-/// semantics.
+/// semantics. Author code reading the raw attribute (e.g. `form.getAttribute("action")`,
+/// strict-equality dispatch, HTMX or web-component integrations that observe the literal
+/// string) would see the trimmed value, but relying on the surrounding whitespace is
+/// vanishingly rare.
 ///
 /// ## References
 /// - [URL Standard: basic URL parser](https://url.spec.whatwg.org/#concept-basic-url-parser)

--- a/crates/djangofmt_lint/src/rules/style/mod.rs
+++ b/crates/djangofmt_lint/src/rules/style/mod.rs
@@ -1,3 +1,4 @@
 pub mod empty_attr_value;
+pub mod form_action_whitespace;
 pub mod redundant_type_attr;
 pub mod uppercase_form_method;

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.fixed.snap
@@ -20,6 +20,9 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <FORM action="/submit/"></FORM>
 <forM action="/submit/"></forM>
 
+<!-- Case-insensitive attribute name -->
+<form Action="/submit/"></form>
+
 <!-- Single-quoted -->
 <form action='/submit/'></form>
 

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.fixed.snap
@@ -1,0 +1,35 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+<!-- Leading whitespace -->
+<form action="/submit/"></form>
+
+<!-- Trailing whitespace -->
+<form action="/submit/"></form>
+
+<!-- Both -->
+<form action="/submit/"></form>
+
+<!-- Whitespace-only value -->
+<form action=""></form>
+
+<!-- Tab and newline characters -->
+<form action="/submit/"></form>
+
+<!-- Case-insensitive tag name -->
+<FORM action="/submit/"></FORM>
+<forM action="/submit/"></forM>
+
+<!-- Single-quoted -->
+<form action='/submit/'></form>
+
+<!-- Multiline form -->
+<form
+    method="post"
+    action="/submit/"
+></form>
+
+<!-- Nested in Jinja block -->
+{% if show_form %}
+    <form action="/submit/"></form>
+{% endif %}

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.html
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.html
@@ -1,0 +1,33 @@
+<!-- Leading whitespace -->
+<form action=" /submit/"></form>
+
+<!-- Trailing whitespace -->
+<form action="/submit/ "></form>
+
+<!-- Both -->
+<form action=" /submit/ "></form>
+
+<!-- Whitespace-only value -->
+<form action="   "></form>
+
+<!-- Tab and newline characters -->
+<form action="	/submit/
+"></form>
+
+<!-- Case-insensitive tag name -->
+<FORM action=" /submit/ "></FORM>
+<forM action="/submit/ "></forM>
+
+<!-- Single-quoted -->
+<form action=' /submit/ '></form>
+
+<!-- Multiline form -->
+<form
+    method="post"
+    action=" /submit/ "
+></form>
+
+<!-- Nested in Jinja block -->
+{% if show_form %}
+    <form action=" /submit/ "></form>
+{% endif %}

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.html
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.html
@@ -18,6 +18,9 @@
 <FORM action=" /submit/ "></FORM>
 <forM action="/submit/ "></forM>
 
+<!-- Case-insensitive attribute name -->
+<form Action=" /submit/ "></form>
+
 <!-- Single-quoted -->
 <form action=' /submit/ '></form>
 

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 10 lint error(s)
+  × Found 11 lint error(s)
 
 Error: 
   × Extra whitespace found in form `action`.
@@ -84,8 +84,8 @@ Error:
 Error: 
   × Extra whitespace found in form `action`.
     ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:22:15]
- 21 │ <!-- Single-quoted -->
- 22 │ <form action=' /submit/ '></form>
+ 21 │ <!-- Case-insensitive attribute name -->
+ 22 │ <form Action=" /submit/ "></form>
     ·               ─────┬────
     ·                    ╰── here
  23 │ 
@@ -94,22 +94,33 @@ Error:
 
 Error: 
   × Extra whitespace found in form `action`.
-    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:27:13]
- 26 │     method="post"
- 27 │     action=" /submit/ "
-    ·             ─────┬────
-    ·                  ╰── here
- 28 │ ></form>
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:25:15]
+ 24 │ <!-- Single-quoted -->
+ 25 │ <form action=' /submit/ '></form>
+    ·               ─────┬────
+    ·                    ╰── here
+ 26 │ 
     ╰────
   help: Remove leading and trailing whitespace from the `action` value.
 
 Error: 
   × Extra whitespace found in form `action`.
-    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:32:19]
- 31 │ {% if show_form %}
- 32 │     <form action=" /submit/ "></form>
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:30:13]
+ 29 │     method="post"
+ 30 │     action=" /submit/ "
+    ·             ─────┬────
+    ·                  ╰── here
+ 31 │ ></form>
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:35:19]
+ 34 │ {% if show_form %}
+ 35 │     <form action=" /submit/ "></form>
     ·                   ─────┬────
     ·                        ╰── here
- 33 │ {% endif %}
+ 36 │ {% endif %}
     ╰────
   help: Remove leading and trailing whitespace from the `action` value.

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.snap
@@ -1,0 +1,115 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 10 lint error(s)
+
+Error: 
+  × Extra whitespace found in form `action`.
+   ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:2:15]
+ 1 │ <!-- Leading whitespace -->
+ 2 │ <form action=" /submit/"></form>
+   ·               ────┬────
+   ·                   ╰── here
+ 3 │ 
+   ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+   ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:5:15]
+ 4 │ <!-- Trailing whitespace -->
+ 5 │ <form action="/submit/ "></form>
+   ·               ────┬────
+   ·                   ╰── here
+ 6 │ 
+   ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+   ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:8:15]
+ 7 │ <!-- Both -->
+ 8 │ <form action=" /submit/ "></form>
+   ·               ─────┬────
+   ·                    ╰── here
+ 9 │ 
+   ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:11:15]
+ 10 │ <!-- Whitespace-only value -->
+ 11 │ <form action="   "></form>
+    ·               ─┬─
+    ·                ╰── here
+ 12 │ 
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:14:15]
+ 13 │ <!-- Tab and newline characters -->
+ 14 │ <form action="  /submit/
+    ·               ─────┬─────
+    ·                    ╰── here
+ 15 │ "></form>
+ 16 │ 
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:18:15]
+ 17 │ <!-- Case-insensitive tag name -->
+ 18 │ <FORM action=" /submit/ "></FORM>
+    ·               ─────┬────
+    ·                    ╰── here
+ 19 │ <forM action="/submit/ "></forM>
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:19:15]
+ 18 │ <FORM action=" /submit/ "></FORM>
+ 19 │ <forM action="/submit/ "></forM>
+    ·               ────┬────
+    ·                   ╰── here
+ 20 │ 
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:22:15]
+ 21 │ <!-- Single-quoted -->
+ 22 │ <form action=' /submit/ '></form>
+    ·               ─────┬────
+    ·                    ╰── here
+ 23 │ 
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:27:13]
+ 26 │     method="post"
+ 27 │     action=" /submit/ "
+    ·             ─────┬────
+    ·                  ╰── here
+ 28 │ ></form>
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Extra whitespace found in form `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:32:19]
+ 31 │ {% if show_form %}
+ 32 │     <form action=" /submit/ "></form>
+    ·                   ─────┬────
+    ·                        ╰── here
+ 33 │ {% endif %}
+    ╰────
+  help: Remove leading and trailing whitespace from the `action` value.

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.valid.html
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.valid.html
@@ -26,6 +26,9 @@
 <form action="{{ submit_url }}"></form>
 <form action=" {{ url }} "></form>
 
+<!-- Non-ASCII whitespace (NBSP) is preserved: URL parser doesn't strip it either -->
+<form action=" /submit/ "></form>
+
 <!-- No value -->
 <form action></form>
 

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.valid.html
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.valid.html
@@ -1,0 +1,39 @@
+<!-- No surrounding whitespace -->
+<form action="/submit/"></form>
+<form action=""></form>
+<form action="https://example.com/submit/"></form>
+
+<!-- Non-form tags are not checked -->
+<a action=" /foo/ ">Link</a>
+<div action=" bar ">div</div>
+
+<!-- Only the `action` attribute is checked -->
+<!-- Regression: djLint #743 — data-action with multiline value must not flag -->
+<form action="#"
+    method="get"
+    data-action="
+        submit:my-custom-element#handleFormSubmit
+        click:my-custom-element#handleClick
+        some-event:my-custom-element#handleSomething" >
+</form>
+
+<!-- Interpolated values are skipped (template tags may legitimately have surrounding padding) -->
+<!-- Regression: djLint #216 — multiline jinja interpolation in action must not flag -->
+<form method="post"
+      action="{%- if connection -%} {{ url_for('connection_bp.edit_connection', connection_id=connection.id) }} {%- else -%} {{ url_for('connection_bp.new_connection') }} {%- endif -%} ">
+</form>
+<form action=" {% url 'foo:bar' %} "></form>
+<form action="{{ submit_url }}"></form>
+<form action=" {{ url }} "></form>
+
+<!-- No value -->
+<form action></form>
+
+<!-- No action attribute -->
+<form method="post"></form>
+
+<!-- Multiline form, trimmed value -->
+<form
+    method="post"
+    action="/submit/"
+></form>


### PR DESCRIPTION
Checks for leading or trailing whitespace in the `action` attribute of `<form>` elements.

The URL parser strips leading and trailing ASCII whitespace when resolving an HTML URL attribute, so the spaces are inert at runtime and only add noise to the source. They are commonly an accidental artefact of inserting a template tag inside the quotes.

Values containing template interpolation are skipped: the surrounding whitespace is usually intentional padding around a `{% url %}` tag and cannot be safely trimmed without knowing the rendered output. Only the `action` attribute is checked; sibling attributes such as `data-action` may legitimately span multiple lines.

```html
<form action=" /submit/ "></form>
```

Use instead:
```html
<form action="/submit/"></form>
```

This rule's fix is marked as safe: the URL parser strips leading and trailing ASCII whitespace from URL attribute values, so trimming the literal source preserves runtime semantics.

- [URL Standard: basic URL parser](https://url.spec.whatwg.org/#concept-basic-url-parser)
- [HTML spec: the form element](https://html.spec.whatwg.org/multipage/forms.html#the-form-element)

Part of #231 