### PR TITLE
feat(lint): Add `missing-title` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -121,6 +121,10 @@ impl<'a> Checker<'a> {
             rules::accessibility::missing_html_lang::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::MissingTitle) {
+            rules::accessibility::missing_title::check(element, self);
+        }
+
         for attr in &element.attrs {
             self.visit_attribute(attr);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -249,4 +249,5 @@ define_rules! {
     (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
     (FormActionWhitespace, rules::style::form_action_whitespace::FormActionWhitespace),
     (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),
+    (MissingTitle, rules::accessibility::missing_title::MissingTitle),
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_title.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_title.rs
@@ -1,0 +1,152 @@
+use markup_fmt::ast::{Element, JinjaBlock, JinjaTagOrChildren, Node, NodeKind};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for `<head>` elements that do not contain a non-empty `<title>` child.
+///
+/// ## Why is this bad?
+/// The `<title>` element names the document. Browsers display it in tabs, history entries, and
+/// bookmarks; screen readers announce it first when the page loads; and search engines use it as
+/// the default link text in result pages. A page without a title leaves users unable to tell tabs
+/// apart and fails WCAG Success Criterion 2.4.2.
+///
+/// ## Example
+/// ```html
+/// <head>
+///     <meta charset="utf-8">
+/// </head>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <head>
+///     <meta charset="utf-8">
+///     <title>My page</title>
+/// </head>
+/// ```
+///
+/// ## References
+/// - [WCAG 2.4.2: Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html)
+/// - [HTML spec: the title element](https://html.spec.whatwg.org/multipage/semantics.html#the-title-element)
+#[derive(Debug, PartialEq, Eq)]
+pub enum TitleViolation {
+    /// No `<title>` element is present anywhere inside `<head>`.
+    Absent,
+    /// A `<title>` element exists but has no visible or templated content.
+    Empty,
+}
+
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct MissingTitle {
+    pub kind: TitleViolation,
+}
+
+impl Violation for MissingTitle {
+    const RULE: Rule = Rule::MissingTitle;
+    const CATEGORY: RuleCategory = RuleCategory::Accessibility;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Missing or empty `<title>` in `<head>`.".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(match self.kind {
+            TitleViolation::Absent => {
+                "Add a `<title>` element with descriptive text inside `<head>`.".to_string()
+            }
+            TitleViolation::Empty => {
+                "Fill the existing `<title>` element with descriptive text.".to_string()
+            }
+        })
+    }
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if !element.tag_name.eq_ignore_ascii_case("head") {
+        return;
+    }
+
+    let kind = match classify_title(&element.children) {
+        TitleStatus::Present => return,
+        TitleStatus::Empty => TitleViolation::Empty,
+        TitleStatus::Absent => TitleViolation::Absent,
+    };
+
+    let offset = checker.source_offset(element.tag_name);
+    checker.report_diagnostic(
+        &MissingTitle { kind },
+        (offset, element.tag_name.len()).into(),
+    );
+}
+
+/// Outcome of inspecting a `<head>`'s descendants for a `<title>`.
+enum TitleStatus {
+    /// A non-empty `<title>` was found.
+    Present,
+    /// At least one `<title>` was found, but none had content.
+    Empty,
+    /// No `<title>` element was found.
+    Absent,
+}
+
+impl TitleStatus {
+    const fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Present, _) | (_, Self::Present) => Self::Present,
+            (Self::Empty, _) | (_, Self::Empty) => Self::Empty,
+            _ => Self::Absent,
+        }
+    }
+}
+
+/// Classify the title situation across a node list (head children or Jinja block children).
+fn classify_title(nodes: &[Node<'_>]) -> TitleStatus {
+    nodes.iter().fold(TitleStatus::Absent, |acc, node| {
+        acc.merge(node_title_status(node))
+    })
+}
+
+fn node_title_status(node: &Node<'_>) -> TitleStatus {
+    match &node.kind {
+        NodeKind::Element(el) if el.tag_name.eq_ignore_ascii_case("title") => {
+            if title_has_content(&el.children) {
+                TitleStatus::Present
+            } else {
+                TitleStatus::Empty
+            }
+        }
+        NodeKind::JinjaBlock(block) => jinja_block_title_status(block),
+        _ => TitleStatus::Absent,
+    }
+}
+
+fn jinja_block_title_status(block: &JinjaBlock<'_, Node<'_>>) -> TitleStatus {
+    block
+        .body
+        .iter()
+        .fold(TitleStatus::Absent, |acc, item| match item {
+            JinjaTagOrChildren::Children(children) => acc.merge(classify_title(children)),
+            JinjaTagOrChildren::Tag(_) => acc,
+        })
+}
+
+/// Whether `<title>`'s children carry visible or templated content.
+///
+/// Whitespace-only text is treated as empty; Jinja interpolations, tags, and blocks count as
+/// content because they may expand to text at render time.
+fn title_has_content(children: &[Node<'_>]) -> bool {
+    children.iter().any(|node| match &node.kind {
+        NodeKind::Text(text) => !text.raw.trim().is_empty(),
+        NodeKind::JinjaInterpolation(_) | NodeKind::JinjaTag(_) | NodeKind::Element(_) => true,
+        NodeKind::JinjaBlock(block) => block.body.iter().any(|item| match item {
+            JinjaTagOrChildren::Children(children) => title_has_content(children),
+            JinjaTagOrChildren::Tag(_) => true,
+        }),
+        _ => false,
+    })
+}

--- a/crates/djangofmt_lint/src/rules/accessibility/mod.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/mod.rs
@@ -1,1 +1,2 @@
 pub mod missing_html_lang;
+pub mod missing_title;

--- a/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.html
@@ -1,0 +1,67 @@
+<!-- Empty <head> -->
+<html lang="en">
+    <head>
+    </head>
+</html>
+
+<!-- <head> with siblings but no <title> -->
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="/static/app.css">
+    </head>
+</html>
+
+<!-- Case-insensitive <head> tag name -->
+<HTML LANG="en">
+    <HEAD>
+        <META charset="utf-8">
+    </HEAD>
+</HTML>
+
+<!-- <head> without an enclosing <html> -->
+<head>
+    <meta charset="utf-8">
+</head>
+
+<!-- Nested in a Jinja block -->
+{% if base_template %}
+    <head>
+        <meta charset="utf-8">
+    </head>
+{% endif %}
+
+<!-- Empty <title> with no content -->
+<html lang="en">
+    <head>
+        <title></title>
+    </head>
+</html>
+
+<!-- Whitespace-only <title> -->
+<html lang="en">
+    <head>
+        <title>   </title>
+    </head>
+</html>
+
+<!-- <title> inside <svg> (in body) does not satisfy <head> -->
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <svg><title>Icon</title></svg>
+    </body>
+</html>
+
+<!-- AMP document missing a <title> -->
+<!doctype html>
+<html amp lang="en">
+    <head>
+        <meta charset="utf-8">
+        <script async src="https://cdn.ampproject.org/v0.js"></script>
+        <link rel="canonical" href="/article">
+    </head>
+    <body></body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.snap
@@ -1,0 +1,103 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 9 lint error(s)
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+   ╭─[tests/check/missing_title/missing_title.invalid.html:3:6]
+ 2 │ <html lang="en">
+ 3 │     <head>
+   ·      ──┬─
+   ·        ╰── here
+ 4 │     </head>
+   ╰────
+  help: Add a `<title>` element with descriptive text inside `<head>`.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:9:6]
+  8 │ <html lang="en">
+  9 │     <head>
+    ·      ──┬─
+    ·        ╰── here
+ 10 │         <meta charset="utf-8">
+    ╰────
+  help: Add a `<title>` element with descriptive text inside `<head>`.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:17:6]
+ 16 │ <HTML LANG="en">
+ 17 │     <HEAD>
+    ·      ──┬─
+    ·        ╰── here
+ 18 │         <META charset="utf-8">
+    ╰────
+  help: Add a `<title>` element with descriptive text inside `<head>`.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:23:2]
+ 22 │ <!-- <head> without an enclosing <html> -->
+ 23 │ <head>
+    ·  ──┬─
+    ·    ╰── here
+ 24 │     <meta charset="utf-8">
+    ╰────
+  help: Add a `<title>` element with descriptive text inside `<head>`.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:29:6]
+ 28 │ {% if base_template %}
+ 29 │     <head>
+    ·      ──┬─
+    ·        ╰── here
+ 30 │         <meta charset="utf-8">
+    ╰────
+  help: Add a `<title>` element with descriptive text inside `<head>`.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:36:6]
+ 35 │ <html lang="en">
+ 36 │     <head>
+    ·      ──┬─
+    ·        ╰── here
+ 37 │         <title></title>
+    ╰────
+  help: Fill the existing `<title>` element with descriptive text.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:43:6]
+ 42 │ <html lang="en">
+ 43 │     <head>
+    ·      ──┬─
+    ·        ╰── here
+ 44 │         <title>   </title>
+    ╰────
+  help: Fill the existing `<title>` element with descriptive text.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:50:6]
+ 49 │ <html lang="en">
+ 50 │     <head>
+    ·      ──┬─
+    ·        ╰── here
+ 51 │         <meta charset="utf-8">
+    ╰────
+  help: Add a `<title>` element with descriptive text inside `<head>`.
+
+Error: 
+  × Missing or empty `<title>` in `<head>`.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:61:6]
+ 60 │ <html amp lang="en">
+ 61 │     <head>
+    ·      ──┬─
+    ·        ╰── here
+ 62 │         <meta charset="utf-8">
+    ╰────
+  help: Add a `<title>` element with descriptive text inside `<head>`.

--- a/crates/djangofmt_lint/tests/check/missing_title/missing_title.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_title/missing_title.valid.html
@@ -1,0 +1,82 @@
+<!-- <title> as direct child of <head> -->
+<html lang="en">
+    <head>
+        <title>My page</title>
+    </head>
+</html>
+
+<!-- Case-insensitive title tag name -->
+<html lang="en">
+    <head>
+        <TITLE>My page</TITLE>
+    </head>
+</html>
+
+<!-- <title> alongside other <head> children -->
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>My page</title>
+        <link rel="stylesheet" href="/static/app.css">
+    </head>
+</html>
+
+<!-- <title> with global attributes -->
+<html lang="en">
+    <head>
+        <title id="title-reload-with-htmx" data-foo="bar">stuff</title>
+    </head>
+</html>
+
+<!-- <title> declared inside a Jinja conditional -->
+<html lang="en">
+    <head>
+        {% if page.title %}<title>{{ page.title }}</title>{% else %}<title>Default</title>{% endif %}
+    </head>
+</html>
+
+<!-- <title> filled with a Jinja interpolation -->
+<html lang="en">
+    <head>
+        <title>{{ page_title }}</title>
+    </head>
+</html>
+
+<!-- <title> filled with a {% block %} extension hook -->
+<html lang="en">
+    <head>
+        <title>{% block title %}{% endblock %}</title>
+    </head>
+</html>
+
+<!-- <title> wrapped in a {% block %} extension hook -->
+<html lang="en">
+    <head>
+        {% block head %}<title>Default</title>{% endblock %}
+    </head>
+</html>
+
+<!-- Documents without any <head> are not checked (fragment / partial template) -->
+<html lang="en">
+    <body>
+        <p>No head, no problem.</p>
+    </body>
+</html>
+
+<!-- Fragment template extending a base with only blocks -->
+{% extends "base.html" %}
+
+{% block content %}<p>Just a fragment.</p>{% endblock %}
+
+<!-- Tag names that look similar but are not <head> -->
+<div>
+    <header></header>
+</div>
+
+<!-- Multiple <title> tags: at least one non-empty satisfies the rule -->
+<html lang="en">
+    <head>
+        <title>Primary</title>
+        <title>Duplicate</title>
+    </head>
+</html>


### PR DESCRIPTION
## What it does
Checks for `<head>` elements that do not contain a non-empty `<title>` child.

## Why is this bad?
The `<title>` element names the document. Browsers display it in tabs, history entries, and bookmarks; screen readers announce it first when the page loads; and search engines use it as the default link text in result pages. A page without a title leaves users unable to tell tabs apart and fails WCAG Success Criterion 2.4.2.

## Example
```html
<head>
    <meta charset="utf-8">
</head>
```

Use instead:
```html
<head>
    <meta charset="utf-8">
    <title>My page</title>
</head>
```

## References
- [WCAG 2.4.2: Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html)
- [HTML spec: the title element](https://html.spec.whatwg.org/multipage/semantics.html#the-title-element)

Part of #231 