### PR TITLE
feat(lint): Add `missing-img-alt` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -137,6 +137,10 @@ impl<'a> Checker<'a> {
             rules::accessibility::missing_title::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::MissingImgAlt) {
+            rules::accessibility::missing_img_alt::check(element, self);
+        }
+
         for attr in &element.attrs {
             self.visit_attribute(attr);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -253,4 +253,5 @@ define_rules! {
     (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),
     (MissingDoctype, rules::style::missing_doctype::MissingDoctype),
     (MissingTitle, rules::accessibility::missing_title::MissingTitle),
+    (MissingImgAlt, rules::accessibility::missing_img_alt::MissingImgAlt),
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_img_alt.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_img_alt.rs
@@ -1,0 +1,63 @@
+use markup_fmt::ast::Element;
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::declares_native_attr;
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for `<img>` tags that do not declare an `alt` attribute.
+///
+/// ## Why is this bad?
+/// The `alt` attribute provides a textual alternative for screen readers and is rendered when the
+/// image cannot be loaded. Without it, assistive technologies have no way to describe the image to
+/// the user.
+/// Decorative images should declare `alt=""` so screen readers skip them.
+///
+/// ## Example
+/// ```html
+/// <img src="photo.jpg">
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <img src="photo.jpg" alt="A photo of the team">
+/// ```
+///
+/// ## References
+/// - [MDN: HTML `alt` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt)
+/// - [WCAG 1.1.1: Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct MissingImgAlt;
+
+impl Violation for MissingImgAlt {
+    const RULE: Rule = Rule::MissingImgAlt;
+    const CATEGORY: RuleCategory = RuleCategory::Accessibility;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "`<img>` tag should declare an `alt` attribute.".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Add `alt=\"\"` for decorative images, or a short description otherwise.".to_string())
+    }
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if !element.tag_name.eq_ignore_ascii_case("img") {
+        return;
+    }
+
+    if element
+        .attrs
+        .iter()
+        .any(|attr| declares_native_attr(attr, "alt"))
+    {
+        return;
+    }
+
+    let offset = checker.source_offset(element.tag_name);
+    checker.report_diagnostic(&MissingImgAlt, (offset, element.tag_name.len()).into());
+}

--- a/crates/djangofmt_lint/src/rules/accessibility/mod.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/mod.rs
@@ -1,2 +1,3 @@
 pub mod missing_html_lang;
+pub mod missing_img_alt;
 pub mod missing_title;

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.html
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.html
@@ -4,9 +4,9 @@
 <link rel="stylesheet" href="static/css/app.css">
 
 <!-- img/src -->
-<img src="/static/img/logo.png">
-<img src='/static/img/logo.png'>
-<img src="static/img/logo.png">
+<img src="/static/img/logo.png" alt="" width="0" height="0">
+<img src='/static/img/logo.png' alt="" width="0" height="0">
+<img src="static/img/logo.png" alt="" width="0" height="0">
 
 <!-- script/src -->
 <script src="/static/js/app.js"></script>
@@ -16,16 +16,16 @@
 <source srcset="/static/img/picture.webp">
 
 <!-- srcset: each candidate is scanned, even when the hardcoded path is not first -->
-<img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+<img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x" alt="" width="0" height="0">
 <source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
 
 <!-- Case-insensitive tag name -->
-<IMG src="/static/img/logo.png">
+<IMG src="/static/img/logo.png" alt="" width="0" height="0">
 
 <!-- Case-insensitive attribute name -->
-<img SRC="/static/img/logo.png">
+<img SRC="/static/img/logo.png" alt="" width="0" height="0">
 
 <!-- Inside a Jinja block -->
 {% if show_logo %}
-    <img src="/static/img/logo.png">
+    <img src="/static/img/logo.png" alt="" width="0" height="0">
 {% endif %}

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
@@ -40,29 +40,29 @@ Error:
   × Hardcoded static path in `src`.
    ╭─[tests/check/django_static_url/django_static_url.invalid.html:7:11]
  6 │ <!-- img/src -->
- 7 │ <img src="/static/img/logo.png">
+ 7 │ <img src="/static/img/logo.png" alt="" width="0" height="0">
    ·           ──────────┬─────────
    ·                     ╰── here
- 8 │ <img src='/static/img/logo.png'>
+ 8 │ <img src='/static/img/logo.png' alt="" width="0" height="0">
    ╰────
   help: Use `{% static 'path/to/file' %}` instead.
 
 Error: 
   × Hardcoded static path in `src`.
    ╭─[tests/check/django_static_url/django_static_url.invalid.html:8:11]
- 7 │ <img src="/static/img/logo.png">
- 8 │ <img src='/static/img/logo.png'>
+ 7 │ <img src="/static/img/logo.png" alt="" width="0" height="0">
+ 8 │ <img src='/static/img/logo.png' alt="" width="0" height="0">
    ·           ──────────┬─────────
    ·                     ╰── here
- 9 │ <img src="static/img/logo.png">
+ 9 │ <img src="static/img/logo.png" alt="" width="0" height="0">
    ╰────
   help: Use `{% static 'path/to/file' %}` instead.
 
 Error: 
   × Hardcoded static path in `src`.
     ╭─[tests/check/django_static_url/django_static_url.invalid.html:9:11]
-  8 │ <img src='/static/img/logo.png'>
-  9 │ <img src="static/img/logo.png">
+  8 │ <img src='/static/img/logo.png' alt="" width="0" height="0">
+  9 │ <img src="static/img/logo.png" alt="" width="0" height="0">
     ·           ─────────┬─────────
     ·                    ╰── here
  10 │ 
@@ -106,7 +106,7 @@ Error:
   × Hardcoded static path in `srcset`.
     ╭─[tests/check/django_static_url/django_static_url.invalid.html:19:51]
  18 │ <!-- srcset: each candidate is scanned, even when the hardcoded path is not first -->
- 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+ 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x" alt="" width="0" height="0">
     ·                                                   ───────────┬───────────
     ·                                                              ╰── here
  20 │ <source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
@@ -116,7 +116,7 @@ Error:
 Error: 
   × Hardcoded static path in `srcset`.
     ╭─[tests/check/django_static_url/django_static_url.invalid.html:20:17]
- 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+ 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x" alt="" width="0" height="0">
  20 │ <source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
     ·                 ──────────┬──────────
     ·                           ╰── here
@@ -127,7 +127,7 @@ Error:
 Error: 
   × Hardcoded static path in `srcset`.
     ╭─[tests/check/django_static_url/django_static_url.invalid.html:20:45]
- 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x">
+ 19 │ <img srcset="https://cdn.example.com/logo.png 1x, /static/img/logo@2x.png 2x" alt="" width="0" height="0">
  20 │ <source srcset="static/img/small.webp 480w, static/img/large.webp 1024w">
     ·                                             ──────────┬──────────
     ·                                                       ╰── here
@@ -139,7 +139,7 @@ Error:
   × Hardcoded static path in `src`.
     ╭─[tests/check/django_static_url/django_static_url.invalid.html:23:11]
  22 │ <!-- Case-insensitive tag name -->
- 23 │ <IMG src="/static/img/logo.png">
+ 23 │ <IMG src="/static/img/logo.png" alt="" width="0" height="0">
     ·           ──────────┬─────────
     ·                     ╰── here
  24 │ 
@@ -150,7 +150,7 @@ Error:
   × Hardcoded static path in `src`.
     ╭─[tests/check/django_static_url/django_static_url.invalid.html:26:11]
  25 │ <!-- Case-insensitive attribute name -->
- 26 │ <img SRC="/static/img/logo.png">
+ 26 │ <img SRC="/static/img/logo.png" alt="" width="0" height="0">
     ·           ──────────┬─────────
     ·                     ╰── here
  27 │ 
@@ -161,7 +161,7 @@ Error:
   × Hardcoded static path in `src`.
     ╭─[tests/check/django_static_url/django_static_url.invalid.html:30:15]
  29 │ {% if show_logo %}
- 30 │     <img src="/static/img/logo.png">
+ 30 │     <img src="/static/img/logo.png" alt="" width="0" height="0">
     ·               ──────────┬─────────
     ·                         ╰── here
  31 │ {% endif %}

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.valid.html
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.valid.html
@@ -1,32 +1,32 @@
 <!-- Correct {% static %} usage -->
 {% load static %}
 <link rel="stylesheet" href="{% static 'css/app.css' %}">
-<img src="{% static 'img/logo.png' %}">
+<img src="{% static 'img/logo.png' %}" alt="" width="0" height="0">
 <script src="{% static 'js/app.js' %}"></script>
 <source srcset="{% static 'img/picture.webp' %}">
 
 <!-- Interpolated values are dynamic -->
 <link rel="stylesheet" href="{{ asset_url }}">
-<img src="{{ static_url }}/img/logo.png">
-<img src="{% if x %}/static/a.png{% else %}/static/b.png{% endif %}">
+<img src="{{ static_url }}/img/logo.png" alt="" width="0" height="0">
+<img src="{% if x %}/static/a.png{% else %}/static/b.png{% endif %}" alt="" width="0" height="0">
 
 <!-- srcset: multi-candidate lists with no hardcoded static path -->
-<img srcset="https://cdn.example.com/a.png 1x, https://cdn.example.com/b.png 2x">
-<img srcset="{% static 'img/a.png' %} 1x, {% static 'img/b.png' %} 2x">
+<img srcset="https://cdn.example.com/a.png 1x, https://cdn.example.com/b.png 2x" alt="" width="0" height="0">
+<img srcset="{% static 'img/a.png' %} 1x, {% static 'img/b.png' %} 2x" alt="" width="0" height="0">
 
 <!-- External absolute URLs -->
 <link rel="stylesheet" href="https://cdn.example.com/static/app.css">
-<img src="https://example.com/static/logo.png">
+<img src="https://example.com/static/logo.png" alt="" width="0" height="0">
 <script src="//cdn.example.com/js/app.js"></script>
 
 <!-- Other absolute paths that look similar but are not under /static/ -->
-<img src="/staticpages/intro.png">
-<img src="/media/uploads/avatar.png">
+<img src="/staticpages/intro.png" alt="" width="0" height="0">
+<img src="/media/uploads/avatar.png" alt="" width="0" height="0">
 <link rel="icon" href="/favicon.ico">
 
 <!-- Path is case-sensitive: only lowercase `static/` is the documented prefix -->
-<img src="/Static/img/logo.png">
-<img src="/STATIC/img/logo.png">
+<img src="/Static/img/logo.png" alt="" width="0" height="0">
+<img src="/STATIC/img/logo.png" alt="" width="0" height="0">
 
 <!-- href without a value -->
 <link href>

--- a/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.html
+++ b/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.html
@@ -14,7 +14,7 @@
 <input type="text" type="email" type="search">
 
 <!-- Alpine-style duplicate (same prefix on both, real duplicate) -->
-<img :src="img.jpg" :src="isLoaded ? url : defaultValue" />
+<img :src="img.jpg" :src="isLoaded ? url : defaultValue" alt="" width="0" height="0" />
 
 <!-- Boolean attributes still count -->
 <input disabled disabled>

--- a/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.invalid.snap
@@ -73,7 +73,7 @@ Error:
   × Duplicate attribute `:src`.
     ╭─[tests/check/duplicate_attr/duplicate_attr.invalid.html:17:21]
  16 │ <!-- Alpine-style duplicate (same prefix on both, real duplicate) -->
- 17 │ <img :src="img.jpg" :src="isLoaded ? url : defaultValue" />
+ 17 │ <img :src="img.jpg" :src="isLoaded ? url : defaultValue" alt="" width="0" height="0" />
     ·                     ──┬─
     ·                       ╰── here
  18 │ 

--- a/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.valid.html
+++ b/crates/djangofmt_lint/tests/check/duplicate_attr/duplicate_attr.valid.html
@@ -15,7 +15,7 @@
 
 <!-- AlpineJS attributes with `:`/`x-bind:` prefix are distinct names from the
      underlying HTML attribute. -->
-<img src="img.jpg" :src="isLoaded ? url : defaultValue" />
+<img src="img.jpg" :src="isLoaded ? url : defaultValue" alt="" width="0" height="0" />
 <tbody class="bg-white" x-bind:class="open ? 'bg-gray-50' : ''"></tbody>
 
 <!-- `key=value` text inside an attribute value is not a separate attribute

--- a/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.invalid.html
@@ -1,0 +1,33 @@
+<!-- No attributes at all -->
+<img>
+
+<!-- Self-closing without alt -->
+<img src="photo.jpg" />
+
+<!-- Multiple attributes but no alt -->
+<img src="photo.jpg" class="hero" id="main-image" loading="lazy" />
+
+<!-- Case-insensitive tag name -->
+<IMG src="photo.jpg" />
+
+<!-- Multi-line opening tag with no alt -->
+<img
+    src="photo.jpg"
+    height="12"
+    width="12"
+/>
+
+<!-- Nested in a Jinja block -->
+{% if show_image %}
+    <img src="photo.jpg" />
+{% endif %}
+
+<!-- Inside a <picture> the <img> still needs alt -->
+<picture>
+    <source srcset="photo.avif" type="image/avif" />
+    <img src="photo.jpg" />
+</picture>
+
+<!-- `aria-hidden`/`role="presentation"` do not substitute for alt -->
+<img src="decorative.png" aria-hidden="true" />
+<img src="decorative.png" role="presentation" />

--- a/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.invalid.snap
@@ -1,0 +1,102 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 9 lint error(s)
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+   ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:2:2]
+ 1 │ <!-- No attributes at all -->
+ 2 │ <img>
+   ·  ─┬─
+   ·   ╰── here
+ 3 │ 
+   ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+   ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:5:2]
+ 4 │ <!-- Self-closing without alt -->
+ 5 │ <img src="photo.jpg" />
+   ·  ─┬─
+   ·   ╰── here
+ 6 │ 
+   ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+   ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:8:2]
+ 7 │ <!-- Multiple attributes but no alt -->
+ 8 │ <img src="photo.jpg" class="hero" id="main-image" loading="lazy" />
+   ·  ─┬─
+   ·   ╰── here
+ 9 │ 
+   ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+    ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:11:2]
+ 10 │ <!-- Case-insensitive tag name -->
+ 11 │ <IMG src="photo.jpg" />
+    ·  ─┬─
+    ·   ╰── here
+ 12 │ 
+    ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+    ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:14:2]
+ 13 │ <!-- Multi-line opening tag with no alt -->
+ 14 │ <img
+    ·  ─┬─
+    ·   ╰── here
+ 15 │     src="photo.jpg"
+    ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+    ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:22:6]
+ 21 │ {% if show_image %}
+ 22 │     <img src="photo.jpg" />
+    ·      ─┬─
+    ·       ╰── here
+ 23 │ {% endif %}
+    ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+    ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:28:6]
+ 27 │     <source srcset="photo.avif" type="image/avif" />
+ 28 │     <img src="photo.jpg" />
+    ·      ─┬─
+    ·       ╰── here
+ 29 │ </picture>
+    ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+    ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:32:2]
+ 31 │ <!-- `aria-hidden`/`role="presentation"` do not substitute for alt -->
+ 32 │ <img src="decorative.png" aria-hidden="true" />
+    ·  ─┬─
+    ·   ╰── here
+ 33 │ <img src="decorative.png" role="presentation" />
+    ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.
+
+Error: 
+  × `<img>` tag should declare an `alt` attribute.
+    ╭─[tests/check/missing_img_alt/missing_img_alt.invalid.html:33:2]
+ 32 │ <img src="decorative.png" aria-hidden="true" />
+ 33 │ <img src="decorative.png" role="presentation" />
+    ·  ─┬─
+    ·   ╰── here
+    ╰────
+  help: Add `alt=""` for decorative images, or a short description otherwise.

--- a/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.valid.html
@@ -1,0 +1,44 @@
+<!-- Plain `alt` attribute -->
+<img src="photo.jpg" alt="A photo of the team" />
+
+<!-- Empty `alt` marks the image as decorative (WCAG H67) -->
+<img src="decorative.png" alt="" width="0" height="0" />
+
+<!-- Whitespace-only `alt` (spacer image convention) -->
+<img src="spacer.gif" alt=" " />
+
+<!-- Case-insensitive attribute name -->
+<img src="photo.jpg" ALT="A photo" />
+<img src="photo.jpg" Alt="A photo" />
+
+<!-- Interpolated `alt` value -->
+<img src="photo.jpg" alt="{{ description }}" />
+<img src="photo.jpg" alt="{% if x %}photo{% else %}image{% endif %}" />
+
+<!-- `alt` declared inside a Jinja conditional -->
+<img src="photo.jpg" {% if decorative %}alt="" width="0" height="0"{% else %}alt="{{ description }}"{% endif %} />
+
+<!-- Boolean `alt` (no value) is equivalent to `alt="" width="0" height="0"` per HTML spec -->
+<img src="photo.jpg" alt />
+
+<!-- Multi-line opening tag with `alt` -->
+<img
+    src="photo.jpg"
+    alt="A photo of the team"
+    height="12"
+    width="12"
+/>
+
+<!-- `alt` inside <picture> -->
+<picture>
+    <source srcset="photo.avif" type="image/avif" />
+    <img src="photo.jpg" alt="A photo of the team" />
+</picture>
+
+<!-- Non-img tags are not checked: `<input type="image">`, `<area>`, `<object>` are out of scope -->
+<div></div>
+<picture></picture>
+<video src="video.mp4"></video>
+<input type="image" src="submit.png" />
+<map name="planets"><area shape="circle" coords="50,50,20" href="/mercury" /></map>
+<object data="diagram.svg" type="image/svg+xml"></object>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.fixed.snap
@@ -7,7 +7,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <a href='http://example.com'>Link</a>
 
 <!-- img/src -->
-<img src="http://example.com/logo.png">
+<img src="http://example.com/logo.png" alt="" width="0" height="0">
 
 <!-- form/action -->
 <form action="http://example.com/submit"></form>
@@ -15,7 +15,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- data-url, url, srcset -->
 <div data-url="http://example.com"></div>
 <a url="http://example.com">Link</a>
-<img srcset="http://example.com/a.png 1x">
+<img srcset="http://example.com/a.png 1x" alt="" width="0" height="0">
 
 <!-- script/src and link/href -->
 <script src="http://cdn.example.com/lib.js"></script>
@@ -27,7 +27,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 
 <!-- Case-insensitive attribute name -->
 <a HREF="http://example.com">Link</a>
-<IMG SrC="http://example.com/logo.png">
+<IMG SrC="http://example.com/logo.png" alt="" width="0" height="0">
 
 <!-- Leading whitespace before scheme -->
 <a href="  http://example.com">Link</a>
@@ -39,13 +39,13 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <a href="http://example.com" data-url="http://example.com">Link</a>
 
 <!-- srcset candidates are checked independently: every http:// entry is flagged -->
-<img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+<img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- srcset insecure candidate after a secure one — must still be flagged -->
-<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- srcset without descriptors, comma-separated -->
-<img srcset="http://example.com/a.png, http://example.com/b.png">
+<img srcset="http://example.com/a.png, http://example.com/b.png" alt="" width="0" height="0">
 
 <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
 <a href="http://{{ host }}/page">Link</a>
@@ -58,10 +58,10 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Real world example -->
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
-<img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+<img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" alt="" width="0" height="0">
 <script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script src="http://d3js.org/d3.v3.min.js"></script>
-<img src="http://stats.amusecode.org/piwik.php?idsite=1">
+<img src="http://stats.amusecode.org/piwik.php?idsite=1" alt="" width="0" height="0">
 <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
 
 <!-- Loopback look-alike are still flagged: the host only resembles localhost -->

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.html
@@ -4,7 +4,7 @@
 <a href='http://example.com'>Link</a>
 
 <!-- img/src -->
-<img src="http://example.com/logo.png">
+<img src="http://example.com/logo.png" alt="" width="0" height="0">
 
 <!-- form/action -->
 <form action="http://example.com/submit"></form>
@@ -12,7 +12,7 @@
 <!-- data-url, url, srcset -->
 <div data-url="http://example.com"></div>
 <a url="http://example.com">Link</a>
-<img srcset="http://example.com/a.png 1x">
+<img srcset="http://example.com/a.png 1x" alt="" width="0" height="0">
 
 <!-- script/src and link/href -->
 <script src="http://cdn.example.com/lib.js"></script>
@@ -24,7 +24,7 @@
 
 <!-- Case-insensitive attribute name -->
 <a HREF="http://example.com">Link</a>
-<IMG SrC="http://example.com/logo.png">
+<IMG SrC="http://example.com/logo.png" alt="" width="0" height="0">
 
 <!-- Leading whitespace before scheme -->
 <a href="  http://example.com">Link</a>
@@ -36,13 +36,13 @@
 <a href="http://example.com" data-url="http://example.com">Link</a>
 
 <!-- srcset candidates are checked independently: every http:// entry is flagged -->
-<img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+<img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- srcset insecure candidate after a secure one — must still be flagged -->
-<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+<img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- srcset without descriptors, comma-separated -->
-<img srcset="http://example.com/a.png, http://example.com/b.png">
+<img srcset="http://example.com/a.png, http://example.com/b.png" alt="" width="0" height="0">
 
 <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
 <a href="http://{{ host }}/page">Link</a>
@@ -55,10 +55,10 @@
 <!-- Real world example -->
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
-<img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+<img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" alt="" width="0" height="0">
 <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script src="http://d3js.org/d3.v3.min.js"></script>
-<img src="http://stats.amusecode.org/piwik.php?idsite=1">
+<img src="http://stats.amusecode.org/piwik.php?idsite=1" alt="" width="0" height="0">
 <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
 
 <!-- Loopback look-alike are still flagged: the host only resembles localhost -->

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.snap
@@ -40,7 +40,7 @@ Error:
   × Avoid `http://` URLs in `src`.
    ╭─[tests/check/use_https/use_https.invalid.html:7:11]
  6 │ <!-- img/src -->
- 7 │ <img src="http://example.com/logo.png">
+ 7 │ <img src="http://example.com/logo.png" alt="" width="0" height="0">
    ·           ───┬───
    ·              ╰── here
  8 │ 
@@ -76,7 +76,7 @@ Error:
  14 │ <a url="http://example.com">Link</a>
     ·         ───┬───
     ·            ╰── here
- 15 │ <img srcset="http://example.com/a.png 1x">
+ 15 │ <img srcset="http://example.com/a.png 1x" alt="" width="0" height="0">
     ╰────
   help: Use `https://` instead.
 
@@ -84,7 +84,7 @@ Error:
   × Avoid `http://` URLs in `srcset`.
     ╭─[tests/check/use_https/use_https.invalid.html:15:14]
  14 │ <a url="http://example.com">Link</a>
- 15 │ <img srcset="http://example.com/a.png 1x">
+ 15 │ <img srcset="http://example.com/a.png 1x" alt="" width="0" height="0">
     ·              ───┬───
     ·                 ╰── here
  16 │ 
@@ -142,7 +142,7 @@ Error:
  26 │ <a HREF="http://example.com">Link</a>
     ·          ───┬───
     ·             ╰── here
- 27 │ <IMG SrC="http://example.com/logo.png">
+ 27 │ <IMG SrC="http://example.com/logo.png" alt="" width="0" height="0">
     ╰────
   help: Use `https://` instead.
 
@@ -150,7 +150,7 @@ Error:
   × Avoid `http://` URLs in `src`.
     ╭─[tests/check/use_https/use_https.invalid.html:27:11]
  26 │ <a HREF="http://example.com">Link</a>
- 27 │ <IMG SrC="http://example.com/logo.png">
+ 27 │ <IMG SrC="http://example.com/logo.png" alt="" width="0" height="0">
     ·           ───┬───
     ·              ╰── here
  28 │ 
@@ -205,7 +205,7 @@ Error:
   × Avoid `http://` URLs in `srcset`.
     ╭─[tests/check/use_https/use_https.invalid.html:39:14]
  38 │ <!-- srcset candidates are checked independently: every http:// entry is flagged -->
- 39 │ <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+ 39 │ <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x" alt="" width="0" height="0">
     ·              ───┬───
     ·                 ╰── here
  40 │ 
@@ -216,7 +216,7 @@ Error:
   × Avoid `http://` URLs in `srcset`.
     ╭─[tests/check/use_https/use_https.invalid.html:39:43]
  38 │ <!-- srcset candidates are checked independently: every http:// entry is flagged -->
- 39 │ <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x">
+ 39 │ <img srcset="http://example.com/a.png 1x, http://example.com/b.png 2x" alt="" width="0" height="0">
     ·                                           ───┬───
     ·                                              ╰── here
  40 │ 
@@ -227,7 +227,7 @@ Error:
   × Avoid `http://` URLs in `srcset`.
     ╭─[tests/check/use_https/use_https.invalid.html:42:44]
  41 │ <!-- srcset insecure candidate after a secure one — must still be flagged -->
- 42 │ <img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x">
+ 42 │ <img srcset="https://example.com/a.png 1x, http://example.com/b.png 2x" alt="" width="0" height="0">
     ·                                            ───┬───
     ·                                               ╰── here
  43 │ 
@@ -238,7 +238,7 @@ Error:
   × Avoid `http://` URLs in `srcset`.
     ╭─[tests/check/use_https/use_https.invalid.html:45:14]
  44 │ <!-- srcset without descriptors, comma-separated -->
- 45 │ <img srcset="http://example.com/a.png, http://example.com/b.png">
+ 45 │ <img srcset="http://example.com/a.png, http://example.com/b.png" alt="" width="0" height="0">
     ·              ───┬───
     ·                 ╰── here
  46 │ 
@@ -249,7 +249,7 @@ Error:
   × Avoid `http://` URLs in `srcset`.
     ╭─[tests/check/use_https/use_https.invalid.html:45:40]
  44 │ <!-- srcset without descriptors, comma-separated -->
- 45 │ <img srcset="http://example.com/a.png, http://example.com/b.png">
+ 45 │ <img srcset="http://example.com/a.png, http://example.com/b.png" alt="" width="0" height="0">
     ·                                        ───┬───
     ·                                           ╰── here
  46 │ 
@@ -296,7 +296,7 @@ Error:
  57 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
     ·                        ───┬───
     ·                           ╰── here
- 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" alt="" width="0" height="0">
     ╰────
   help: Use `https://` instead.
 
@@ -304,7 +304,7 @@ Error:
   × Avoid `http://` URLs in `src`.
     ╭─[tests/check/use_https/use_https.invalid.html:58:11]
  57 │ <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
- 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" alt="" width="0" height="0">
     ·           ───┬───
     ·              ╰── here
  59 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
@@ -314,7 +314,7 @@ Error:
 Error: 
   × Redundant type="text/javascript" on <script> tag.
     ╭─[tests/check/use_https/use_https.invalid.html:59:15]
- 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" alt="" width="0" height="0">
  59 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
     ·               ───────┬───────
     ·                      ╰── here
@@ -325,7 +325,7 @@ Error:
 Error: 
   × Avoid `http://` URLs in `src`.
     ╭─[tests/check/use_https/use_https.invalid.html:59:51]
- 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+ 58 │ <img src="http://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" alt="" width="0" height="0">
  59 │ <script type="text/javascript" async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
     ·                                                   ───┬───
     ·                                                      ╰── here
@@ -340,7 +340,7 @@ Error:
  60 │ <script src="http://d3js.org/d3.v3.min.js"></script>
     ·              ───┬───
     ·                 ╰── here
- 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+ 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1" alt="" width="0" height="0">
     ╰────
   help: Use `https://` instead.
 
@@ -348,7 +348,7 @@ Error:
   × Avoid `http://` URLs in `src`.
     ╭─[tests/check/use_https/use_https.invalid.html:61:11]
  60 │ <script src="http://d3js.org/d3.v3.min.js"></script>
- 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+ 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1" alt="" width="0" height="0">
     ·           ───┬───
     ·              ╰── here
  62 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
@@ -358,7 +358,7 @@ Error:
 Error: 
   × Avoid `http://` URLs in `href`.
     ╭─[tests/check/use_https/use_https.invalid.html:62:10]
- 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1">
+ 61 │ <img src="http://stats.amusecode.org/piwik.php?idsite=1" alt="" width="0" height="0">
  62 │ <a href="http://stackoverflow.com/questions/tagged/django">Django questions</a>
     ·          ───┬───
     ·             ╰── here

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.invalid.unsafe-fixed.snap
@@ -7,7 +7,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <a href='https://example.com'>Link</a>
 
 <!-- img/src -->
-<img src="https://example.com/logo.png">
+<img src="https://example.com/logo.png" alt="" width="0" height="0">
 
 <!-- form/action -->
 <form action="https://example.com/submit"></form>
@@ -15,7 +15,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- data-url, url, srcset -->
 <div data-url="https://example.com"></div>
 <a url="https://example.com">Link</a>
-<img srcset="https://example.com/a.png 1x">
+<img srcset="https://example.com/a.png 1x" alt="" width="0" height="0">
 
 <!-- script/src and link/href -->
 <script src="https://cdn.example.com/lib.js"></script>
@@ -27,7 +27,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 
 <!-- Case-insensitive attribute name -->
 <a HREF="https://example.com">Link</a>
-<IMG SrC="https://example.com/logo.png">
+<IMG SrC="https://example.com/logo.png" alt="" width="0" height="0">
 
 <!-- Leading whitespace before scheme -->
 <a href="  https://example.com">Link</a>
@@ -39,13 +39,13 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <a href="https://example.com" data-url="https://example.com">Link</a>
 
 <!-- srcset candidates are checked independently: every http:// entry is flagged -->
-<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x">
+<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- srcset insecure candidate after a secure one — must still be flagged -->
-<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x">
+<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- srcset without descriptors, comma-separated -->
-<img srcset="https://example.com/a.png, https://example.com/b.png">
+<img srcset="https://example.com/a.png, https://example.com/b.png" alt="" width="0" height="0">
 
 <!-- Literal `http://` prefix followed by interpolation in the body is unambiguously insecure -->
 <a href="https://{{ host }}/page">Link</a>
@@ -58,10 +58,10 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Real world example -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
 <a rel="license" href="https://creativecommons.org/licenses/by-nc-nd/3.0/"></a>
-<img src="https://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png">
+<img src="https://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" alt="" width="0" height="0">
 <script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script src="https://d3js.org/d3.v3.min.js"></script>
-<img src="https://stats.amusecode.org/piwik.php?idsite=1">
+<img src="https://stats.amusecode.org/piwik.php?idsite=1" alt="" width="0" height="0">
 <a href="https://stackoverflow.com/questions/tagged/django">Django questions</a>
 
 <!-- Loopback look-alike are still flagged: the host only resembles localhost -->

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
@@ -1,23 +1,23 @@
 <!-- HTTPS URLs -->
 <a href="https://example.com">Link</a>
-<img src="https://example.com/logo.png">
+<img src="https://example.com/logo.png" alt="" width="0" height="0">
 <form action="https://example.com/submit"></form>
 <script src="https://cdn.example.com/lib.js"></script>
 <link href="https://cdn.example.com/style.css" rel="stylesheet">
 
 <!-- srcset with every candidate secure -->
-<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x">
+<img srcset="https://example.com/a.png 1x, https://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- srcset whose only http candidate points at a loopback host -->
-<img srcset="http://localhost:5173/a.png 1x, https://example.com/b.png 2x">
+<img srcset="http://localhost:5173/a.png 1x, https://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- Relative and root-relative URLs -->
 <a href="/page/">Link</a>
 <a href="page.html">Link</a>
-<img src="/assets/logo.png">
+<img src="/assets/logo.png" alt="" width="0" height="0">
 
 <!-- Protocol-relative URLs (caller defers to surrounding page scheme) -->
-<img src="//cdn.example.com/logo.png">
+<img src="//cdn.example.com/logo.png" alt="" width="0" height="0">
 <a href="//example.com">Link</a>
 
 <!-- Other schemes -->
@@ -63,6 +63,6 @@
 <!-- Loopback / localhost: http is fine here and https usually breaks local dev -->
 <a href="http://localhost:3000/admin">Admin</a>
 <script src="http://localhost:5173/@vite/client"></script>
-<img src="http://127.0.0.1:8080/preview.png">
+<img src="http://127.0.0.1:8080/preview.png" alt="" width="0" height="0">
 <a href="http://[::1]:8000/">IPv6 loopback</a>
 <a href="http://app.localhost/">.localhost TLD</a>


### PR DESCRIPTION
## What it does
Checks for `<img>` tags that do not declare an `alt` attribute.

## Why is this bad?
The `alt` attribute provides a textual alternative for screen readers and is rendered when the image cannot be loaded. Without it, assistive technologies have no way to describe the image to the user. Decorative images should declare `alt=""` so screen readers skip them.

## Example
```html
<img src="photo.jpg">
```

Use instead:
```html
<img src="photo.jpg" alt="A photo of the team">
```

## References
- [MDN: HTML `alt` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt)
- [WCAG 1.1.1: Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)

Part of #231 