### PR TITLE
feat(lint): Add `missing-doctype` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -75,6 +75,10 @@ impl<'a> Checker<'a> {
 
     /// Visit the root of the AST and run all lint rules.
     pub fn visit_root(&mut self, root: &Root<'_>) {
+        if self.is_rule_enabled(Rule::MissingDoctype) {
+            rules::style::missing_doctype::check(root, self);
+        }
+
         for node in &root.children {
             self.visit_node(node);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -249,4 +249,5 @@ define_rules! {
     (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
     (FormActionWhitespace, rules::style::form_action_whitespace::FormActionWhitespace),
     (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),
+    (MissingDoctype, rules::style::missing_doctype::MissingDoctype),
 }

--- a/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
+++ b/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
@@ -1,0 +1,103 @@
+use markup_fmt::ast::{NodeKind, Root};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for HTML documents that contain an `<html>` tag but no `<!DOCTYPE html>` declaration.
+///
+/// ## Why is this bad?
+/// HTML5 requires a DOCTYPE declaration at the top of every document. Without it, browsers fall
+/// back to "quirks mode", which emulates legacy rendering bugs and applies different CSS box-model
+/// rules. The result is inconsistent layout across browsers and behaviour that is hard to debug.
+///
+/// Template partials (files with a root-level `{% extends %}` tag or `{% block %}` block) are
+/// assumed to inherit the DOCTYPE from their parent template and are not flagged.
+///
+/// ## Example
+/// ```html
+/// <html lang="en">
+///   <head><title>Page</title></head>
+///   <body>Content</body>
+/// </html>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <!DOCTYPE html>
+/// <html lang="en">
+///   <head><title>Page</title></head>
+///   <body>Content</body>
+/// </html>
+/// ```
+///
+/// ## References
+/// - [HTML spec: The DOCTYPE](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype)
+/// - [MDN: Doctype](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct MissingDoctype;
+
+impl Violation for MissingDoctype {
+    const RULE: Rule = Rule::MissingDoctype;
+    const CATEGORY: RuleCategory = RuleCategory::Style;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Missing `<!DOCTYPE html>` declaration.".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Add `<!DOCTYPE html>` before the `<html>` tag.".to_string())
+    }
+}
+
+pub fn check(root: &Root<'_>, checker: &Checker<'_>) {
+    let mut html_element = None;
+    let mut has_doctype = false;
+
+    for node in &root.children {
+        match &node.kind {
+            NodeKind::JinjaBlock(_) => return,
+            NodeKind::JinjaTag(tag) if is_extends_tag(tag.content) => return,
+            NodeKind::Doctype(_) => has_doctype = true,
+            NodeKind::Element(el)
+                if html_element.is_none() && el.tag_name.eq_ignore_ascii_case("html") =>
+            {
+                html_element = Some(el);
+            }
+            _ => {}
+        }
+    }
+
+    if has_doctype {
+        return;
+    }
+
+    let Some(html) = html_element else {
+        return;
+    };
+
+    let offset = checker.source_offset(html.tag_name);
+    checker.report_diagnostic(&MissingDoctype, (offset, html.tag_name.len()).into());
+}
+
+/// Returns `true` if `content` is the body of a Jinja `{% extends %}` tag.
+///
+/// Handles Jinja's whitespace-stripping markers (`{%-` / `-%}`), which the parser preserves as
+/// leading/trailing `-` inside `content`. The check after `extends` requires a word boundary so
+/// e.g. `{% extendsfoo %}` is not matched.
+fn is_extends_tag(content: &str) -> bool {
+    let trimmed = content
+        .trim_start()
+        .strip_prefix('-')
+        .map_or_else(|| content.trim_start(), str::trim_start);
+    let Some(after_extends) = trimmed.strip_prefix("extends") else {
+        return false;
+    };
+    after_extends
+        .chars()
+        .next()
+        .is_none_or(|c| c.is_ascii_whitespace())
+}

--- a/crates/djangofmt_lint/src/rules/style/mod.rs
+++ b/crates/djangofmt_lint/src/rules/style/mod.rs
@@ -1,4 +1,5 @@
 pub mod empty_attr_value;
 pub mod form_action_whitespace;
+pub mod missing_doctype;
 pub mod redundant_type_attr;
 pub mod uppercase_form_method;

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype.invalid.html
@@ -1,0 +1,5 @@
+<!-- `<html>` with no DOCTYPE declaration -->
+<html lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype.invalid.snap
@@ -1,0 +1,15 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 1 lint error(s)
+
+Error: 
+  × Missing `<!DOCTYPE html>` declaration.
+   ╭─[tests/check/missing_doctype/missing_doctype.invalid.html:2:2]
+ 1 │ <!-- `<html>` with no DOCTYPE declaration -->
+ 2 │ <html lang="en">
+   ·  ──┬─
+   ·    ╰── here
+ 3 │     <head><title>Page</title></head>
+   ╰────
+  help: Add `<!DOCTYPE html>` before the `<html>` tag.

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype.valid.html
@@ -1,0 +1,6 @@
+<!-- DOCTYPE present, `<html>` follows -->
+<!DOCTYPE html>
+<html lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_block_doctype.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_block_doctype.valid.html
@@ -1,0 +1,7 @@
+<!-- Base template with the DOCTYPE wrapped in a `{% block %}` so child templates can override
+     it. Treated as a partial: the rule does not flag root-level blocks. -->
+{% block doctype %}<!DOCTYPE html>{% endblock %}
+<html lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_block_partial.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_block_partial.valid.html
@@ -1,0 +1,4 @@
+<!-- Template partial: root-level `{% block %}` means this file is included in another. -->
+{% block content %}
+    <div>Block content</div>
+{% endblock %}

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends.valid.html
@@ -1,0 +1,5 @@
+<!-- Template partial: `{% extends %}` means the base template owns the DOCTYPE. -->
+{% extends "base.html" %}
+{% block content %}
+    <div>Partial content</div>
+{% endblock %}

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.html
@@ -1,0 +1,5 @@
+<!-- `extendsfoo` is not the `extends` directive: the file is a full document, not a partial. -->
+{% extendsfoo "base.html" %}
+<html lang="en">
+    <body></body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.snap
@@ -1,0 +1,15 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 1 lint error(s)
+
+Error: 
+  × Missing `<!DOCTYPE html>` declaration.
+   ╭─[tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.html:3:2]
+ 2 │ {% extendsfoo "base.html" %}
+ 3 │ <html lang="en">
+   ·  ──┬─
+   ·    ╰── here
+ 4 │     <body></body>
+   ╰────
+  help: Add `<!DOCTYPE html>` before the `<html>` tag.

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_whitespace.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_whitespace.valid.html
@@ -1,0 +1,5 @@
+<!-- Jinja whitespace-stripping form `{%- extends -%}` is a legitimate extends. -->
+{%- extends "base.html" -%}
+{% block content %}
+    <div>Partial content</div>
+{% endblock %}

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_legacy_doctype.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_legacy_doctype.valid.html
@@ -1,0 +1,7 @@
+<!-- Legacy doctype (HTML 4.01 / XHTML 1.0): the rule only checks for *presence* of any
+     DOCTYPE, so this must not be flagged. Quality of the doctype is out of scope. -->
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd">
+<html lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_load_tag.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_load_tag.invalid.html
@@ -1,0 +1,7 @@
+<!-- A bare `{% load %}` tag before `<html>` does not declare a DOCTYPE; the rule must still
+     flag the document. -->
+{% load static %}
+<html lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_load_tag.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_load_tag.invalid.snap
@@ -1,0 +1,15 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 1 lint error(s)
+
+Error: 
+  × Missing `<!DOCTYPE html>` declaration.
+   ╭─[tests/check/missing_doctype/missing_doctype_load_tag.invalid.html:4:2]
+ 3 │ {% load static %}
+ 4 │ <html lang="en">
+   ·  ──┬─
+   ·    ╰── here
+ 5 │     <head><title>Page</title></head>
+   ╰────
+  help: Add `<!DOCTYPE html>` before the `<html>` tag.

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_lowercase_doctype.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_lowercase_doctype.valid.html
@@ -1,0 +1,6 @@
+<!-- Lowercase `<!doctype html>` is recognised by the parser as a DOCTYPE. -->
+<!doctype html>
+<html lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_no_html.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_no_html.valid.html
@@ -1,0 +1,4 @@
+<!-- No `<html>` tag anywhere: a snippet, not a full document. -->
+<div>
+    <p>Some content</p>
+</div>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_uppercase.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_uppercase.invalid.html
@@ -1,0 +1,5 @@
+<!-- Case-insensitive tag name: `<HTML>` is still flagged. -->
+<HTML lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</HTML>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_uppercase.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_uppercase.invalid.snap
@@ -1,0 +1,15 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 1 lint error(s)
+
+Error: 
+  × Missing `<!DOCTYPE html>` declaration.
+   ╭─[tests/check/missing_doctype/missing_doctype_uppercase.invalid.html:2:2]
+ 1 │ <!-- Case-insensitive tag name: `<HTML>` is still flagged. -->
+ 2 │ <HTML lang="en">
+   ·  ──┬─
+   ·    ╰── here
+ 3 │     <head><title>Page</title></head>
+   ╰────
+  help: Add `<!DOCTYPE html>` before the `<html>` tag.

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_xml_decl.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_xml_decl.valid.html
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- No attributes at all -->
 <html>
 </html>

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.snap
@@ -5,66 +5,66 @@ source: crates/djangofmt_lint/tests/check/main.rs
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.
-   ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:2:2]
- 1 │ <!-- No attributes at all -->
- 2 │ <html>
+   ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:3:2]
+ 2 │ <!-- No attributes at all -->
+ 3 │ <html>
    ·  ──┬─
    ·    ╰── here
- 3 │ </html>
+ 4 │ </html>
    ╰────
   help: Add `lang="en"` (or the appropriate language code).
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.
-   ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:6:2]
- 5 │ <!-- Has other attributes but no lang -->
- 6 │ <html class="no-js" dir="ltr">
+   ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:7:2]
+ 6 │ <!-- Has other attributes but no lang -->
+ 7 │ <html class="no-js" dir="ltr">
    ·  ──┬─
    ·    ╰── here
- 7 │ </html>
+ 8 │ </html>
    ╰────
   help: Add `lang="en"` (or the appropriate language code).
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.
-    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:10:2]
-  9 │ <!-- Case-insensitive tag name -->
- 10 │ <HTML>
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:11:2]
+ 10 │ <!-- Case-insensitive tag name -->
+ 11 │ <HTML>
     ·  ──┬─
     ·    ╰── here
- 11 │ </HTML>
+ 12 │ </HTML>
     ╰────
   help: Add `lang="en"` (or the appropriate language code).
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.
-    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:15:6]
- 14 │ {% if base_template %}
- 15 │     <html>
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:16:6]
+ 15 │ {% if base_template %}
+ 16 │     <html>
     ·      ──┬─
     ·        ╰── here
- 16 │     </html>
+ 17 │     </html>
     ╰────
   help: Add `lang="en"` (or the appropriate language code).
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.
-    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:20:2]
- 19 │ <!-- Multi-line opening tag with no lang -->
- 20 │ <html
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:21:2]
+ 20 │ <!-- Multi-line opening tag with no lang -->
+ 21 │ <html
     ·  ──┬─
     ·    ╰── here
- 21 │     xmlns="http://www.w3.org/1999/xhtml"
+ 22 │     xmlns="http://www.w3.org/1999/xhtml"
     ╰────
   help: Add `lang="en"` (or the appropriate language code).
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.
-    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:26:2]
- 25 │ <!-- XHTML `xml:lang` alone: HTML5 ignores it; screen readers need `lang` -->
- 26 │ <html xml:lang="en">
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:27:2]
+ 26 │ <!-- XHTML `xml:lang` alone: HTML5 ignores it; screen readers need `lang` -->
+ 27 │ <html xml:lang="en">
     ·  ──┬─
     ·    ╰── here
- 27 │ </html>
+ 28 │ </html>
     ╰────
   help: Add `lang="en"` (or the appropriate language code).

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.valid.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- Plain `lang` attribute -->
 <html lang="en">
 </html>


### PR DESCRIPTION
## What it does
Checks for HTML documents that contain an `<html>` tag but no `<!DOCTYPE html>` declaration.

## Why is this bad?
HTML5 requires a DOCTYPE declaration at the top of every document. Without it, browsers fall back to "quirks mode", which emulates legacy rendering bugs and applies different CSS box-model rules. The result is inconsistent layout across browsers and behaviour that is hard to debug.

Template partials (files that `{% extends %}` a base or whose root is a `{% block %}`) are assumed to inherit the DOCTYPE from their parent template and are not flagged.

## Example
```html
<html lang="en">
  <head><title>Page</title></head>
  <body>Content</body>
</html>
```

Use instead:
```html
<!DOCTYPE html>
<html lang="en">
  <head><title>Page</title></head>
  <body>Content</body>
</html>
```

## References
- [HTML spec: The DOCTYPE](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype)
- [MDN: Doctype](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)

Part of #231 