### PR TITLE
feat(lint): Add `empty-tag-pair` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -121,6 +121,10 @@ impl<'a> Checker<'a> {
             rules::suspicious::use_https::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::EmptyTagPair) {
+            rules::suspicious::empty_tag_pair::check(element, self);
+        }
+
         if self.is_rule_enabled(Rule::UppercaseFormMethod) {
             rules::style::uppercase_form_method::check(element, self);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -248,6 +248,7 @@ define_rules! {
     (JavascriptUrl, rules::suspicious::javascript_url::JavascriptUrl),
     (DuplicateAttr, rules::suspicious::duplicate_attr::DuplicateAttr),
     (UseHttps, rules::suspicious::use_https::UseHttps),
+    (EmptyTagPair, rules::suspicious::empty_tag_pair::EmptyTagPair),
     (UppercaseFormMethod, rules::style::uppercase_form_method::UppercaseFormMethod),
     (FormActionWhitespace, rules::style::form_action_whitespace::FormActionWhitespace),
     (MissingHtmlLang, rules::accessibility::missing_html_lang::MissingHtmlLang),

--- a/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
@@ -9,28 +9,15 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 ///
 /// ## Why is this bad?
 /// A bare `<tag></tag>` pair renders nothing, so it is often leftover scaffolding or a typo.
+///
 /// The HTML specification recommends, "as a general rule," that such elements contain at least
 /// one node of palpable content. That is explicitly *not* a hard requirement — an element may
 /// be empty legitimately "when it is used as a placeholder which will later be filled in by a
-/// script, or when the element is part of a template" — so this rule is a heuristic and stays
-/// in preview.
-///
-/// To keep false positives low, an element is only reported when it has **no attributes**. An
-/// `id`, `class`, `data-*` hook, or any other attribute signals the empty element is
-/// intentional (a CSS/JS hook, a custom element, an external `<script src>`, ...).
-///
-/// Whitespace-only content (newlines, indentation) is treated as empty. Tags whose empty form
-/// is normal rather than suspicious are exempt: structural cells (`<td>`, `<th>`, `<li>`,
-/// `<dt>`, `<dd>`), form controls that start empty or are populated by a script (`<textarea>`,
-/// `<select>`, `<output>`, `<option>`), the script-rendered `<canvas>` surface, and the
-/// web-component default `<slot>`. `<pre>` is also exempt because whitespace is significant
-/// there, so a whitespace-only `<pre>` is not actually empty.
+/// script, or when the element is part of a template".
 ///
 /// ## Example
 /// ```html
-/// <div></div>
-/// <span>
-/// </span>
+/// <div>Welcome<span></span></div>
 /// ```
 ///
 /// Use instead:
@@ -68,8 +55,7 @@ impl Violation for EmptyTagPair {
 ///   state is their normal initial state (`<option></option>` is a common blank placeholder).
 /// - `canvas`: a script-rendered drawing surface whose children are fallback content only.
 /// - `slot`: the default slot of a web component.
-/// - `pre`: whitespace is significant, so a whitespace-only `<pre>` renders meaningful content
-///   and is not "empty".
+/// - `pre`:  a whitespace-only `<pre>` renders meaningful content and is not "empty".
 const EXCLUDED_TAGS: &[&str] = &[
     "td", "th", "li", "dt", "dd", "textarea", "select", "output", "option", "canvas", "slot", "pre",
 ];
@@ -81,9 +67,6 @@ fn is_excluded_tag(tag: &str) -> bool {
 }
 
 /// Returns `true` when `children` is either empty or contains only whitespace-only text nodes.
-///
-/// Any non-text child (nested element, Jinja block, interpolation, comment, ...) makes the
-/// element dynamically-populated and disqualifies it from the rule.
 fn has_only_whitespace(children: &[Node<'_>]) -> bool {
     children.iter().all(|child| match &child.kind {
         NodeKind::Text(text) => text.raw.chars().all(char::is_whitespace),
@@ -92,19 +75,12 @@ fn has_only_whitespace(children: &[Node<'_>]) -> bool {
 }
 
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    if element.void_element || element.self_closing {
-        return;
-    }
-
-    if !element.attrs.is_empty() {
-        return;
-    }
-
-    if is_excluded_tag(element.tag_name) {
-        return;
-    }
-
-    if !has_only_whitespace(&element.children) {
+    if element.void_element
+        || element.self_closing
+        || !element.attrs.is_empty()
+        || is_excluded_tag(element.tag_name)
+        || !has_only_whitespace(&element.children)
+    {
         return;
     }
 

--- a/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
@@ -1,0 +1,98 @@
+use markup_fmt::ast::{Element, Node, NodeKind};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for non-void elements with no attributes whose open and close tags wrap no content.
+///
+/// ## Why is this bad?
+/// A bare `<tag></tag>` pair renders nothing and carries no metadata, so it is almost always
+/// either leftover scaffolding or a typo. Remove it (or replace it with a self-closing element
+/// where appropriate) to keep the template intentional and easier to scan.
+///
+/// Whitespace-only content (newlines, indentation) is treated as empty, matching the way the
+/// browser would render the element. Cells used to preserve table or list structure
+/// (`<td>`, `<li>`, `<th>`, `<dt>`, `<dd>`) are exempt.
+///
+/// ## Example
+/// ```html
+/// <div></div>
+/// <span>
+/// </span>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <div>Welcome</div>
+/// ```
+///
+/// ## References
+/// - [HTML spec: void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements)
+/// - [HTML spec: palpable content](https://html.spec.whatwg.org/multipage/dom.html#palpable-content)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct EmptyTagPair {
+    pub tag: String,
+}
+
+impl Violation for EmptyTagPair {
+    const RULE: Rule = Rule::EmptyTagPair;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Empty `<{}>` tag pair.", self.tag)
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Remove the empty tag pair or add content.".to_string())
+    }
+}
+
+/// Tags commonly left empty to preserve table or list structure.
+const EXCLUDED_TAGS: &[&str] = &["td", "li", "th", "dt", "dd"];
+
+fn is_excluded_tag(tag: &str) -> bool {
+    EXCLUDED_TAGS
+        .iter()
+        .any(|excluded| tag.eq_ignore_ascii_case(excluded))
+}
+
+/// Returns `true` when `children` is either empty or contains only whitespace-only text nodes.
+///
+/// Any non-text child (nested element, Jinja block, interpolation, comment, ...) makes the
+/// element dynamically-populated and disqualifies it from the rule.
+fn has_only_whitespace(children: &[Node<'_>]) -> bool {
+    children.iter().all(|child| match &child.kind {
+        NodeKind::Text(text) => text.raw.chars().all(char::is_whitespace),
+        _ => false,
+    })
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    if element.void_element || element.self_closing {
+        return;
+    }
+
+    if !element.attrs.is_empty() {
+        return;
+    }
+
+    if is_excluded_tag(element.tag_name) {
+        return;
+    }
+
+    if !has_only_whitespace(&element.children) {
+        return;
+    }
+
+    let offset = checker.source_offset(element.tag_name);
+    checker.report_diagnostic(
+        &EmptyTagPair {
+            tag: element.tag_name.to_string(),
+        },
+        (offset, element.tag_name.len()).into(),
+    );
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
@@ -8,13 +8,23 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// Checks for non-void elements with no attributes whose open and close tags wrap no content.
 ///
 /// ## Why is this bad?
-/// A bare `<tag></tag>` pair renders nothing and carries no metadata, so it is almost always
-/// either leftover scaffolding or a typo. Remove it (or replace it with a self-closing element
-/// where appropriate) to keep the template intentional and easier to scan.
+/// A bare `<tag></tag>` pair renders nothing, so it is often leftover scaffolding or a typo.
+/// The HTML specification recommends, "as a general rule," that such elements contain at least
+/// one node of palpable content. That is explicitly *not* a hard requirement — an element may
+/// be empty legitimately "when it is used as a placeholder which will later be filled in by a
+/// script, or when the element is part of a template" — so this rule is a heuristic and stays
+/// in preview.
 ///
-/// Whitespace-only content (newlines, indentation) is treated as empty, matching the way the
-/// browser would render the element. Cells used to preserve table or list structure
-/// (`<td>`, `<li>`, `<th>`, `<dt>`, `<dd>`) are exempt.
+/// To keep false positives low, an element is only reported when it has **no attributes**. An
+/// `id`, `class`, `data-*` hook, or any other attribute signals the empty element is
+/// intentional (a CSS/JS hook, a custom element, an external `<script src>`, ...).
+///
+/// Whitespace-only content (newlines, indentation) is treated as empty. Tags whose empty form
+/// is normal rather than suspicious are exempt: structural cells (`<td>`, `<th>`, `<li>`,
+/// `<dt>`, `<dd>`), form controls that start empty or are populated by a script (`<textarea>`,
+/// `<select>`, `<output>`, `<option>`), the script-rendered `<canvas>` surface, and the
+/// web-component default `<slot>`. `<pre>` is also exempt because whitespace is significant
+/// there, so a whitespace-only `<pre>` is not actually empty.
 ///
 /// ## Example
 /// ```html
@@ -32,7 +42,7 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// - [HTML spec: void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements)
 /// - [HTML spec: palpable content](https://html.spec.whatwg.org/multipage/dom.html#palpable-content)
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
-#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+#[violation_metadata(preview_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct EmptyTagPair {
     pub tag: String,
 }
@@ -51,8 +61,18 @@ impl Violation for EmptyTagPair {
     }
 }
 
-/// Tags commonly left empty to preserve table or list structure.
-const EXCLUDED_TAGS: &[&str] = &["td", "li", "th", "dt", "dd"];
+/// Tags whose empty form is legitimate rather than suspicious.
+///
+/// - `td`, `th`, `li`, `dt`, `dd`: kept empty to preserve table or list structure.
+/// - `textarea`, `select`, `output`, `option`: form controls whose empty or script-populated
+///   state is their normal initial state (`<option></option>` is a common blank placeholder).
+/// - `canvas`: a script-rendered drawing surface whose children are fallback content only.
+/// - `slot`: the default slot of a web component.
+/// - `pre`: whitespace is significant, so a whitespace-only `<pre>` renders meaningful content
+///   and is not "empty".
+const EXCLUDED_TAGS: &[&str] = &[
+    "td", "th", "li", "dt", "dd", "textarea", "select", "output", "option", "canvas", "slot", "pre",
+];
 
 fn is_excluded_tag(tag: &str) -> bool {
     EXCLUDED_TAGS

--- a/crates/djangofmt_lint/src/rules/suspicious/mod.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/mod.rs
@@ -1,4 +1,5 @@
 pub mod django_static_url;
 pub mod duplicate_attr;
+pub mod empty_tag_pair;
 pub mod javascript_url;
 pub mod use_https;

--- a/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.html
+++ b/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.html
@@ -1,0 +1,30 @@
+<!-- Plain empty pair -->
+<div></div>
+
+<!-- Whitespace-only content (newlines + indent) is still empty -->
+<span>
+    </span>
+
+<!-- Tab/space-only content -->
+<p>	  </p>
+
+<!-- Case-insensitive tag name -->
+<DIV></DIV>
+
+<!-- Nested empty pair inside a populated parent -->
+<article>
+    <header></header>
+    <p>Body</p>
+</article>
+
+<!-- Raw-text elements with no attribute and no content -->
+<script></script>
+<style></style>
+<textarea></textarea>
+
+<!-- Form controls without an accessible name -->
+<button></button>
+
+<!-- Generic containers without identifying attributes -->
+<section></section>
+<aside></aside>

--- a/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.html
+++ b/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.html
@@ -17,10 +17,9 @@
     <p>Body</p>
 </article>
 
-<!-- Raw-text elements with no attribute and no content -->
+<!-- Empty inline `<script>`/`<style>` with no attribute do nothing -->
 <script></script>
 <style></style>
-<textarea></textarea>
 
 <!-- Form controls without an accessible name -->
 <button></button>

--- a/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.snap
@@ -1,0 +1,124 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 11 lint error(s)
+
+Error: 
+  × Empty `<div>` tag pair.
+   ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:2:2]
+ 1 │ <!-- Plain empty pair -->
+ 2 │ <div></div>
+   ·  ─┬─
+   ·   ╰── here
+ 3 │ 
+   ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<span>` tag pair.
+   ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:5:2]
+ 4 │ <!-- Whitespace-only content (newlines + indent) is still empty -->
+ 5 │ <span>
+   ·  ──┬─
+   ·    ╰── here
+ 6 │     </span>
+   ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<p>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:9:2]
+  8 │ <!-- Tab/space-only content -->
+  9 │ <p>   </p>
+    ·  ┬
+    ·  ╰── here
+ 10 │ 
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<DIV>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:12:2]
+ 11 │ <!-- Case-insensitive tag name -->
+ 12 │ <DIV></DIV>
+    ·  ─┬─
+    ·   ╰── here
+ 13 │ 
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<header>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:16:6]
+ 15 │ <article>
+ 16 │     <header></header>
+    ·      ───┬──
+    ·         ╰── here
+ 17 │     <p>Body</p>
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<script>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:21:2]
+ 20 │ <!-- Raw-text elements with no attribute and no content -->
+ 21 │ <script></script>
+    ·  ───┬──
+    ·     ╰── here
+ 22 │ <style></style>
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<style>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:22:2]
+ 21 │ <script></script>
+ 22 │ <style></style>
+    ·  ──┬──
+    ·    ╰── here
+ 23 │ <textarea></textarea>
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<textarea>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:23:2]
+ 22 │ <style></style>
+ 23 │ <textarea></textarea>
+    ·  ────┬───
+    ·      ╰── here
+ 24 │ 
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<button>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:26:2]
+ 25 │ <!-- Form controls without an accessible name -->
+ 26 │ <button></button>
+    ·  ───┬──
+    ·     ╰── here
+ 27 │ 
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<section>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:29:2]
+ 28 │ <!-- Generic containers without identifying attributes -->
+ 29 │ <section></section>
+    ·  ───┬───
+    ·     ╰── here
+ 30 │ <aside></aside>
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
+  × Empty `<aside>` tag pair.
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:30:2]
+ 29 │ <section></section>
+ 30 │ <aside></aside>
+    ·  ──┬──
+    ·    ╰── here
+    ╰────
+  help: Remove the empty tag pair or add content.

--- a/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.invalid.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 11 lint error(s)
+  × Found 10 lint error(s)
 
 Error: 
   × Empty `<div>` tag pair.
@@ -61,7 +61,7 @@ Error:
 Error: 
   × Empty `<script>` tag pair.
     ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:21:2]
- 20 │ <!-- Raw-text elements with no attribute and no content -->
+ 20 │ <!-- Empty inline `<script>`/`<style>` with no attribute do nothing -->
  21 │ <script></script>
     ·  ───┬──
     ·     ╰── here
@@ -76,48 +76,37 @@ Error:
  22 │ <style></style>
     ·  ──┬──
     ·    ╰── here
- 23 │ <textarea></textarea>
-    ╰────
-  help: Remove the empty tag pair or add content.
-
-Error: 
-  × Empty `<textarea>` tag pair.
-    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:23:2]
- 22 │ <style></style>
- 23 │ <textarea></textarea>
-    ·  ────┬───
-    ·      ╰── here
- 24 │ 
+ 23 │ 
     ╰────
   help: Remove the empty tag pair or add content.
 
 Error: 
   × Empty `<button>` tag pair.
-    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:26:2]
- 25 │ <!-- Form controls without an accessible name -->
- 26 │ <button></button>
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:25:2]
+ 24 │ <!-- Form controls without an accessible name -->
+ 25 │ <button></button>
     ·  ───┬──
     ·     ╰── here
- 27 │ 
+ 26 │ 
     ╰────
   help: Remove the empty tag pair or add content.
 
 Error: 
   × Empty `<section>` tag pair.
-    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:29:2]
- 28 │ <!-- Generic containers without identifying attributes -->
- 29 │ <section></section>
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:28:2]
+ 27 │ <!-- Generic containers without identifying attributes -->
+ 28 │ <section></section>
     ·  ───┬───
     ·     ╰── here
- 30 │ <aside></aside>
+ 29 │ <aside></aside>
     ╰────
   help: Remove the empty tag pair or add content.
 
 Error: 
   × Empty `<aside>` tag pair.
-    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:30:2]
- 29 │ <section></section>
- 30 │ <aside></aside>
+    ╭─[tests/check/empty_tag_pair/empty_tag_pair.invalid.html:29:2]
+ 28 │ <section></section>
+ 29 │ <aside></aside>
     ·  ──┬──
     ·    ╰── here
     ╰────

--- a/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.valid.html
+++ b/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.valid.html
@@ -58,6 +58,26 @@
     </tr>
 </table>
 
+<!-- Form controls start empty (or are populated by a script) as their normal state;
+     `<option></option>` is a common blank placeholder -->
+<textarea></textarea>
+<select></select>
+<output></output>
+<option></option>
+
+<!-- `<pre>` preserves whitespace, so a whitespace-only `<pre>` is meaningful, not empty -->
+<pre>   </pre>
+
+<!-- `<canvas>` is a script-rendered surface; its children are fallback content only -->
+<canvas></canvas>
+
+<!-- `<slot>` with no name is a web component's default slot -->
+<slot></slot>
+
+<!-- Exemptions are case-insensitive too -->
+<TEXTAREA></TEXTAREA>
+<CANVAS></CANVAS>
+
 <!-- Jinja control flow inside an element is dynamic content -->
 <div>{% if user %}Hello, {{ user.name }}{% endif %}</div>
 <span>{% block title %}{% endblock %}</span>

--- a/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.valid.html
+++ b/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.valid.html
@@ -1,0 +1,79 @@
+<!-- Populated element -->
+<div>Hello, world!</div>
+
+<!-- Element with nested children -->
+<section>
+    <h2>Title</h2>
+    <p>Body</p>
+</section>
+
+<!-- Void elements have no closing tag -->
+<br>
+<hr>
+<img src="logo.png" alt="Logo" width="100" height="100">
+<input type="text" name="q">
+
+<!-- Self-closing tags -->
+<input type="text" name="q" />
+<br />
+
+<!-- Any attribute signals the empty tag is intentional
+     (CSS hook, JS hook, custom element, ...) -->
+<div id="placeholder"></div>
+<section class="hero"></section>
+<aside
+    class="sidebar"
+    role="complementary">
+</aside>
+<my-widget data-name="x"></my-widget>
+
+<!-- `<script>` with `src` is an external script and legitimately empty -->
+<script src="app.js"></script>
+<link rel="stylesheet" href="app.css">
+
+<!-- `<button>` with an accessible name is intentional -->
+<button aria-label="Close"></button>
+<button type="submit"></button>
+
+<!-- Table and list cells are commonly empty to preserve structure -->
+<table>
+    <tr>
+        <td></td>
+        <th></th>
+    </tr>
+</table>
+<ul>
+    <li></li>
+</ul>
+<dl>
+    <dt></dt>
+    <dd></dd>
+</dl>
+
+<!-- Case-insensitive exclusions: TD/LI/TH/DT/DD -->
+<table>
+    <tr>
+        <TD></TD>
+        <TH></TH>
+    </tr>
+</table>
+
+<!-- Jinja control flow inside an element is dynamic content -->
+<div>{% if user %}Hello, {{ user.name }}{% endif %}</div>
+<span>{% block title %}{% endblock %}</span>
+
+<!-- Jinja interpolation is dynamic content -->
+<p>{{ description }}</p>
+
+<!-- Jinja comments are content -->
+<div>{# placeholder for future copy #}</div>
+
+<!-- HTML comments are content -->
+<div><!-- TODO: fill in --></div>
+
+<!-- Nested elements as content are not "empty" even when leaves are -->
+<div><span>x</span></div>
+
+<!-- Doctype is not an element with children -->
+<!DOCTYPE html>
+<html lang="en"><body>x</body></html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 1 lint error(s)
+  × Found 2 lint error(s)
 
 Error: 
   × Missing `<!DOCTYPE html>` declaration.
@@ -13,3 +13,14 @@ Error:
  4 │     <body></body>
    ╰────
   help: Add `<!DOCTYPE html>` before the `<html>` tag.
+
+Error: 
+  × Empty `<body>` tag pair.
+   ╭─[tests/check/missing_doctype/missing_doctype_extends_lookalike.invalid.html:4:6]
+ 3 │ <html lang="en">
+ 4 │     <body></body>
+   ·      ──┬─
+   ·        ╰── here
+ 5 │ </html>
+   ╰────
+  help: Remove the empty tag pair or add content.

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.invalid.snap
@@ -1,7 +1,18 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 6 lint error(s)
+  × Found 9 lint error(s)
+
+Error: 
+  × Empty `<html>` tag pair.
+   ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:3:2]
+ 2 │ <!-- No attributes at all -->
+ 3 │ <html>
+   ·  ──┬─
+   ·    ╰── here
+ 4 │ </html>
+   ╰────
+  help: Remove the empty tag pair or add content.
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.
@@ -26,6 +37,17 @@ Error:
   help: Add `lang="en"` (or the appropriate language code).
 
 Error: 
+  × Empty `<HTML>` tag pair.
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:11:2]
+ 10 │ <!-- Case-insensitive tag name -->
+ 11 │ <HTML>
+    ·  ──┬─
+    ·    ╰── here
+ 12 │ </HTML>
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
   × `<html>` tag should declare a `lang` attribute.
     ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:11:2]
  10 │ <!-- Case-insensitive tag name -->
@@ -35,6 +57,17 @@ Error:
  12 │ </HTML>
     ╰────
   help: Add `lang="en"` (or the appropriate language code).
+
+Error: 
+  × Empty `<html>` tag pair.
+    ╭─[tests/check/missing_html_lang/missing_html_lang.invalid.html:16:6]
+ 15 │ {% if base_template %}
+ 16 │     <html>
+    ·      ──┬─
+    ·        ╰── here
+ 17 │     </html>
+    ╰────
+  help: Remove the empty tag pair or add content.
 
 Error: 
   × `<html>` tag should declare a `lang` attribute.

--- a/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_html_lang/missing_html_lang.valid.html
@@ -16,8 +16,8 @@
 </html>
 
 <!-- Non-html tags are not checked -->
-<div></div>
-<body></body>
+<div>x</div>
+<body>x</body>
 
 <!-- `lang` declared inside a Jinja conditional -->
 <html {% if rtl %}lang="ar"{% else %}lang="en"{% endif %}>

--- a/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_img_alt/missing_img_alt.valid.html
@@ -36,8 +36,8 @@
 </picture>
 
 <!-- Non-img tags are not checked: `<input type="image">`, `<area>`, `<object>` are out of scope -->
-<div></div>
-<picture></picture>
+<div class="spacer"></div>
+<picture class="frame"></picture>
 <video src="video.mp4"></video>
 <input type="image" src="submit.png" />
 <map name="planets"><area shape="circle" coords="50,50,20" href="/mercury" /></map>

--- a/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_title/missing_title.invalid.snap
@@ -1,7 +1,18 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 9 lint error(s)
+  × Found 13 lint error(s)
+
+Error: 
+  × Empty `<head>` tag pair.
+   ╭─[tests/check/missing_title/missing_title.invalid.html:3:6]
+ 2 │ <html lang="en">
+ 3 │     <head>
+   ·      ──┬─
+   ·        ╰── here
+ 4 │     </head>
+   ╰────
+  help: Remove the empty tag pair or add content.
 
 Error: 
   × Missing or empty `<title>` in `<head>`.
@@ -70,6 +81,17 @@ Error:
   help: Fill the existing `<title>` element with descriptive text.
 
 Error: 
+  × Empty `<title>` tag pair.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:37:10]
+ 36 │     <head>
+ 37 │         <title></title>
+    ·          ──┬──
+    ·            ╰── here
+ 38 │     </head>
+    ╰────
+  help: Remove the empty tag pair or add content.
+
+Error: 
   × Missing or empty `<title>` in `<head>`.
     ╭─[tests/check/missing_title/missing_title.invalid.html:43:6]
  42 │ <html lang="en">
@@ -79,6 +101,17 @@ Error:
  44 │         <title>   </title>
     ╰────
   help: Fill the existing `<title>` element with descriptive text.
+
+Error: 
+  × Empty `<title>` tag pair.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:44:10]
+ 43 │     <head>
+ 44 │         <title>   </title>
+    ·          ──┬──
+    ·            ╰── here
+ 45 │     </head>
+    ╰────
+  help: Remove the empty tag pair or add content.
 
 Error: 
   × Missing or empty `<title>` in `<head>`.
@@ -101,3 +134,14 @@ Error:
  62 │         <meta charset="utf-8">
     ╰────
   help: Add a `<title>` element with descriptive text inside `<head>`.
+
+Error: 
+  × Empty `<body>` tag pair.
+    ╭─[tests/check/missing_title/missing_title.invalid.html:66:6]
+ 65 │     </head>
+ 66 │     <body></body>
+    ·      ──┬─
+    ·        ╰── here
+ 67 │ </html>
+    ╰────
+  help: Remove the empty tag pair or add content.

--- a/crates/djangofmt_lint/tests/check/missing_title/missing_title.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_title/missing_title.valid.html
@@ -70,7 +70,7 @@
 
 <!-- Tag names that look similar but are not <head> -->
 <div>
-    <header></header>
+    <header>x</header>
 </div>
 
 <!-- Multiple <title> tags: at least one non-empty satisfies the rule -->


### PR DESCRIPTION
## What it does
Checks for non-void elements with no attributes whose open and close tags wrap no content.

## Why is this bad?
A bare `<tag></tag>` pair renders nothing and carries no metadata, so it is almost always either leftover scaffolding or a typo. Remove it (or replace it with a self-closing element where appropriate) to keep the template intentional and easier to scan.

Whitespace-only content (newlines, indentation) is treated as empty, matching the way the browser would render the element. Cells used to preserve table or list structure (`<td>`, `<li>`, `<th>`, `<dt>`, `<dd>`) are exempt.

## Example
```html
<div></div>
<span>
</span>
```

Use instead:
```html
<div>Welcome</div>
```

## References
- [HTML spec: void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements)
- [HTML spec: palpable content](https://html.spec.whatwg.org/multipage/dom.html#palpable-content)

Part of #231 