### PR TITLE
feat(lint): Add `missing-img-dimensions` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -121,6 +121,10 @@ impl<'a> Checker<'a> {
             rules::accessibility::missing_html_lang::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::MissingImgDimensions) {
+            rules::accessibility::missing_img_dimensions::check(element, self);
+        }
+
         for attr in &element.attrs {
             self.visit_attribute(attr);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -249,4 +249,5 @@ define_rules! {
     (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
     (FormActionWhitespace, rules::style::form_action_whitespace::FormActionWhitespace),
     (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),
+    (MissingImgDimensions, rules::accessibility::missing_img_dimensions::MissingImgDimensions),
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
@@ -1,0 +1,90 @@
+use markup_fmt::ast::{Attribute, Element, JinjaBlock, JinjaTagOrChildren};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for `<img>` tags that omit the `height` or `width` attribute.
+///
+/// ## Why is this bad?
+/// Explicit `height` and `width` on `<img>` let the browser reserve space for the image before it
+/// loads, preventing cumulative layout shift (CLS) as surrounding content jumps when the image
+/// arrives. Both attributes are required, since the browser uses them together to derive the
+/// intrinsic aspect ratio.
+///
+/// ## Example
+/// ```html
+/// <img src="photo.jpg" alt="photo">
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <img src="photo.jpg" alt="photo" height="100" width="200">
+/// ```
+///
+/// ## References
+/// - [MDN: `<img>` — Setting `width` and `height`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#setting_width_and_height)
+/// - [web.dev: Optimize Cumulative Layout Shift](https://web.dev/articles/optimize-cls#images-without-dimensions)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct MissingImgDimensions;
+
+impl Violation for MissingImgDimensions {
+    const RULE: Rule = Rule::MissingImgDimensions;
+    const CATEGORY: RuleCategory = RuleCategory::Accessibility;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "`<img>` tag should declare both `height` and `width` attributes.".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(
+            "Add explicit `height` and `width` to avoid layout shifts as the image loads."
+                .to_string(),
+        )
+    }
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if !element.tag_name.eq_ignore_ascii_case("img") {
+        return;
+    }
+
+    let has_height = element
+        .attrs
+        .iter()
+        .any(|attr| attr_declares(attr, "height"));
+    let has_width = element
+        .attrs
+        .iter()
+        .any(|attr| attr_declares(attr, "width"));
+
+    if has_height && has_width {
+        return;
+    }
+
+    let offset = checker.source_offset(element.tag_name);
+    checker.report_diagnostic(
+        &MissingImgDimensions,
+        (offset, element.tag_name.len()).into(),
+    );
+}
+
+fn attr_declares(attr: &Attribute<'_>, name: &str) -> bool {
+    match attr {
+        Attribute::Native(native) => native.name.eq_ignore_ascii_case(name),
+        Attribute::JinjaBlock(block) => jinja_block_declares(block, name),
+        _ => false,
+    }
+}
+
+fn jinja_block_declares(block: &JinjaBlock<'_, Attribute<'_>>, name: &str) -> bool {
+    block.body.iter().any(|item| match item {
+        JinjaTagOrChildren::Children(children) => {
+            children.iter().any(|attr| attr_declares(attr, name))
+        }
+        JinjaTagOrChildren::Tag(_) => false,
+    })
+}

--- a/crates/djangofmt_lint/src/rules/accessibility/mod.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/mod.rs
@@ -1,1 +1,2 @@
 pub mod missing_html_lang;
+pub mod missing_img_dimensions;

--- a/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.html
+++ b/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.html
@@ -14,7 +14,7 @@
 <input type="text" type="email" type="search">
 
 <!-- Alpine-style duplicate (same prefix on both, real duplicate) -->
-<img :src="img.jpg" :src="isLoaded ? url : defaultValue" />
+<img :src="img.jpg" :src="isLoaded ? url : defaultValue" height="100" width="100" />
 
 <!-- Boolean attributes still count -->
 <input disabled disabled>

--- a/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.snap
@@ -73,7 +73,7 @@ Error:
   × Duplicate attribute `:src`.
     ╭─[tests/check/duplicate_attr/duplicate_attr.invalid.html:17:21]
  16 │ <!-- Alpine-style duplicate (same prefix on both, real duplicate) -->
- 17 │ <img :src="img.jpg" :src="isLoaded ? url : defaultValue" />
+ 17 │ <img :src="img.jpg" :src="isLoaded ? url : defaultValue" height="100" width="100" />
     ·                     ──┬─
     ·                       ╰── here
  18 │ 

--- a/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.valid.html
+++ b/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.valid.html
@@ -15,7 +15,7 @@
 
 <!-- AlpineJS attributes with `:`/`x-bind:` prefix are distinct names from the
      underlying HTML attribute. -->
-<img src="img.jpg" :src="isLoaded ? url : defaultValue" />
+<img src="img.jpg" :src="isLoaded ? url : defaultValue" height="100" width="100" />
 <tbody class="bg-white" x-bind:class="open ? 'bg-gray-50' : ''"></tbody>
 
 <!-- `key=value` text inside an attribute value is not a separate attribute

--- a/crates/djangofmt_lint/tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html
@@ -1,0 +1,37 @@
+<!-- Missing both `height` and `width` -->
+<img src="photo.jpg" alt="photo">
+
+<!-- Missing `width` only -->
+<img src="photo.jpg" alt="photo" height="100">
+
+<!-- Missing `height` only -->
+<img src="photo.jpg" alt="photo" width="200">
+
+<!-- Completely empty `<img>` -->
+<img>
+
+<!-- Case-insensitive tag name -->
+<IMG src="photo.jpg" alt="photo">
+
+<!-- Multi-line opening tag with no dimensions -->
+<img
+    src="photo.jpg"
+    alt="photo"
+>
+
+<!-- Nested in a Jinja block -->
+{% if show_image %}
+    <img src="photo.jpg" alt="photo">
+{% endif %}
+
+<!-- Inline `style` is not a substitute: browsers don't reserve space until the stylesheet loads -->
+<img src="photo.jpg" alt="photo" style="width: 100px; height: 100px">
+
+<!-- SVG referenced via `<img>` — same dimensions are required -->
+<img src="logo.svg" alt="logo">
+
+<!-- `<img>` inside `<picture>`: the dimensions belong on the `<img>` fallback -->
+<picture>
+    <source srcset="photo.avif" type="image/avif">
+    <img src="photo.jpg" alt="photo">
+</picture>

--- a/crates/djangofmt_lint/tests/check/missing_img_dimensions/missing_img_dimensions.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_img_dimensions/missing_img_dimensions.invalid.snap
@@ -1,0 +1,114 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 10 lint error(s)
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+   ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:2:2]
+ 1 │ <!-- Missing both `height` and `width` -->
+ 2 │ <img src="photo.jpg" alt="photo">
+   ·  ─┬─
+   ·   ╰── here
+ 3 │ 
+   ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+   ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:5:2]
+ 4 │ <!-- Missing `width` only -->
+ 5 │ <img src="photo.jpg" alt="photo" height="100">
+   ·  ─┬─
+   ·   ╰── here
+ 6 │ 
+   ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+   ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:8:2]
+ 7 │ <!-- Missing `height` only -->
+ 8 │ <img src="photo.jpg" alt="photo" width="200">
+   ·  ─┬─
+   ·   ╰── here
+ 9 │ 
+   ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+    ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:11:2]
+ 10 │ <!-- Completely empty `<img>` -->
+ 11 │ <img>
+    ·  ─┬─
+    ·   ╰── here
+ 12 │ 
+    ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+    ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:14:2]
+ 13 │ <!-- Case-insensitive tag name -->
+ 14 │ <IMG src="photo.jpg" alt="photo">
+    ·  ─┬─
+    ·   ╰── here
+ 15 │ 
+    ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+    ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:17:2]
+ 16 │ <!-- Multi-line opening tag with no dimensions -->
+ 17 │ <img
+    ·  ─┬─
+    ·   ╰── here
+ 18 │     src="photo.jpg"
+    ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+    ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:24:6]
+ 23 │ {% if show_image %}
+ 24 │     <img src="photo.jpg" alt="photo">
+    ·      ─┬─
+    ·       ╰── here
+ 25 │ {% endif %}
+    ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+    ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:28:2]
+ 27 │ <!-- Inline `style` is not a substitute: browsers don't reserve space until the stylesheet loads -->
+ 28 │ <img src="photo.jpg" alt="photo" style="width: 100px; height: 100px">
+    ·  ─┬─
+    ·   ╰── here
+ 29 │ 
+    ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+    ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:31:2]
+ 30 │ <!-- SVG referenced via `<img>` — same dimensions are required -->
+ 31 │ <img src="logo.svg" alt="logo">
+    ·  ─┬─
+    ·   ╰── here
+ 32 │ 
+    ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.
+
+Error: 
+  × `<img>` tag should declare both `height` and `width` attributes.
+    ╭─[tests/check/missing_img_dimensions/missing_img_dimensions.invalid.html:36:6]
+ 35 │     <source srcset="photo.avif" type="image/avif">
+ 36 │     <img src="photo.jpg" alt="photo">
+    ·      ─┬─
+    ·       ╰── here
+ 37 │ </picture>
+    ╰────
+  help: Add explicit `height` and `width` to avoid layout shifts as the image loads.

--- a/crates/djangofmt_lint/tests/check/missing_img_dimensions/missing_img_dimensions.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_img_dimensions/missing_img_dimensions.valid.html
@@ -1,0 +1,39 @@
+<!-- Both `height` and `width` present -->
+<img src="photo.jpg" alt="photo" height="100" width="200">
+
+<!-- Case-insensitive attribute names -->
+<img src="photo.jpg" alt="photo" HEIGHT="100" WIDTH="200">
+
+<!-- Alongside other attributes -->
+<img src="photo.jpg" alt="photo" height="100" width="200" loading="lazy">
+
+<!-- Interpolated dimension values -->
+<img src="photo.jpg" alt="photo" height="{{ h }}" width="{{ w }}">
+
+<!-- Boolean attributes (no value) -->
+<img src="photo.jpg" alt="photo" height width>
+
+<!-- Empty values: the rule only checks for presence; other rules cover empty values -->
+<img src="photo.jpg" alt="photo" height="" width="">
+
+<!-- Multi-line opening tag -->
+<img
+    src="photo.jpg"
+    alt="photo"
+    height="100"
+    width="200"
+>
+
+<!-- Non-`<img>` tags are not checked -->
+<div height="100"></div>
+<canvas></canvas>
+
+<!-- `<source>` inside `<picture>` is not an `<img>` -->
+<picture>
+    <source srcset="photo.avif" type="image/avif">
+    <img src="photo.jpg" alt="photo" height="100" width="200">
+</picture>
+
+<!-- `height` and `width` declared inside a Jinja conditional -->
+<img src="photo.jpg" alt="photo"
+    {% if portrait %}height="200" width="100"{% else %}height="100" width="200"{% endif %}>


### PR DESCRIPTION
## What it does
Checks for `<img>` tags that omit the `height` or `width` attribute.

## Why is this bad?
Explicit `height` and `width` on `<img>` let the browser reserve space for the image before it loads, preventing cumulative layout shift (CLS) as surrounding content jumps when the image arrives. Both attributes are required, since the browser uses them together to derive the intrinsic aspect ratio.

## Example
```html
<img src="photo.jpg" alt="photo">
```

Use instead:
```html
<img src="photo.jpg" alt="photo" height="100" width="200">
```

## References
- [MDN: `<img>` — Setting `width` and `height`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#setting_width_and_height)
- [web.dev: Optimize Cumulative Layout Shift](https://web.dev/articles/optimize-cls#images-without-dimensions)

Part of #231 