### PR TITLE
feat(lint): Add `use-https` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -113,6 +113,10 @@ impl<'a> Checker<'a> {
             rules::suspicious::duplicate_attr::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::UseHttps) {
+            rules::suspicious::use_https::check(element, self);
+        }
+
         if self.is_rule_enabled(Rule::UppercaseFormMethod) {
             rules::style::uppercase_form_method::check(element, self);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -246,6 +246,7 @@ define_rules! {
     (RedundantTypeAttr, rules::style::redundant_type_attr::RedundantTypeAttr),
     (JavascriptUrl, rules::suspicious::javascript_url::JavascriptUrl),
     (DuplicateAttr, rules::suspicious::duplicate_attr::DuplicateAttr),
+    (UseHttps, rules::suspicious::use_https::UseHttps),
     (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
     (FormActionWhitespace, rules::style::form_action_whitespace::FormActionWhitespace),
     (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),

--- a/crates/djangofmt_lint/src/rules/suspicious/mod.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/mod.rs
@@ -1,2 +1,3 @@
 pub mod duplicate_attr;
 pub mod javascript_url;
+pub mod use_https;

--- a/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
@@ -1,0 +1,140 @@
+use std::net::IpAddr;
+
+use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+
+use crate::Checker;
+use crate::fix::{Edit, Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for `http://` URLs in HTML attributes that load or link external resources.
+///
+/// ## Why is this bad?
+/// `http://` traffic is unencrypted and can be intercepted or modified in transit.
+/// Modern browsers also block mixed content (HTTP subresources on an HTTPS page),
+/// so a single `http://` URL can silently break the page.
+///
+/// Prefer `https://` for all external links and subresources.
+///
+/// ## Example
+/// ```html
+/// <a href="http://example.com">Link</a>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <a href="https://example.com">Link</a>
+/// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe: rewriting the scheme changes which endpoint the browser use.
+/// The host may not serve HTTPS at all, so the fix can break a link or subresource that
+/// previously worked over HTTP, and even when HTTPS is available it may serve different content .
+///
+/// ## References
+/// - [MDN: Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
+/// - [WHATWG Fetch: HTTPS state](https://fetch.spec.whatwg.org/#concept-request-https-state)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct UseHttps {
+    pub attribute: &'static str,
+}
+
+impl Violation for UseHttps {
+    const RULE: Rule = Rule::UseHttps;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Avoid `http://` URLs in `{}`.", self.attribute)
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Use `https://` instead.".to_string())
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Replace `http://` with `https://`".to_string())
+    }
+}
+
+const HTTP_SCHEME: &str = "http://";
+const HTTPS_SCHEME: &str = "https://";
+
+/// Attributes whose value is a URL subject to the HTTPS check.
+const URL_ATTRIBUTES: &[&str] = &["href", "data-url", "action", "src", "url", "srcset"];
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    for attr in &element.attrs {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            ..
+        }) = attr
+        else {
+            continue;
+        };
+
+        let Some(canonical) = URL_ATTRIBUTES
+            .iter()
+            .find(|candidate| candidate.eq_ignore_ascii_case(name))
+        else {
+            continue;
+        };
+
+        let trimmed = value_str.trim_start_matches(|c: char| c.is_ascii_whitespace());
+        if trimmed
+            .get(..HTTP_SCHEME.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(HTTP_SCHEME))
+        {
+            if is_local_host(&trimmed[HTTP_SCHEME.len()..]) {
+                continue;
+            }
+            let leading_ws = value_str.len() - trimmed.len();
+            let scheme_span = (*offset + leading_ws, HTTP_SCHEME.len());
+            let mut guard = checker.report_diagnostic(
+                &UseHttps {
+                    attribute: canonical,
+                },
+                scheme_span.into(),
+            );
+            guard.set_fix(Fix::unsafe_edit(Edit::replacement(
+                HTTPS_SCHEME,
+                scheme_span.into(),
+            )));
+        }
+    }
+}
+
+/// Whether the authority of a URL (the part after `http://`) refers to the local machine.
+///
+/// [spec]: https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
+fn is_local_host(after_scheme: &str) -> bool {
+    // Authority is everything up to the path, query, or fragment.
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_scheme);
+    // Drop any `user:pass@` userinfo prefix.
+    let host_port = authority.rsplit('@').next().unwrap_or(authority);
+    // Strip the port. A bracketed IPv6 literal (`[::1]:8080`) keeps everything
+    // between the brackets; otherwise the host is everything before the colon.
+    let host = host_port.strip_prefix('[').map_or_else(
+        || host_port.split(':').next().unwrap_or(host_port),
+        |rest| rest.split(']').next().unwrap_or(rest),
+    );
+
+    // `IpAddr::is_loopback` covers `127.0.0.0/8` and `::1` in every valid
+    // spelling; fall back to the `localhost` name for non-IP hosts.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return ip.is_loopback();
+    }
+    host.eq_ignore_ascii_case("localhost") || ends_with_ignore_ascii_case(host, ".localhost")
+}
+
+fn ends_with_ignore_ascii_case(haystack: &str, suffix: &str) -> bool {
+    haystack.len() >= suffix.len()
+        && haystack[haystack.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
@@ -63,9 +63,6 @@ impl Violation for UseHttps {
 const HTTP_SCHEME: &str = "http://";
 const HTTPS_SCHEME: &str = "https://";
 
-/// Attributes whose value is a URL subject to the HTTPS check.
-const URL_ATTRIBUTES: &[&str] = &["href", "data-url", "action", "src", "url", "srcset"];
-
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     for attr in &element.attrs {
         let Attribute::Native(NativeAttribute {
@@ -77,35 +74,67 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
             continue;
         };
 
-        let Some(canonical) = URL_ATTRIBUTES
-            .iter()
-            .find(|candidate| candidate.eq_ignore_ascii_case(name))
-        else {
+        let Some(canonical) = canonical_url_attr(name) else {
             continue;
         };
 
-        let trimmed = value_str.trim_start_matches(|c: char| c.is_ascii_whitespace());
-        if trimmed
-            .get(..HTTP_SCHEME.len())
-            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(HTTP_SCHEME))
-        {
-            if is_local_host(&trimmed[HTTP_SCHEME.len()..]) {
-                continue;
+        // `srcset` is a comma-separated candidate list; every other attribute
+        // holds a single URL.
+        if canonical == "srcset" {
+            for (url, at) in srcset_candidates(value_str, *offset) {
+                report_http_scheme(url, at, canonical, checker);
             }
-            let leading_ws = value_str.len() - trimmed.len();
-            let scheme_span = (*offset + leading_ws, HTTP_SCHEME.len());
-            let mut guard = checker.report_diagnostic(
-                &UseHttps {
-                    attribute: canonical,
-                },
-                scheme_span.into(),
-            );
-            guard.set_fix(Fix::unsafe_edit(Edit::replacement(
-                HTTPS_SCHEME,
-                scheme_span.into(),
-            )));
+        } else {
+            report_http_scheme(value_str, *offset, canonical, checker);
         }
     }
+}
+
+/// The canonical name if `name` is a URL-bearing attribute, else `None`.
+/// Matching on length first rejects non-URL attributes (the common case) cheaply.
+fn canonical_url_attr(name: &str) -> Option<&'static str> {
+    let candidates: &[&str] = match name.len() {
+        3 => &["src", "url"],
+        4 => &["href"],
+        6 => &["action", "srcset"],
+        8 => &["data-url"],
+        _ => return None,
+    };
+    candidates
+        .iter()
+        .copied()
+        .find(|c| c.eq_ignore_ascii_case(name))
+}
+
+/// Yields each `srcset` candidate URL with its byte offset in the source.
+/// Candidates are comma-separated; the URL is the first token of each.
+fn srcset_candidates(value: &str, base: usize) -> impl Iterator<Item = (&str, usize)> {
+    let mut pos = 0;
+    value.split(',').filter_map(move |candidate| {
+        let start = pos;
+        pos += candidate.len() + 1; // skip the candidate and its `,`
+        let trimmed = candidate.trim_start_matches(|c: char| c.is_ascii_whitespace());
+        let url = trimmed.split_ascii_whitespace().next()?;
+        Some((url, base + start + candidate.len() - trimmed.len()))
+    })
+}
+
+/// Reports (and offers a fix for) a URL that uses the insecure `http://` scheme.
+/// `offset` is the byte offset of `url` in the source.
+fn report_http_scheme(url: &str, offset: usize, attribute: &'static str, checker: &Checker<'_>) {
+    let trimmed = url.trim_start_matches(|c: char| c.is_ascii_whitespace());
+    let Some(rest) = trimmed.get(HTTP_SCHEME.len()..) else {
+        return;
+    };
+    if !trimmed[..HTTP_SCHEME.len()].eq_ignore_ascii_case(HTTP_SCHEME) || is_local_host(rest) {
+        return;
+    }
+    let scheme_span = (offset + url.len() - trimmed.len(), HTTP_SCHEME.len());
+    let mut guard = checker.report_diagnostic(&UseHttps { attribute }, scheme_span.into());
+    guard.set_fix(Fix::unsafe_edit(Edit::replacement(
+        HTTPS_SCHEME,
+        scheme_span.into(),
+    )));
 }
 
 /// Whether the authority of a URL (the part after `http://`) refers to the local machine.

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -49,7 +49,10 @@ fn check_invalid() {
     });
 }
 
-/// Snapshots the post-fix source for each `*.invalid.html` fixture whose rule applies a safe fix.
+/// Snapshots the post-fix source for each `*.invalid.html` fixture that produces a fix.
+///
+/// Safe fixes are snapshot as `{stem}.fixed`;
+/// Unsafe fixes are snapshot as `{stem}.unsafe-fixed`;
 #[test]
 fn fix_snapshot() {
     glob!("**/*.invalid.html", |path| {
@@ -58,15 +61,21 @@ fn fix_snapshot() {
         let ast = parser
             .parse_root()
             .unwrap_or_else(|err| panic!("Failed to parse {}: {err:?}", path.display()));
-        let result = fix_ast(&input, &ast, &Settings::default(), Applicability::Safe);
-        if result.applied_count == 0 {
-            return;
+        let stem = path.file_stem().unwrap().to_str().unwrap();
+
+        let safe = fix_ast(&input, &ast, &Settings::default(), Applicability::Safe);
+        if safe.applied_count > 0 {
+            build_settings(path).bind(|| {
+                assert_snapshot!(format!("{stem}.fixed"), safe.output);
+            });
         }
-        build_settings(path).bind(|| {
-            let stem = path.file_stem().unwrap().to_str().unwrap();
-            let name = format!("{stem}.fixed");
-            assert_snapshot!(name, result.output);
-        });
+
+        let unsafe_fixed = fix_ast(&input, &ast, &Settings::default(), Applicability::Unsafe);
+        if unsafe_fixed.applied_count > safe.applied_count {
+            build_settings(path).bind(|| {
+                assert_snapshot!(format!("{stem}.unsafe-fixed"), unsafe_fixed.output);
+            });
+        }
     });
 }
 

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.fixed.snap
@@ -1,0 +1,63 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+<!-- a/href -->
+<a href="http://example.com">Link</a>
+<a href="http://">Link</a>
+<a href='http://example.com'>Link</a>
+
+<!-- img/src -->
+<img src="http://example.com/logo.png">
+
+<!-- form/action -->
+<form action="http://example.com/submit"></form>
+
+<!-- data-url, url, srcset -->
+<div data-url="http://example.com"></div>
+<a url="http://example.com">Link</a>
+<img srcset="http://example.com/a.png 1x">
+
+<!-- script/src and link/href -->
+<script src="http://cdn.example.com/lib.js"></script>
+<link href="http://cdn.example.com/style.css" rel="stylesheet">
+
+<!-- Case-insensitive scheme -->
+<a href="HTTP://example.com">Link</a>
+<a href="Http://example.com">Link</a>
+
+<!-- Case-insensitive attribute name -->
+<a HREF="http://example.com">Link</a>
+<IMG SrC="http://example.com/logo.png">
+
+<!-- Leading whitespace before scheme -->
+<a href="  http://example.com">Link</a>
+
+<!-- Multi-attr element with mixed http/https — only the http one is flagged -->
+<a href="http://example.com" data-url="https://example.com">Link</a>
+
+<!-- Multiple flagged attributes on the same element -->
+<a href="http://example.com" data-url="http://example.com">Link</a>
+
+<!-- srcset with multiple descriptors — the value still starts with http:// -->
+<img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+
+<!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
+<a href="http://{{ host }}/page">Link</a>
+
+<!-- Inside a Jinja block -->
+{% if show_link %}
+    <a href="http://example.com">Link</a>
+{% endif %}
+
+<!-- Real world example -->
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
+<a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+<img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
+<img src="http://stats.amusecode.org/piwik.php?idsite=1">
+<a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
+
+<!-- Loopback look-alike are still flagged: the host only resembles localhost -->
+<a href="http://localhost.evil.com/admin">Phishing</a>
+<a href="http://127.0.0.1.evil.com/">Spoof</a>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.fixed.snap
@@ -38,8 +38,14 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Multiple flagged attributes on the same element -->
 <a href="http://example.com" data-url="http://example.com">Link</a>
 
-<!-- srcset with multiple descriptors — the value still starts with http:// -->
+<!-- srcset candidates are checked independently: every http:// entry is flagged -->
 <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+
+<!-- srcset insecure candidate after a secure one — must still be flagged -->
+<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+
+<!-- srcset without descriptors, comma-separated -->
+<img srcset="http://example.com/a.png, http://example.com/b.png">
 
 <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
 <a href="http://{{ host }}/page">Link</a>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.html
@@ -1,0 +1,60 @@
+<!-- a/href -->
+<a href="http://example.com">Link</a>
+<a href="http://">Link</a>
+<a href='http://example.com'>Link</a>
+
+<!-- img/src -->
+<img src="http://example.com/logo.png">
+
+<!-- form/action -->
+<form action="http://example.com/submit"></form>
+
+<!-- data-url, url, srcset -->
+<div data-url="http://example.com"></div>
+<a url="http://example.com">Link</a>
+<img srcset="http://example.com/a.png 1x">
+
+<!-- script/src and link/href -->
+<script src="http://cdn.example.com/lib.js"></script>
+<link href="http://cdn.example.com/style.css" rel="stylesheet">
+
+<!-- Case-insensitive scheme -->
+<a href="HTTP://example.com">Link</a>
+<a href="Http://example.com">Link</a>
+
+<!-- Case-insensitive attribute name -->
+<a HREF="http://example.com">Link</a>
+<IMG SrC="http://example.com/logo.png">
+
+<!-- Leading whitespace before scheme -->
+<a href="  http://example.com">Link</a>
+
+<!-- Multi-attr element with mixed http/https — only the http one is flagged -->
+<a href="http://example.com" data-url="https://example.com">Link</a>
+
+<!-- Multiple flagged attributes on the same element -->
+<a href="http://example.com" data-url="http://example.com">Link</a>
+
+<!-- srcset with multiple descriptors — the value still starts with http:// -->
+<img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+
+<!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
+<a href="http://{{ host }}/page">Link</a>
+
+<!-- Inside a Jinja block -->
+{% if show_link %}
+    <a href="http://example.com">Link</a>
+{% endif %}
+
+<!-- Real world example -->
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
+<a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+<img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+<script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
+<img src="http://stats.amusecode.org/piwik.php?idsite=1">
+<a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
+
+<!-- Loopback look-alike are still flagged: the host only resembles localhost -->
+<a href="http://localhost.evil.com/admin">Phishing</a>
+<a href="http://127.0.0.1.evil.com/">Spoof</a>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.html
@@ -35,8 +35,14 @@
 <!-- Multiple flagged attributes on the same element -->
 <a href="http://example.com" data-url="http://example.com">Link</a>
 
-<!-- srcset with multiple descriptors — the value still starts with http:// -->
+<!-- srcset candidates are checked independently: every http:// entry is flagged -->
 <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+
+<!-- srcset insecure candidate after a secure one — must still be flagged -->
+<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+
+<!-- srcset without descriptors, comma-separated -->
+<img srcset="http://example.com/a.png, http://example.com/b.png">
 
 <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
 <a href="http://{{ host }}/page">Link</a>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 31 lint error(s)
+  × Found 35 lint error(s)
 
 Error: 
   × Avoid `http://` URLs in `href`.
@@ -204,7 +204,7 @@ Error:
 Error: 
   × Avoid `http://` URLs in `srcset`.
     ╭─[tests/check/use_https/use_https.invalid.html:39:14]
- 38 │ <!-- srcset with multiple descriptors — the value still starts with http:// -->
+ 38 │ <!-- srcset candidates are checked independently: every http:// entry is flagged -->
  39 │ <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
     ·              ───┬───
     ·                 ╰── here
@@ -213,131 +213,175 @@ Error:
   help: Use `https://` instead.
 
 Error: 
-  × Avoid `http://` URLs in `href`.
-    ╭─[tests/check/use_https/use_https.invalid.html:42:10]
- 41 │ <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
- 42 │ <a href="http://{{ host }}/page">Link</a>
-    ·          ───┬───
-    ·             ╰── here
+  × Avoid `http://` URLs in `srcset`.
+    ╭─[tests/check/use_https/use_https.invalid.html:39:43]
+ 38 │ <!-- srcset candidates are checked independently: every http:// entry is flagged -->
+ 39 │ <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+    ·                                           ───┬───
+    ·                                              ╰── here
+ 40 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `srcset`.
+    ╭─[tests/check/use_https/use_https.invalid.html:42:44]
+ 41 │ <!-- srcset insecure candidate after a secure one — must still be flagged -->
+ 42 │ <img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+    ·                                            ───┬───
+    ·                                               ╰── here
  43 │ 
     ╰────
   help: Use `https://` instead.
 
 Error: 
-  × Avoid `http://` URLs in `href`.
-    ╭─[tests/check/use_https/use_https.invalid.html:46:14]
- 45 │ {% if show_link %}
- 46 │     <a href="http://example.com">Link</a>
+  × Avoid `http://` URLs in `srcset`.
+    ╭─[tests/check/use_https/use_https.invalid.html:45:14]
+ 44 │ <!-- srcset without descriptors, comma-separated -->
+ 45 │ <img srcset="http://example.com/a.png, http://example.com/b.png">
     ·              ───┬───
     ·                 ╰── here
- 47 │ {% endif %}
+ 46 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `srcset`.
+    ╭─[tests/check/use_https/use_https.invalid.html:45:40]
+ 44 │ <!-- srcset without descriptors, comma-separated -->
+ 45 │ <img srcset="http://example.com/a.png, http://example.com/b.png">
+    ·                                        ───┬───
+    ·                                           ╰── here
+ 46 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:48:10]
+ 47 │ <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
+ 48 │ <a href="http://{{ host }}/page">Link</a>
+    ·          ───┬───
+    ·             ╰── here
+ 49 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:52:14]
+ 51 │ {% if show_link %}
+ 52 │     <a href="http://example.com">Link</a>
+    ·              ───┬───
+    ·                 ╰── here
+ 53 │ {% endif %}
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `src`.
-    ╭─[tests/check/use_https/use_https.invalid.html:50:14]
- 49 │ <!-- Real world example -->
- 50 │ <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
+    ╭─[tests/check/use_https/use_https.invalid.html:56:14]
+ 55 │ <!-- Real world example -->
+ 56 │ <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
     ·              ───┬───
     ·                 ╰── here
- 51 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+ 57 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `href`.
-    ╭─[tests/check/use_https/use_https.invalid.html:51:24]
- 50 │ <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
- 51 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+    ╭─[tests/check/use_https/use_https.invalid.html:57:24]
+ 56 │ <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
+ 57 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
     ·                        ───┬───
     ·                           ╰── here
- 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `src`.
-    ╭─[tests/check/use_https/use_https.invalid.html:52:11]
- 51 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
- 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+    ╭─[tests/check/use_https/use_https.invalid.html:58:11]
+ 57 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
     ·           ───┬───
     ·              ╰── here
- 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+ 59 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Redundant type="text/javascript" on <script> tag.
-    ╭─[tests/check/use_https/use_https.invalid.html:53:15]
- 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
- 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    ╭─[tests/check/use_https/use_https.invalid.html:59:15]
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 59 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
     ·               ───────┬───────
     ·                      ╰── here
- 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+ 60 │ <script src="http://d3js.org/d3.v3.min.js"></script>
     ╰────
   help: Remove the `type` attribute. `<script>` defaults to `type="text/javascript"`.
 
 Error: 
   × Avoid `http://` URLs in `src`.
-    ╭─[tests/check/use_https/use_https.invalid.html:53:51]
- 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
- 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    ╭─[tests/check/use_https/use_https.invalid.html:59:51]
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 59 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
     ·                                                   ───┬───
     ·                                                      ╰── here
- 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+ 60 │ <script src="http://d3js.org/d3.v3.min.js"></script>
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `src`.
-    ╭─[tests/check/use_https/use_https.invalid.html:54:14]
- 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
- 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+    ╭─[tests/check/use_https/use_https.invalid.html:60:14]
+ 59 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+ 60 │ <script src="http://d3js.org/d3.v3.min.js"></script>
     ·              ───┬───
     ·                 ╰── here
- 55 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+ 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `src`.
-    ╭─[tests/check/use_https/use_https.invalid.html:55:11]
- 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
- 55 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+    ╭─[tests/check/use_https/use_https.invalid.html:61:11]
+ 60 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+ 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
     ·           ───┬───
     ·              ╰── here
- 56 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
+ 62 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `href`.
-    ╭─[tests/check/use_https/use_https.invalid.html:56:10]
- 55 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
- 56 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
+    ╭─[tests/check/use_https/use_https.invalid.html:62:10]
+ 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+ 62 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
     ·          ───┬───
     ·             ╰── here
- 57 │ 
+ 63 │ 
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `href`.
-    ╭─[tests/check/use_https/use_https.invalid.html:59:10]
- 58 │ <!-- Loopback look-alike are still flagged: the host only resembles localhost -->
- 59 │ <a href="http://localhost.evil.com/admin">Phishing</a>
+    ╭─[tests/check/use_https/use_https.invalid.html:65:10]
+ 64 │ <!-- Loopback look-alike are still flagged: the host only resembles localhost -->
+ 65 │ <a href="http://localhost.evil.com/admin">Phishing</a>
     ·          ───┬───
     ·             ╰── here
- 60 │ <a href="http://127.0.0.1.evil.com/">Spoof</a>
+ 66 │ <a href="http://127.0.0.1.evil.com/">Spoof</a>
     ╰────
   help: Use `https://` instead.
 
 Error: 
   × Avoid `http://` URLs in `href`.
-    ╭─[tests/check/use_https/use_https.invalid.html:60:10]
- 59 │ <a href="http://localhost.evil.com/admin">Phishing</a>
- 60 │ <a href="http://127.0.0.1.evil.com/">Spoof</a>
+    ╭─[tests/check/use_https/use_https.invalid.html:66:10]
+ 65 │ <a href="http://localhost.evil.com/admin">Phishing</a>
+ 66 │ <a href="http://127.0.0.1.evil.com/">Spoof</a>
     ·          ───┬───
     ·             ╰── here
     ╰────

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.snap
@@ -1,0 +1,344 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 31 lint error(s)
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+   ╭─[tests/check/use_https/use_https.invalid.html:2:10]
+ 1 │ <!-- a/href -->
+ 2 │ <a href="http://example.com">Link</a>
+   ·          ───┬───
+   ·             ╰── here
+ 3 │ <a href="http://">Link</a>
+   ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+   ╭─[tests/check/use_https/use_https.invalid.html:3:10]
+ 2 │ <a href="http://example.com">Link</a>
+ 3 │ <a href="http://">Link</a>
+   ·          ───┬───
+   ·             ╰── here
+ 4 │ <a href='http://example.com'>Link</a>
+   ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+   ╭─[tests/check/use_https/use_https.invalid.html:4:10]
+ 3 │ <a href="http://">Link</a>
+ 4 │ <a href='http://example.com'>Link</a>
+   ·          ───┬───
+   ·             ╰── here
+ 5 │ 
+   ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+   ╭─[tests/check/use_https/use_https.invalid.html:7:11]
+ 6 │ <!-- img/src -->
+ 7 │ <img src="http://example.com/logo.png">
+   ·           ───┬───
+   ·              ╰── here
+ 8 │ 
+   ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `action`.
+    ╭─[tests/check/use_https/use_https.invalid.html:10:15]
+  9 │ <!-- form/action -->
+ 10 │ <form action="http://example.com/submit"></form>
+    ·               ───┬───
+    ·                  ╰── here
+ 11 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `data-url`.
+    ╭─[tests/check/use_https/use_https.invalid.html:13:16]
+ 12 │ <!-- data-url, url, srcset -->
+ 13 │ <div data-url="http://example.com"></div>
+    ·                ───┬───
+    ·                   ╰── here
+ 14 │ <a url="http://example.com">Link</a>
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `url`.
+    ╭─[tests/check/use_https/use_https.invalid.html:14:9]
+ 13 │ <div data-url="http://example.com"></div>
+ 14 │ <a url="http://example.com">Link</a>
+    ·         ───┬───
+    ·            ╰── here
+ 15 │ <img srcset="http://example.com/a.png 1x">
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `srcset`.
+    ╭─[tests/check/use_https/use_https.invalid.html:15:14]
+ 14 │ <a url="http://example.com">Link</a>
+ 15 │ <img srcset="http://example.com/a.png 1x">
+    ·              ───┬───
+    ·                 ╰── here
+ 16 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+    ╭─[tests/check/use_https/use_https.invalid.html:18:14]
+ 17 │ <!-- script/src and link/href -->
+ 18 │ <script src="http://cdn.example.com/lib.js"></script>
+    ·              ───┬───
+    ·                 ╰── here
+ 19 │ <link href="http://cdn.example.com/style.css" rel="stylesheet">
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:19:13]
+ 18 │ <script src="http://cdn.example.com/lib.js"></script>
+ 19 │ <link href="http://cdn.example.com/style.css" rel="stylesheet">
+    ·             ───┬───
+    ·                ╰── here
+ 20 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:22:10]
+ 21 │ <!-- Case-insensitive scheme -->
+ 22 │ <a href="HTTP://example.com">Link</a>
+    ·          ───┬───
+    ·             ╰── here
+ 23 │ <a href="Http://example.com">Link</a>
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:23:10]
+ 22 │ <a href="HTTP://example.com">Link</a>
+ 23 │ <a href="Http://example.com">Link</a>
+    ·          ───┬───
+    ·             ╰── here
+ 24 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:26:10]
+ 25 │ <!-- Case-insensitive attribute name -->
+ 26 │ <a HREF="http://example.com">Link</a>
+    ·          ───┬───
+    ·             ╰── here
+ 27 │ <IMG SrC="http://example.com/logo.png">
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+    ╭─[tests/check/use_https/use_https.invalid.html:27:11]
+ 26 │ <a HREF="http://example.com">Link</a>
+ 27 │ <IMG SrC="http://example.com/logo.png">
+    ·           ───┬───
+    ·              ╰── here
+ 28 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:30:12]
+ 29 │ <!-- Leading whitespace before scheme -->
+ 30 │ <a href="  http://example.com">Link</a>
+    ·            ───┬───
+    ·               ╰── here
+ 31 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:33:10]
+ 32 │ <!-- Multi-attr element with mixed http/https — only the http one is flagged -->
+ 33 │ <a href="http://example.com" data-url="https://example.com">Link</a>
+    ·          ───┬───
+    ·             ╰── here
+ 34 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:36:10]
+ 35 │ <!-- Multiple flagged attributes on the same element -->
+ 36 │ <a href="http://example.com" data-url="http://example.com">Link</a>
+    ·          ───┬───
+    ·             ╰── here
+ 37 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `data-url`.
+    ╭─[tests/check/use_https/use_https.invalid.html:36:40]
+ 35 │ <!-- Multiple flagged attributes on the same element -->
+ 36 │ <a href="http://example.com" data-url="http://example.com">Link</a>
+    ·                                        ───┬───
+    ·                                           ╰── here
+ 37 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `srcset`.
+    ╭─[tests/check/use_https/use_https.invalid.html:39:14]
+ 38 │ <!-- srcset with multiple descriptors — the value still starts with http:// -->
+ 39 │ <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+    ·              ───┬───
+    ·                 ╰── here
+ 40 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:42:10]
+ 41 │ <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
+ 42 │ <a href="http://{{ host }}/page">Link</a>
+    ·          ───┬───
+    ·             ╰── here
+ 43 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:46:14]
+ 45 │ {% if show_link %}
+ 46 │     <a href="http://example.com">Link</a>
+    ·              ───┬───
+    ·                 ╰── here
+ 47 │ {% endif %}
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+    ╭─[tests/check/use_https/use_https.invalid.html:50:14]
+ 49 │ <!-- Real world example -->
+ 50 │ <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
+    ·              ───┬───
+    ·                 ╰── here
+ 51 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:51:24]
+ 50 │ <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
+ 51 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+    ·                        ───┬───
+    ·                           ╰── here
+ 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+    ╭─[tests/check/use_https/use_https.invalid.html:52:11]
+ 51 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+ 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+    ·           ───┬───
+    ·              ╰── here
+ 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Redundant type="text/javascript" on <script> tag.
+    ╭─[tests/check/use_https/use_https.invalid.html:53:15]
+ 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    ·               ───────┬───────
+    ·                      ╰── here
+ 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+    ╰────
+  help: Remove the `type` attribute. `<script>` defaults to `type="text/javascript"`.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+    ╭─[tests/check/use_https/use_https.invalid.html:53:51]
+ 52 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    ·                                                   ───┬───
+    ·                                                      ╰── here
+ 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+    ╭─[tests/check/use_https/use_https.invalid.html:54:14]
+ 53 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+ 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+    ·              ───┬───
+    ·                 ╰── here
+ 55 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `src`.
+    ╭─[tests/check/use_https/use_https.invalid.html:55:11]
+ 54 │ <script src="http://d3js.org/d3.v3.min.js"></script>
+ 55 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+    ·           ───┬───
+    ·              ╰── here
+ 56 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:56:10]
+ 55 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+ 56 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
+    ·          ───┬───
+    ·             ╰── here
+ 57 │ 
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:59:10]
+ 58 │ <!-- Loopback look-alike are still flagged: the host only resembles localhost -->
+ 59 │ <a href="http://localhost.evil.com/admin">Phishing</a>
+    ·          ───┬───
+    ·             ╰── here
+ 60 │ <a href="http://127.0.0.1.evil.com/">Spoof</a>
+    ╰────
+  help: Use `https://` instead.
+
+Error: 
+  × Avoid `http://` URLs in `href`.
+    ╭─[tests/check/use_https/use_https.invalid.html:60:10]
+ 59 │ <a href="http://localhost.evil.com/admin">Phishing</a>
+ 60 │ <a href="http://127.0.0.1.evil.com/">Spoof</a>
+    ·          ───┬───
+    ·             ╰── here
+    ╰────
+  help: Use `https://` instead.

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.unsafe-fixed.snap
@@ -38,8 +38,14 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Multiple flagged attributes on the same element -->
 <a href="https://example.com" data-url="https://example.com">Link</a>
 
-<!-- srcset with multiple descriptors — the value still starts with http:// -->
-<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+<!-- srcset candidates are checked independently: every http:// entry is flagged -->
+<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x">
+
+<!-- srcset insecure candidate after a secure one — must still be flagged -->
+<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x">
+
+<!-- srcset without descriptors, comma-separated -->
+<img srcset="https://example.com/a.png, https://example.com/b.png">
 
 <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
 <a href="https://{{ host }}/page">Link</a>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.unsafe-fixed.snap
@@ -1,0 +1,63 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+<!-- a/href -->
+<a href="https://example.com">Link</a>
+<a href="https://">Link</a>
+<a href='https://example.com'>Link</a>
+
+<!-- img/src -->
+<img src="https://example.com/logo.png">
+
+<!-- form/action -->
+<form action="https://example.com/submit"></form>
+
+<!-- data-url, url, srcset -->
+<div data-url="https://example.com"></div>
+<a url="https://example.com">Link</a>
+<img srcset="https://example.com/a.png 1x">
+
+<!-- script/src and link/href -->
+<script src="https://cdn.example.com/lib.js"></script>
+<link href="https://cdn.example.com/style.css" rel="stylesheet">
+
+<!-- Case-insensitive scheme -->
+<a href="https://example.com">Link</a>
+<a href="https://example.com">Link</a>
+
+<!-- Case-insensitive attribute name -->
+<a HREF="https://example.com">Link</a>
+<IMG SrC="https://example.com/logo.png">
+
+<!-- Leading whitespace before scheme -->
+<a href="  https://example.com">Link</a>
+
+<!-- Multi-attr element with mixed http/https — only the http one is flagged -->
+<a href="https://example.com" data-url="https://example.com">Link</a>
+
+<!-- Multiple flagged attributes on the same element -->
+<a href="https://example.com" data-url="https://example.com">Link</a>
+
+<!-- srcset with multiple descriptors — the value still starts with http:// -->
+<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+
+<!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
+<a href="https://{{ host }}/page">Link</a>
+
+<!-- Inside a Jinja block -->
+{% if show_link %}
+    <a href="https://example.com">Link</a>
+{% endif %}
+
+<!-- Real world example -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
+<a rel="license" href="https://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
+<img src="https://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+<script src="https://d3js.org/d3.v3.min.js"></script>
+<img src="https://stats.amusecode.org/piwik.php?idsite=1">
+<a href="https://stackoverflow.com/questions/tagged/django">Django questions</a>
+
+<!-- Loopback look-alike are still flagged: the host only resembles localhost -->
+<a href="https://localhost.evil.com/admin">Phishing</a>
+<a href="https://127.0.0.1.evil.com/">Spoof</a>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
@@ -5,6 +5,12 @@
 <script src="https://cdn.example.com/lib.js"></script>
 <link href="https://cdn.example.com/style.css" rel="stylesheet">
 
+<!-- srcset with every candidate secure -->
+<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x">
+
+<!-- srcset whose only http candidate points at a loopback host -->
+<img srcset="http://localhost:5173/a.png 1x, https://example.com/b.png 2x">
+
 <!-- Relative and root-relative URLs -->
 <a href="/page/">Link</a>
 <a href="page.html">Link</a>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
@@ -1,0 +1,62 @@
+<!-- HTTPS URLs -->
+<a href="https://example.com">Link</a>
+<img src="https://example.com/logo.png">
+<form action="https://example.com/submit"></form>
+<script src="https://cdn.example.com/lib.js"></script>
+<link href="https://cdn.example.com/style.css" rel="stylesheet">
+
+<!-- Relative and root-relative URLs -->
+<a href="/page/">Link</a>
+<a href="page.html">Link</a>
+<img src="/static/logo.png">
+
+<!-- Protocol-relative URLs (caller defers to surrounding page scheme) -->
+<img src="//cdn.example.com/logo.png">
+<a href="//example.com">Link</a>
+
+<!-- Other schemes -->
+<a href="mailto:user@example.com">Email</a>
+<a href="tel:+15550100">Call</a>
+<a href="data:text/plain,hello">Data</a>
+<a href="ftp://example.com">FTP</a>
+<a href="#section">Anchor</a>
+
+<!-- No false positive when `http://` appears mid-value rather than as the scheme -->
+<a href="/redirect?to=http://example.com">Link</a>
+<meta name="description" content="See http://example.com for details">
+
+<!-- Interpolation without a literal `http://` prefix is not flagged -->
+<a href="{{ url }}">Link</a>
+<a href="{% url 'home' %}">Home</a>
+<a href="{% if x %}http://a{% else %}http://b{% endif %}">Link</a>
+<form action="{% url 'submit' %}"></form>
+
+<!-- Interpolated scheme — caller controls the protocol, so we cannot prove it is `http://` -->
+<a href="{{ scheme }}://example.com">Link</a>
+
+<!-- Attributes outside the URL attribute set -->
+<a data-href="http://example.com">Link</a>
+<div title="http://example.com">Hover</div>
+<input value="http://example.com">
+<meta http-equiv="refresh" content="0; url=http://example.com">
+
+<!-- href without value -->
+<a href>Link</a>
+
+<!-- Empty value -->
+<a href="">Link</a>
+
+<!-- Leading non-ASCII whitespace (U+00A0) is not stripped: value does not start with http:// -->
+<a href=" http://example.com">Link</a>
+
+<!-- Nested in Jinja block -->
+{% if show_link %}
+    <a href="https://example.com">Link</a>
+{% endif %}
+
+<!-- Loopback / localhost: http is fine here and https usually breaks local dev -->
+<a href="http://localhost:3000/admin">Admin</a>
+<script src="http://localhost:5173/@vite/client"></script>
+<img src="http://127.0.0.1:8080/preview.png">
+<a href="http://[::1]:8000/">IPv6 loopback</a>
+<a href="http://app.localhost/">.localhost TLD</a>

--- a/justfile
+++ b/justfile
@@ -14,13 +14,23 @@ bootstrap:
     rustup component add llvm-tools-preview
     cargo install cargo-llvm-cov --locked
 
+# Run clippy on all targets and features
+[group('dev')]
+lint:
+    cargo clippy --all-targets --all-features
+
+# Run the full test suite, accepting snapshot updates automatically.
+[group('dev')]
+test update="always":
+    INSTA_UPDATE={{update}} cargo test --workspace --all-targets --all-features
+
 # Pre-merge request checks
 [group('dev')]
 pre-mr-check:
     SKIP=actionlint,renovate-config-validator pre-commit run -a
     uv run maturin develop
-    cargo clippy --all-targets --all-features
-    cargo test --workspace --all-targets --all-features
+    just lint
+    just test no
     just docs-build
 
 # Regenerate the per-rule documentation under docs/rules/ and docs/rules.md


### PR DESCRIPTION
## What it does
Checks for `http://` URLs in HTML attributes that load or link external resources.

## Why is this bad?
`http://` traffic is unencrypted and can be intercepted or modified in transit. Modern browsers also block mixed content (HTTP subresources on an HTTPS page), so a single `http://` URL can silently break the page. Prefer `https://` for all external links and subresources.

## Example
```html
<a href="http://example.com">Link</a>
```

Use instead:
```html
<a href="https://example.com">Link</a>
```

## References
- [MDN: Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
- [WHATWG Fetch: HTTPS state](https://fetch.spec.whatwg.org/#concept-request-https-state)

Part of #231 