### PR TITLE
feat(lint): Add `django-url-pattern` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -109,6 +109,10 @@ impl<'a> Checker<'a> {
             rules::suspicious::django_static_url::check(element, self);
         }
 
+        if self.is_rule_enabled(Rule::DjangoUrlPattern) {
+            rules::suspicious::django_url_pattern::check(element, self);
+        }
+
         if self.is_rule_enabled(Rule::JavascriptUrl) {
             rules::suspicious::javascript_url::check(element, self);
         }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -248,6 +248,7 @@ define_rules! {
     (EmptyAttrValue, rules::style::empty_attr_value::EmptyAttrValue<'static>),
     (RedundantTypeAttr, rules::style::redundant_type_attr::RedundantTypeAttr),
     (DjangoStaticUrl, rules::suspicious::django_static_url::DjangoStaticUrl),
+    (DjangoUrlPattern, rules::suspicious::django_url_pattern::DjangoUrlPattern),
     (JavascriptUrl, rules::suspicious::javascript_url::JavascriptUrl),
     (DuplicateAttr, rules::suspicious::duplicate_attr::DuplicateAttr),
     (UseHttps, rules::suspicious::use_https::UseHttps),

--- a/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
@@ -1,0 +1,191 @@
+use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::contains_interpolation;
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for hardcoded internal URLs in HTML link attributes that should use Django's
+/// `{% url %}` template tag.
+///
+/// ## Why is this bad?
+/// Hardcoded internal paths duplicate the routing configuration into every template and break
+/// silently when a `urls.py` entry is renamed or remounted. The `{% url %}` template tag resolves
+/// paths from named URL patterns at render time, so the template stays correct across refactors
+/// and respects URL namespacing (`app_name`, `instance_namespace`).
+///
+/// ## Example
+/// ```html
+/// <a href="/profile/">Profile</a>
+/// <form action="/login/"></form>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <a href="{% url 'profile' %}">Profile</a>
+/// <form action="{% url 'login' %}"></form>
+/// ```
+///
+/// ## References
+/// - [Django: the `url` template tag](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#url)
+/// - [Django: URL dispatcher](https://docs.djangoproject.com/en/stable/topics/http/urls/)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(preview_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct DjangoUrlPattern {
+    pub attribute: &'static str,
+}
+
+impl Violation for DjangoUrlPattern {
+    const RULE: Rule = Rule::DjangoUrlPattern;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hardcoded internal URL in `{}`.", self.attribute)
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Use `{% url 'view_name' %}` to reference a named URL pattern.".to_string())
+    }
+}
+
+const A_DIV_SPAN_INPUT_ATTRS: &[&str] = &["href", "data-url", "data-src", "action"];
+const FORM_ATTRS: &[&str] = &["action"];
+
+const fn url_attributes_for(tag_name: &str) -> &'static [&'static str] {
+    if tag_name.eq_ignore_ascii_case("form") {
+        return FORM_ATTRS;
+    }
+    if tag_name.eq_ignore_ascii_case("a")
+        || tag_name.eq_ignore_ascii_case("div")
+        || tag_name.eq_ignore_ascii_case("span")
+        || tag_name.eq_ignore_ascii_case("input")
+    {
+        return A_DIV_SPAN_INPUT_ATTRS;
+    }
+    &[]
+}
+
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    let attr_names = url_attributes_for(element.tag_name);
+    if attr_names.is_empty() {
+        return;
+    }
+    for attr in &element.attrs {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            ..
+        }) = attr
+        else {
+            continue;
+        };
+        let Some(canonical) = attr_names
+            .iter()
+            .find(|candidate| candidate.eq_ignore_ascii_case(name))
+        else {
+            continue;
+        };
+        if contains_interpolation(value_str) {
+            continue;
+        }
+        if is_hardcoded_internal_path(value_str) {
+            checker.report_diagnostic(
+                &DjangoUrlPattern {
+                    attribute: canonical,
+                },
+                (*offset, value_str.len()).into(),
+            );
+        }
+    }
+}
+
+/// Returns true if `value` looks like a hardcoded internal path that should use `{% url %}`.
+///
+/// Matches values whose first character is `/` (root-relative) or an ASCII word character
+/// (relative), after excluding protocol-relative URLs, the bare site root, anything carrying a
+/// URL scheme, file paths (`/favicon.ico`, `logo.png`), and bare hostnames (`www.example.com/…`).
+fn is_hardcoded_internal_path(value: &str) -> bool {
+    let Some(first) = value.chars().next() else {
+        return false;
+    };
+
+    // Must start with `/` (root-relative) or a word character (relative).
+    if first != '/' && !is_ascii_word_char(first) {
+        return false;
+    }
+
+    // Protocol-relative URLs (`//cdn.example.com/...`).
+    if value.starts_with("//") {
+        return false;
+    }
+
+    // Site root: `/` alone is conventionally the home link and shouldn't be flagged.
+    if value == "/" {
+        return false;
+    }
+
+    // Any value carrying a URL scheme (`https:`, `mailto:`, `ftp:`, `tel:`, …) addresses an
+    // external resource or a non-navigational target, not an internal route.
+    if has_url_scheme(value) {
+        return false;
+    }
+
+    // A value pointing at a file — its last path segment carries an extension (`/favicon.ico`,
+    // `/assets/app.js`, `logo.png`) — is a static asset served via `{% static %}`, not a named
+    // route. This holds for root-relative and relative paths alike.
+    if last_segment_has_dot(value) {
+        return false;
+    }
+
+    // A schemeless, relative value whose first segment is a hostname (`www.example.com/...`,
+    // `example.com/path`) is an external link, not an internal route.
+    if first != '/' && first_segment_has_dot(value) {
+        return false;
+    }
+
+    true
+}
+
+const fn is_ascii_word_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+/// Returns true if `value` begins with an RFC 3986 scheme, e.g. `https://…`, `mailto:…`, or
+/// `ftp://…`. A scheme is `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` followed by `:`.
+fn has_url_scheme(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    // A scheme must start with a letter.
+    if !bytes.first().is_some_and(u8::is_ascii_alphabetic) {
+        return false;
+    }
+    let scheme_len = bytes
+        .iter()
+        .take_while(|&&b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'))
+        .count();
+    bytes.get(scheme_len) == Some(&b':')
+}
+
+/// Returns true if the first path segment (up to the first `/`, `?`, or `#`) contains a `.` —
+/// the shape of a hostname (`www.example.com`) or a file name (`logo.png`).
+fn first_segment_has_dot(value: &str) -> bool {
+    value
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(value)
+        .contains('.')
+}
+
+/// Returns true if the last path segment (the text after the final `/`, with any query string or
+/// fragment stripped) contains a `.` — the shape of a file name (`favicon.ico`, `app.js`).
+fn last_segment_has_dot(value: &str) -> bool {
+    value
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(value)
+        .rsplit('/')
+        .next()
+        .unwrap_or(value)
+        .contains('.')
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/mod.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/mod.rs
@@ -1,4 +1,5 @@
 pub mod django_static_url;
+pub mod django_url_pattern;
 pub mod duplicate_attr;
 pub mod empty_tag_pair;
 pub mod javascript_url;

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.valid.html
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.valid.html
@@ -32,7 +32,7 @@
 <link href>
 
 <!-- Tags outside the asset-element scope: same attribute, different element -->
-<a href="/static/docs.pdf">Static doc</a>
+<area href="/static/docs.pdf">
 <iframe src="/static/inner.html"></iframe>
 
 <!-- Attributes outside the URL-attribute scope on in-scope tags -->

--- a/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.html
+++ b/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.html
@@ -1,0 +1,53 @@
+<!-- a/href: hardcoded absolute path -->
+<a href="/profile/">Profile</a>
+<a href="/accounts/login/">Login</a>
+
+<!-- a/href: query string still counts as an internal URL -->
+<a href="/Collections?handler=RemoveAgreement&id=42">Link</a>
+<a href="/path?param=value">Link</a>
+
+<!-- a/href: a trailing fragment identifier does not exempt the hardcoded path -->
+<a href="/profile/#section">Link</a>
+
+<!-- a/href: hardcoded relative path (no leading slash) -->
+<a href="profile/">Profile</a>
+
+<!-- form/action: hardcoded absolute path -->
+<form action="/submit/"></form>
+<form action="/login/"></form>
+
+<!-- div/span/input data-url and data-src -->
+<div data-src="/table/task/log/"></div>
+<div data-url="/api/items/"></div>
+<span data-url="/api/widgets/"></span>
+<input data-url="/api/things/">
+
+<!-- href on div/span/input is in scope -->
+<div href="/page/">Link</div>
+<span href="/page/">Link</span>
+<input href="/page/">
+
+<!-- action on a/div/span/input is in scope -->
+<a action="/submit/">Link</a>
+<div action="/submit/">Link</div>
+
+<!-- Case-insensitive on tag and attribute names -->
+<A HREF="/page/">Link</A>
+
+<!-- Inside a Jinja block (literal value still flagged) -->
+{% if show_link %}
+    <a href="/page/">Link</a>
+{% endif %}
+
+<!-- Real-world: django-allauth's default auth routes hardcoded as form actions instead of
+     `{% url 'account_login' %}` / `{% url 'account_signup' %}`. This shape recurs across public
+     Django templates (e.g. wireguard_webadmin, hydroshare, trunk-player, Webolith). -->
+<form action="/accounts/login/" method="post"></form>
+<form action="/accounts/signup/" method="post"></form>
+
+<!-- Real-world: hardcoded routes found smoke testing a production Django project — a hyphenated
+     slug route, a root-relative route with no trailing slash, and a form posting to a path that
+     carries a query string. Each should resolve a named pattern through `{% url %}`. -->
+<a href="/gaz-propane-en-citerne/">Propane</a>
+<a href="/devenir-partenaire">Become a partner</a>
+<form method="post" action="/widgetform?form_type=keyword_city"></form>

--- a/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.snap
@@ -1,0 +1,267 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 24 lint error(s)
+
+Error: 
+  × Hardcoded internal URL in `href`.
+   ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:2:10]
+ 1 │ <!-- a/href: hardcoded absolute path -->
+ 2 │ <a href="/profile/">Profile</a>
+   ·          ────┬────
+   ·              ╰── here
+ 3 │ <a href="/accounts/login/">Login</a>
+   ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+   ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:3:10]
+ 2 │ <a href="/profile/">Profile</a>
+ 3 │ <a href="/accounts/login/">Login</a>
+   ·          ────────┬───────
+   ·                  ╰── here
+ 4 │ 
+   ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+   ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:6:10]
+ 5 │ <!-- a/href: query string still counts as an internal URL -->
+ 6 │ <a href="/Collections?handler=RemoveAgreement&id=42">Link</a>
+   ·          ─────────────────────┬────────────────────
+   ·                               ╰── here
+ 7 │ <a href="/path?param=value">Link</a>
+   ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+   ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:7:10]
+ 6 │ <a href="/Collections?handler=RemoveAgreement&id=42">Link</a>
+ 7 │ <a href="/path?param=value">Link</a>
+   ·          ────────┬────────
+   ·                  ╰── here
+ 8 │ 
+   ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:10:10]
+  9 │ <!-- a/href: a trailing fragment identifier does not exempt the hardcoded path -->
+ 10 │ <a href="/profile/#section">Link</a>
+    ·          ────────┬────────
+    ·                  ╰── here
+ 11 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:13:10]
+ 12 │ <!-- a/href: hardcoded relative path (no leading slash) -->
+ 13 │ <a href="profile/">Profile</a>
+    ·          ────┬───
+    ·              ╰── here
+ 14 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:16:15]
+ 15 │ <!-- form/action: hardcoded absolute path -->
+ 16 │ <form action="/submit/"></form>
+    ·               ────┬───
+    ·                   ╰── here
+ 17 │ <form action="/login/"></form>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:17:15]
+ 16 │ <form action="/submit/"></form>
+ 17 │ <form action="/login/"></form>
+    ·               ───┬───
+    ·                  ╰── here
+ 18 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `data-src`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:20:16]
+ 19 │ <!-- div/span/input data-url and data-src -->
+ 20 │ <div data-src="/table/task/log/"></div>
+    ·                ────────┬───────
+    ·                        ╰── here
+ 21 │ <div data-url="/api/items/"></div>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `data-url`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:21:16]
+ 20 │ <div data-src="/table/task/log/"></div>
+ 21 │ <div data-url="/api/items/"></div>
+    ·                ─────┬─────
+    ·                     ╰── here
+ 22 │ <span data-url="/api/widgets/"></span>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `data-url`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:22:17]
+ 21 │ <div data-url="/api/items/"></div>
+ 22 │ <span data-url="/api/widgets/"></span>
+    ·                 ──────┬──────
+    ·                       ╰── here
+ 23 │ <input data-url="/api/things/">
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `data-url`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:23:18]
+ 22 │ <span data-url="/api/widgets/"></span>
+ 23 │ <input data-url="/api/things/">
+    ·                  ──────┬─────
+    ·                        ╰── here
+ 24 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:26:12]
+ 25 │ <!-- href on div/span/input is in scope -->
+ 26 │ <div href="/page/">Link</div>
+    ·            ───┬──
+    ·               ╰── here
+ 27 │ <span href="/page/">Link</span>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:27:13]
+ 26 │ <div href="/page/">Link</div>
+ 27 │ <span href="/page/">Link</span>
+    ·             ───┬──
+    ·                ╰── here
+ 28 │ <input href="/page/">
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:28:14]
+ 27 │ <span href="/page/">Link</span>
+ 28 │ <input href="/page/">
+    ·              ───┬──
+    ·                 ╰── here
+ 29 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:31:12]
+ 30 │ <!-- action on a/div/span/input is in scope -->
+ 31 │ <a action="/submit/">Link</a>
+    ·            ────┬───
+    ·                ╰── here
+ 32 │ <div action="/submit/">Link</div>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:32:14]
+ 31 │ <a action="/submit/">Link</a>
+ 32 │ <div action="/submit/">Link</div>
+    ·              ────┬───
+    ·                  ╰── here
+ 33 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:35:10]
+ 34 │ <!-- Case-insensitive on tag and attribute names -->
+ 35 │ <A HREF="/page/">Link</A>
+    ·          ───┬──
+    ·             ╰── here
+ 36 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:39:14]
+ 38 │ {% if show_link %}
+ 39 │     <a href="/page/">Link</a>
+    ·              ───┬──
+    ·                 ╰── here
+ 40 │ {% endif %}
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:45:15]
+ 44 │      Django templates (e.g. wireguard_webadmin, hydroshare, trunk-player, Webolith). -->
+ 45 │ <form action="/accounts/login/" method="post"></form>
+    ·               ────────┬───────
+    ·                       ╰── here
+ 46 │ <form action="/accounts/signup/" method="post"></form>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:46:15]
+ 45 │ <form action="/accounts/login/" method="post"></form>
+ 46 │ <form action="/accounts/signup/" method="post"></form>
+    ·               ────────┬────────
+    ·                       ╰── here
+ 47 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:51:10]
+ 50 │      carries a query string. Each should resolve a named pattern through `{% url %}`. -->
+ 51 │ <a href="/gaz-propane-en-citerne/">Propane</a>
+    ·          ────────────┬───────────
+    ·                      ╰── here
+ 52 │ <a href="/devenir-partenaire">Become a partner</a>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:52:10]
+ 51 │ <a href="/gaz-propane-en-citerne/">Propane</a>
+ 52 │ <a href="/devenir-partenaire">Become a partner</a>
+    ·          ─────────┬─────────
+    ·                   ╰── here
+ 53 │ <form method="post" action="/widgetform?form_type=keyword_city"></form>
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:53:29]
+ 52 │ <a href="/devenir-partenaire">Become a partner</a>
+ 53 │ <form method="post" action="/widgetform?form_type=keyword_city"></form>
+    ·                             ─────────────────┬────────────────
+    ·                                              ╰── here
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.

--- a/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.valid.html
+++ b/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.valid.html
@@ -1,0 +1,120 @@
+<!-- Canonical fix: use the {% url %} template tag -->
+<a href="{% url 'home' %}">Home</a>
+<a href="{% url 'profile' %}">Profile</a>
+<form action="{% url 'login' %}"></form>
+
+<!-- Interpolation in href/action is skipped -->
+<a href="{{ url }}">Link</a>
+<a href="{{ link_target }}">Link</a>
+<a href="{% if x %}/a{% else %}/b{% endif %}">Link</a>
+<form action="{{ form_action }}"></form>
+<div data-url="/items/{{ item.id }}/"></div>
+
+<!-- External URLs are not flagged (http:// is exercised by the use-https fixture instead) -->
+<a href="https://example.com">Link</a>
+<a href="https://example.com/path">Link</a>
+<form action="https://example.com/submit"></form>
+
+<!-- Fragment-only links are not flagged
+     (Regression: djLint #45 — `href="#"` and `#section` must not be flagged.) -->
+<a href="#">Link</a>
+<a href="#section">Section</a>
+<a href="#anchor">Anchor</a>
+<a href="#tab1">Tab 1</a>
+<form action="#"></form>
+<form action="#go"></form>
+
+<!-- Any value carrying a URL scheme is not flagged, not just a fixed allowlist
+     (`javascript:` URLs are covered by a separate rule, so they're not exercised here). -->
+<a href="mailto:user@example.com">Email</a>
+<a href="tel:+15550100">Call</a>
+<a href="data:text/plain,hello">Data</a>
+<!-- Regression: djLint #814 — `sms:` links must not be treated as internal. -->
+<a href="sms:+15550100">Text</a>
+<a href="ftp://files.example.com/manual.pdf">Manual</a>
+<a href="ws://example.com/socket">Socket</a>
+<a href="bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa">Donate</a>
+<a href="webcal://example.com/feed.ics">Calendar</a>
+<form action="ftp://upload.example.com/"></form>
+
+<!-- Protocol-relative URLs are not flagged -->
+<a href="//cdn.example.com/asset.js">CDN</a>
+
+<!-- Schemeless external hosts and file names are not internal routes: a relative value whose
+     first segment carries a dot is a hostname or a static asset, not a named URL pattern.
+     (Regression: false positive on `www.…`-style links found smoke-testing a real Django site.) -->
+<a href="www.hellowatt.fr/comparateur/">Compare</a>
+<a href="example.com/path">External</a>
+<a href="cdn.example.com/app.js">CDN script</a>
+<a href="logo.png">Logo</a>
+<a href="report.pdf">Report</a>
+
+<!-- Root-relative file paths are static assets (served via `{% static %}`), not named routes:
+     the exclusion keys off the file extension in the last path segment, not the leading slash.
+     (Regression: PR #314 review — `/favicon.ico`-style absolute assets must not be flagged.) -->
+<a href="/favicon.ico">Favicon</a>
+<a href="/downloads/report.pdf">Report</a>
+<div data-src="/assets/app.js"></div>
+<div data-url="/static/css/app.css"></div>
+<a href="assets/app.js">Relative asset</a>
+
+<!-- Relative paths (no leading slash, not a bare word) are not flagged -->
+<a href="../relative/">Up one</a>
+<a href="./sibling/">Sibling</a>
+
+<!-- Site root: `/` alone is the home link sentinel
+     (Regression: djLint #1601 — `href="/"` must not be flagged.) -->
+<a href="/">Home</a>
+
+<!-- An href with no value, or an explicit empty value, is not a hardcoded route -->
+<a href>Link</a>
+<a href="">Link</a>
+
+<!-- Attributes that merely END with `action`/`href`/`data-url`/`data-src` must not trigger;
+     only exact attribute matches count.
+     (Regression: djLint #248 — partial attribute name matching.) -->
+<div data-row-selection-action="highlight"></div>
+<div data-custom-href="ignored"></div>
+<form data-custom-action="ignored"></form>
+
+<!-- `data-action` (and other `data-*` attrs) on `<form>` must not be flagged;
+     only `action` itself is in scope for `<form>`.
+     (Regression: djLint #500 / #501.) -->
+<form action="{% url 'something' %}" data-action="xxx"></form>
+<div data-action="highlight"></div>
+
+<!-- A Django `{% url %}` call whose keyword argument happens to be named `action` must not be
+     misread as a literal `action="..."` attribute.
+     (Regression: djLint #755 / #1183.) -->
+<form method="post" action="{% url 'web:profile_action' action='token_revoke' %}"></form>
+<a href="#" hx-post="{% url 'foo' action='bar' %}">Link</a>
+
+<!-- Real-world false-positive guards (smoke testing a production Django project).
+     Framework-bound URL attributes (Alpine `x-bind:href`, Vue `:href`) are not the plain `href`
+     attribute: only an exact name match is in scope, so their bare-word expressions stay untouched. -->
+<a x-bind:href="solarPanelLayoutURL">Roof layout</a>
+<a :href="layoutUrl">Layout</a>
+
+<!-- Query-only links stay on the current route and resolve no named pattern. -->
+<a href="?page=2">Next page</a>
+<a href="?handler=RemoveAgreement&id=42">Remove</a>
+
+<!-- Analytics keyword arguments inside a `{% include %}` are template-tag kwargs, not an HTML
+     `action` attribute, and must not be read as a hardcoded route. -->
+{% include "form.html" with ga_action="heating_directory_filter" ga_location="sidebar" %}
+
+<!-- Tags out of scope: same attribute names but not in the rule's element list. -->
+<button href="/page/">Click</button>
+<area href="/page/">
+<link href="/page/">
+<link rel="canonical" href="/page/">
+<base href="/">
+
+<!-- Attributes out of scope on the in-scope elements. -->
+<input value="/page/">
+<a title="/page/">Link</a>
+
+<!-- Nested in Jinja block (templated href stays untouched) -->
+{% if show_link %}
+    <a href="{% url 'home' %}">Link</a>
+{% endif %}

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.invalid.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 11 lint error(s)
+  × Found 13 lint error(s)
 
 Error: 
   × Extra whitespace found in form `action`.
@@ -13,6 +13,17 @@ Error:
  3 │ 
    ╰────
   help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+   ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:5:15]
+ 4 │ <!-- Trailing whitespace -->
+ 5 │ <form action="/submit/ "></form>
+   ·               ────┬────
+   ·                   ╰── here
+ 6 │ 
+   ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
 
 Error: 
   × Extra whitespace found in form `action`.
@@ -69,6 +80,17 @@ Error:
  19 │ <forM action="/submit/ "></forM>
     ╰────
   help: Remove leading and trailing whitespace from the `action` value.
+
+Error: 
+  × Hardcoded internal URL in `action`.
+    ╭─[tests/check/form_action_whitespace/form_action_whitespace.invalid.html:19:15]
+ 18 │ <FORM action=" /submit/ "></FORM>
+ 19 │ <forM action="/submit/ "></forM>
+    ·               ────┬────
+    ·                   ╰── here
+ 20 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
 
 Error: 
   × Extra whitespace found in form `action`.

--- a/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.valid.html
+++ b/crates/djangofmt_lint/tests/check/form_action_whitespace/form_action_whitespace.valid.html
@@ -1,5 +1,5 @@
 <!-- No surrounding whitespace -->
-<form action="/submit/"></form>
+<form action="{% url 'submit' %}"></form>
 <form action=""></form>
 <form action="https://example.com/submit/"></form>
 
@@ -38,5 +38,5 @@
 <!-- Multiline form, trimmed value -->
 <form
     method="post"
-    action="/submit/"
+    action="{% url 'submit' %}"
 ></form>

--- a/crates/djangofmt_lint/tests/check/form_method/form_method.valid.html
+++ b/crates/djangofmt_lint/tests/check/form_method/form_method.valid.html
@@ -11,7 +11,7 @@
 <div method="put"></div>
 
 <!-- Form with non-method attr - should not trigger -->
-<form action="/submit">Submit</form>
+<form action="{% url 'submit' %}">Submit</form>
 
 <!-- Form with method attr but no value - should not trigger -->
 <form method>Submit</form>

--- a/crates/djangofmt_lint/tests/check/javascript_url/javascript_url.valid.html
+++ b/crates/djangofmt_lint/tests/check/javascript_url/javascript_url.valid.html
@@ -1,5 +1,4 @@
 <!-- Normal URLs -->
-<a href="/page/">Link</a>
 <a href="https://example.com">Link</a>
 <a href="{% url 'home' %}">Home</a>
 
@@ -11,7 +10,7 @@
 
 <!-- Event handlers (correct pattern) -->
 <button onclick="doStuff()">Click</button>
-<a href="/page/" onclick="doStuff()">Link</a>
+<a href="{% url 'page' %}" onclick="doStuff()">Link</a>
 
 <!-- Other schemes are not flagged -->
 <a href="mailto:user@example.com">Email</a>
@@ -24,8 +23,8 @@
 <a href="javascript:{{ payload }}">Link</a>
 
 <!-- Forms with safe actions -->
-<form action="/submit/"></form>
 <form action="{% url 'submit' %}"></form>
+<form action="https://example.com/submit"></form>
 
 <!-- Tags out of scope: same attribute name but not in djLint's scope -->
 <button href="javascript:void(0)">Click</button>
@@ -40,5 +39,5 @@
 
 <!-- Nested in Jinja block -->
 {% if show_link %}
-    <a href="/page/">Link</a>
+    <a href="{% url 'page' %}">Link</a>
 {% endif %}

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.fixed.snap
@@ -19,7 +19,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 
 <!-- Multiline form with uppercase method -->
 <form
-    action="/submit/"
+    action="{% url 'submit' %}"
     method="post"
 ></form>
 

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.html
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.html
@@ -16,7 +16,7 @@
 
 <!-- Multiline form with uppercase method -->
 <form
-    action="/submit/"
+    action="{% url 'submit' %}"
     method="POST"
 ></form>
 

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.invalid.snap
@@ -94,7 +94,7 @@ Error:
 Error: 
   × Form method `POST` should be lowercase.
     ╭─[tests/check/uppercase_form_method/uppercase_form_method.invalid.html:20:13]
- 19 │     action="/submit/"
+ 19 │     action="{% url 'submit' %}"
  20 │     method="POST"
     ·             ──┬─
     ·               ╰── here

--- a/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.valid.html
+++ b/crates/djangofmt_lint/tests/check/uppercase_form_method/uppercase_form_method.valid.html
@@ -20,10 +20,10 @@
 <form method=post></form>
 
 <!-- No method attribute -->
-<form action="/submit/"></form>
+<form action="{% url 'submit' %}"></form>
 
 <!-- Multiline with lowercase method -->
 <form
-    action="/submit/"
+    action="{% url 'submit' %}"
     method="post"
 ></form>

--- a/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
+++ b/crates/djangofmt_lint/tests/check/use_https/use_https.valid.html
@@ -12,8 +12,9 @@
 <img srcset="http://localhost:5173/a.png 1x, https://example.com/b.png 2x" alt="" width="0" height="0">
 
 <!-- Relative and root-relative URLs -->
-<a href="/page/">Link</a>
 <a href="page.html">Link</a>
+<!-- `/page/` is a root-relative path django-url-pattern flags; `<area>` is out of its scope -->
+<area href="/page/">
 <img src="/assets/logo.png" alt="" width="0" height="0">
 
 <!-- Protocol-relative URLs (caller defers to surrounding page scheme) -->
@@ -27,8 +28,9 @@
 <a href="ftp://example.com">FTP</a>
 <a href="#section">Anchor</a>
 
-<!-- No false positive when `http://` appears mid-value rather than as the scheme -->
-<a href="/redirect?to=http://example.com">Link</a>
+<!-- No false positive when `http://` appears mid-value rather than as the scheme
+     (`<area>` keeps this internal path out of django-url-pattern's scope) -->
+<area href="/redirect?to=http://example.com">
 <meta name="description" content="See http://example.com for details">
 
 <!-- Interpolation without a literal `http://` prefix is not flagged -->


### PR DESCRIPTION
## What it does
Checks for hardcoded internal URLs in HTML link attributes that should use Django's `{% url %}` template tag.

## Why is this bad?
Hardcoded internal paths duplicate the routing configuration into every template and break silently when a `urls.py` entry is renamed or remounted. The `{% url %}` template tag resolves paths from named URL patterns at render time, so the template stays correct across refactors and respects URL namespacing (`app_name`, `instance_namespace`).

## Example
```html
<a href="/profile/">Profile</a>
<form action="/login/"></form>
```

Use instead:
```html
<a href="{% url 'profile' %}">Profile</a>
<form action="{% url 'login' %}"></form>
```

## References
- [Django: the `url` template tag](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#url)
- [Django: URL dispatcher](https://docs.djangoproject.com/en/stable/topics/http/urls/)

Part of #231 