### PR TITLE
feat(lint): Add `django-static-url` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -105,6 +105,10 @@ impl<'a> Checker<'a> {
             rules::style::redundant_type_attr::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::DjangoStaticUrl) {
+            rules::suspicious::django_static_url::check(element, self);
+        }
+
         if self.is_rule_enabled(Rule::JavascriptUrl) {
             rules::suspicious::javascript_url::check(element, self);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -244,6 +244,7 @@ define_rules! {
     (UntrimmedBlocktranslate, rules::correctness::untrimmed_blocktranslate::UntrimmedBlocktranslate),
     (EmptyAttrValue, rules::style::empty_attr_value::EmptyAttrValue<'static>),
     (RedundantTypeAttr, rules::style::redundant_type_attr::RedundantTypeAttr),
+    (DjangoStaticUrl, rules::suspicious::django_static_url::DjangoStaticUrl),
     (JavascriptUrl, rules::suspicious::javascript_url::JavascriptUrl),
     (DuplicateAttr, rules::suspicious::duplicate_attr::DuplicateAttr),
     (UseHttps, rules::suspicious::use_https::UseHttps),

--- a/crates/djangofmt_lint/src/rules/helpers.rs
+++ b/crates/djangofmt_lint/src/rules/helpers.rs
@@ -6,6 +6,23 @@ pub fn contains_interpolation(value: &str) -> bool {
     value.contains("{{") || value.contains("{%")
 }
 
+/// Yields each `srcset` candidate URL with its byte offset in the source.
+///
+/// `srcset` holds a comma-separated list of candidates, each `<url> <descriptor>`
+/// (e.g. `a.png 1x, b.png 2x`); the URL is the first whitespace-delimited token of
+/// each candidate. `base` is the byte offset of `value` in the source, so the
+/// yielded offset points at the candidate URL itself.
+pub fn srcset_candidates(value: &str, base: usize) -> impl Iterator<Item = (&str, usize)> {
+    let mut pos = 0;
+    value.split(',').filter_map(move |candidate| {
+        let start = pos;
+        pos += candidate.len() + 1; // skip the candidate and its `,`
+        let trimmed = candidate.trim_start_matches(|c: char| c.is_ascii_whitespace());
+        let url = trimmed.split_ascii_whitespace().next()?;
+        Some((url, base + start + candidate.len() - trimmed.len()))
+    })
+}
+
 /// Walk backwards from `offset` over ASCII whitespace bytes in `source`,
 /// returning the offset of the first non-whitespace byte.
 ///

--- a/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
@@ -1,0 +1,116 @@
+use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::{contains_interpolation, srcset_candidates};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for asset URLs in `<link>`, `<img>`, `<script>`, and `<source>` elements that point at a
+/// hardcoded `static/` path instead of going through Django's `{% static %}` template tag.
+///
+/// ## Why is this bad?
+/// Hardcoding `/static/...` couples templates to a single value of Django's `STATIC_URL` setting.
+/// Projects that serve assets from a CDN, version assets with `ManifestStaticFilesStorage`, or
+/// mount static files under a different prefix end up with broken or unfingerprinted URLs. The
+/// `{% static %}` tag resolves the configured storage backend at render time, so the same template
+/// works across environments.
+///
+/// ## Example
+/// ```html
+/// <link rel="stylesheet" href="/static/css/app.css">
+/// <img src="static/img/logo.png">
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {% load static %}
+/// <link rel="stylesheet" href="{% static 'css/app.css' %}">
+/// <img src="{% static 'img/logo.png' %}">
+/// ```
+///
+/// ## References
+/// - [Django: managing static files](https://docs.djangoproject.com/en/stable/howto/static-files/)
+/// - [Django: the `{% static %}` template tag](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#static)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct DjangoStaticUrl {
+    pub attribute: &'static str,
+}
+
+impl Violation for DjangoStaticUrl {
+    const RULE: Rule = Rule::DjangoStaticUrl;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hardcoded static path in `{}`.", self.attribute)
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Use `{% static 'path/to/file' %}` instead.".to_string())
+    }
+}
+
+const URL_ATTRIBUTES: &[&str] = &["href", "src", "srcset"];
+
+const fn is_asset_tag(tag_name: &str) -> bool {
+    tag_name.eq_ignore_ascii_case("link")
+        || tag_name.eq_ignore_ascii_case("img")
+        || tag_name.eq_ignore_ascii_case("script")
+        || tag_name.eq_ignore_ascii_case("source")
+}
+
+/// Returns `true` when `value` starts with `static/` or `/static/`.
+fn starts_with_static_path(value: &str) -> bool {
+    let rest = value.strip_prefix('/').unwrap_or(value);
+    let Some(after) = rest.strip_prefix("static") else {
+        return false;
+    };
+    // Require the segment boundary so we don't flag e.g. `staticpages/`.
+    matches!(after.as_bytes().first(), Some(b'/'))
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if !is_asset_tag(element.tag_name) {
+        return;
+    }
+    for attr in &element.attrs {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            ..
+        }) = attr
+        else {
+            continue;
+        };
+        let Some(canonical) = URL_ATTRIBUTES
+            .iter()
+            .copied()
+            .find(|candidate| candidate.eq_ignore_ascii_case(name))
+        else {
+            continue;
+        };
+
+        // `srcset` is a comma-separated candidate list; every other attribute
+        // holds a single URL.
+        if canonical == "srcset" {
+            for (url, at) in srcset_candidates(value_str, *offset) {
+                report_static_path(url, at, canonical, checker);
+            }
+        } else {
+            report_static_path(value_str, *offset, canonical, checker);
+        }
+    }
+}
+
+/// Reports a URL that points at a hardcoded `static/` path.
+/// `offset` is the byte offset of `url` in the source.
+fn report_static_path(url: &str, offset: usize, attribute: &'static str, checker: &Checker<'_>) {
+    if contains_interpolation(url) {
+        return;
+    }
+    if starts_with_static_path(url) {
+        checker.report_diagnostic(&DjangoStaticUrl { attribute }, (offset, url.len()).into());
+    }
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
@@ -10,11 +10,9 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// hardcoded `static/` path instead of going through Django's `{% static %}` template tag.
 ///
 /// ## Why is this bad?
-/// Hardcoding `/static/...` couples templates to a single value of Django's `STATIC_URL` setting.
+/// Hardcoding `/static` couples templates to a single value of Django's `STATIC_URL` setting.
 /// Projects that serve assets from a CDN, version assets with `ManifestStaticFilesStorage`, or
-/// mount static files under a different prefix end up with broken or unfingerprinted URLs. The
-/// `{% static %}` tag resolves the configured storage backend at render time, so the same template
-/// works across environments.
+/// mount static files under a different prefix end up with broken URLs.
 ///
 /// ## Example
 /// ```html
@@ -72,9 +70,11 @@ fn starts_with_static_path(value: &str) -> bool {
 }
 
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    // Fast-path to skip processing tag that cannot have a static url.
     if !is_asset_tag(element.tag_name) {
         return;
     }
+
     for attr in &element.attrs {
         let Attribute::Native(NativeAttribute {
             name,
@@ -84,9 +84,9 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         else {
             continue;
         };
+
         let Some(canonical) = URL_ATTRIBUTES
             .iter()
-            .copied()
             .find(|candidate| candidate.eq_ignore_ascii_case(name))
         else {
             continue;
@@ -94,7 +94,7 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
 
         // `srcset` is a comma-separated candidate list; every other attribute
         // holds a single URL.
-        if canonical == "srcset" {
+        if *canonical == "srcset" {
             for (url, at) in srcset_candidates(value_str, *offset) {
                 report_static_path(url, at, canonical, checker);
             }

--- a/crates/djangofmt_lint/src/rules/suspicious/mod.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/mod.rs
@@ -1,3 +1,4 @@
+pub mod django_static_url;
 pub mod duplicate_attr;
 pub mod javascript_url;
 pub mod use_https;

--- a/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
@@ -5,6 +5,7 @@ use markup_fmt::ast::{Attribute, Element, NativeAttribute};
 use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::srcset_candidates;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 
 /// ## What it does
@@ -104,19 +105,6 @@ fn canonical_url_attr(name: &str) -> Option<&'static str> {
         .iter()
         .copied()
         .find(|c| c.eq_ignore_ascii_case(name))
-}
-
-/// Yields each `srcset` candidate URL with its byte offset in the source.
-/// Candidates are comma-separated; the URL is the first token of each.
-fn srcset_candidates(value: &str, base: usize) -> impl Iterator<Item = (&str, usize)> {
-    let mut pos = 0;
-    value.split(',').filter_map(move |candidate| {
-        let start = pos;
-        pos += candidate.len() + 1; // skip the candidate and its `,`
-        let trimmed = candidate.trim_start_matches(|c: char| c.is_ascii_whitespace());
-        let url = trimmed.split_ascii_whitespace().next()?;
-        Some((url, base + start + candidate.len() - trimmed.len()))
-    })
 }
 
 /// Reports (and offers a fix for) a URL that uses the insecure `http://` scheme.

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.html
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.html
@@ -1,0 +1,31 @@
+<!-- link/href -->
+<link rel="stylesheet" href="/static/css/app.css">
+<link rel="stylesheet" href='/static/css/app.css'>
+<link rel="stylesheet" href="static/css/app.css">
+
+<!-- img/src -->
+<img src="/static/img/logo.png">
+<img src='/static/img/logo.png'>
+<img src="static/img/logo.png">
+
+<!-- script/src -->
+<script src="/static/js/app.js"></script>
+
+<!-- source/src and source/srcset -->
+<source src="/static/audio/clip.mp3">
+<source srcset="/static/img/picture.webp">
+
+<!-- srcset: each candidate is scanned, even when the hardcoded path is not first -->
+<img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+<source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
+
+<!-- Case-insensitive tag name -->
+<IMG src="/static/img/logo.png">
+
+<!-- Case-insensitive attribute name -->
+<img SRC="/static/img/logo.png">
+
+<!-- Inside a Jinja block -->
+{% if show_logo %}
+    <img src="/static/img/logo.png">
+{% endif %}

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
@@ -1,0 +1,169 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 15 lint error(s)
+
+Error: 
+  × Hardcoded static path in `href`.
+   ╭─[tests/check/django_static_url/django_static_url.invalid.html:2:30]
+ 1 │ <!-- link/href -->
+ 2 │ <link rel="stylesheet" href="/static/css/app.css">
+   ·                              ─────────┬─────────
+   ·                                       ╰── here
+ 3 │ <link rel="stylesheet" href='/static/css/app.css'>
+   ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `href`.
+   ╭─[tests/check/django_static_url/django_static_url.invalid.html:3:30]
+ 2 │ <link rel="stylesheet" href="/static/css/app.css">
+ 3 │ <link rel="stylesheet" href='/static/css/app.css'>
+   ·                              ─────────┬─────────
+   ·                                       ╰── here
+ 4 │ <link rel="stylesheet" href="static/css/app.css">
+   ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `href`.
+   ╭─[tests/check/django_static_url/django_static_url.invalid.html:4:30]
+ 3 │ <link rel="stylesheet" href='/static/css/app.css'>
+ 4 │ <link rel="stylesheet" href="static/css/app.css">
+   ·                              ─────────┬────────
+   ·                                       ╰── here
+ 5 │ 
+   ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+   ╭─[tests/check/django_static_url/django_static_url.invalid.html:7:11]
+ 6 │ <!-- img/src -->
+ 7 │ <img src="/static/img/logo.png">
+   ·           ──────────┬─────────
+   ·                     ╰── here
+ 8 │ <img src='/static/img/logo.png'>
+   ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+   ╭─[tests/check/django_static_url/django_static_url.invalid.html:8:11]
+ 7 │ <img src="/static/img/logo.png">
+ 8 │ <img src='/static/img/logo.png'>
+   ·           ──────────┬─────────
+   ·                     ╰── here
+ 9 │ <img src="static/img/logo.png">
+   ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:9:11]
+  8 │ <img src='/static/img/logo.png'>
+  9 │ <img src="static/img/logo.png">
+    ·           ─────────┬─────────
+    ·                    ╰── here
+ 10 │ 
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:12:14]
+ 11 │ <!-- script/src -->
+ 12 │ <script src="/static/js/app.js"></script>
+    ·              ────────┬────────
+    ·                      ╰── here
+ 13 │ 
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:15:14]
+ 14 │ <!-- source/src and source/srcset -->
+ 15 │ <source src="/static/audio/clip.mp3">
+    ·              ───────────┬──────────
+    ·                         ╰── here
+ 16 │ <source srcset="/static/img/picture.webp">
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `srcset`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:16:17]
+ 15 │ <source src="/static/audio/clip.mp3">
+ 16 │ <source srcset="/static/img/picture.webp">
+    ·                 ────────────┬───────────
+    ·                             ╰── here
+ 17 │ 
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `srcset`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:19:51]
+ 18 │ <!-- srcset: each candidate is scanned, even when the hardcoded path is not first -->
+ 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+    ·                                                   ───────────┬───────────
+    ·                                                              ╰── here
+ 20 │ <source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `srcset`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:20:17]
+ 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+ 20 │ <source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
+    ·                 ──────────┬──────────
+    ·                           ╰── here
+ 21 │ 
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `srcset`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:20:45]
+ 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+ 20 │ <source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
+    ·                                             ──────────┬──────────
+    ·                                                       ╰── here
+ 21 │ 
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:23:11]
+ 22 │ <!-- Case-insensitive tag name -->
+ 23 │ <IMG src="/static/img/logo.png">
+    ·           ──────────┬─────────
+    ·                     ╰── here
+ 24 │ 
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:26:11]
+ 25 │ <!-- Case-insensitive attribute name -->
+ 26 │ <img SRC="/static/img/logo.png">
+    ·           ──────────┬─────────
+    ·                     ╰── here
+ 27 │ 
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.
+
+Error: 
+  × Hardcoded static path in `src`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:30:15]
+ 29 │ {% if show_logo %}
+ 30 │     <img src="/static/img/logo.png">
+    ·               ──────────┬─────────
+    ·                         ╰── here
+ 31 │ {% endif %}
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.valid.html
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.valid.html
@@ -1,0 +1,40 @@
+<!-- Correct {% static %} usage -->
+{% load static %}
+<link rel="stylesheet" href="{% static 'css/app.css' %}">
+<img src="{% static 'img/logo.png' %}">
+<script src="{% static 'js/app.js' %}"></script>
+<source srcset="{% static 'img/picture.webp' %}">
+
+<!-- Interpolated values are dynamic -->
+<link rel="stylesheet" href="{{ asset_url }}">
+<img src="{{ static_url }}/img/logo.png">
+<img src="{% if x %}/static/a.png{% else %}/static/b.png{% endif %}">
+
+<!-- srcset: multi-candidate lists with no hardcoded static path -->
+<img srcset="https://cdn.example.com/a.png 1x, https://cdn.example.com/b.png 2x">
+<img srcset="{% static 'img/a.png' %} 1x, {% static 'img/b.png' %} 2x">
+
+<!-- External absolute URLs -->
+<link rel="stylesheet" href="https://cdn.example.com/static/app.css">
+<img src="https://example.com/static/logo.png">
+<script src="//cdn.example.com/js/app.js"></script>
+
+<!-- Other absolute paths that look similar but are not under /static/ -->
+<img src="/staticpages/intro.png">
+<img src="/media/uploads/avatar.png">
+<link rel="icon" href="/favicon.ico">
+
+<!-- Path is case-sensitive: only lowercase `static/` is the documented prefix -->
+<img src="/Static/img/logo.png">
+<img src="/STATIC/img/logo.png">
+
+<!-- href without a value -->
+<link href>
+
+<!-- Tags outside the asset-element scope: same attribute, different element -->
+<a href="/static/docs.pdf">Static doc</a>
+<iframe src="/static/inner.html"></iframe>
+
+<!-- Attributes outside the URL-attribute scope on in-scope tags -->
+<link rel="canonical" data-url="/static/page.html">
+<img alt="/static/img/logo.png">

--- a/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.html
@@ -8,7 +8,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <link rel="stylesheet" href="/static/app.css">
+        <link rel="stylesheet" href="{% static 'app.css' %}">
     </head>
 </html>
 

--- a/crates/djangofmt_lint/tests/check/missing_title/missing_title.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_title/missing_title.valid.html
@@ -17,7 +17,7 @@
     <head>
         <meta charset="utf-8">
         <title>My page</title>
-        <link rel="stylesheet" href="/static/app.css">
+        <link rel="stylesheet" href="{% static 'app.css' %}">
     </head>
 </html>
 

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
@@ -14,7 +14,7 @@
 <!-- Relative and root-relative URLs -->
 <a href="/page/">Link</a>
 <a href="page.html">Link</a>
-<img src="/static/logo.png">
+<img src="/assets/logo.png">
 
 <!-- Protocol-relative URLs (caller defers to surrounding page scheme) -->
 <img src="//cdn.example.com/logo.png">


### PR DESCRIPTION
## What it does
Checks for asset URLs in `<link>`, `<img>`, `<script>`, and `<source>` elements that point at a hardcoded `static/` path instead of going through Django's `{% static %}` template tag.

## Why is this bad?
Hardcoding `/static/...` couples templates to a single value of Django's `STATIC_URL` setting. Projects that serve assets from a CDN, version assets with `ManifestStaticFilesStorage`, or mount static files under a different prefix end up with broken or unfingerprinted URLs. The `{% static %}` tag resolves the configured storage backend at render time, so the same template works across environments.

## Example
```html
<link rel="stylesheet" href="/static/css/app.css">
<img src="static/img/logo.png">
```

Use instead:
```html
{% load static %}
<link rel="stylesheet" href="{% static 'css/app.css' %}">
<img src="{% static 'img/logo.png' %}">
```

## References
- [Django: managing static files](https://docs.djangoproject.com/en/stable/howto/static-files/)
- [Django: the `{% static %}` template tag](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#static)

Part of #231 