### PR TITLE
refactor(lint): fold attr value pattern

### DIFF
--- a/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
@@ -74,32 +74,34 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     }
 
     for attr in &element.attrs {
-        if let Attribute::Native(NativeAttribute { name, value, .. }) = attr {
-            if !name.eq_ignore_ascii_case("method") {
-                continue;
-            }
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            ..
+        }) = attr
+        else {
+            continue;
+        };
 
-            // Skip if no value
-            let Some((value_str, offset)) = value else {
-                continue;
-            };
+        if !name.eq_ignore_ascii_case("method") {
+            continue;
+        }
 
-            // Skip interpolated values
-            if contains_interpolation(value_str) {
-                continue;
-            }
+        // Skip interpolated values
+        if contains_interpolation(value_str) {
+            continue;
+        }
 
-            let allowed: &[&str] = &["get", "post", "dialog"];
-            if !allowed.iter().any(|v| v.eq_ignore_ascii_case(value_str)) {
-                checker.report_diagnostic(
-                    &InvalidAttrValue {
-                        value: (*value_str).to_string(),
-                        attribute: "method",
-                        allowed,
-                    },
-                    (*offset, value_str.len()).into(),
-                );
-            }
+        let allowed: &[&str] = &["get", "post", "dialog"];
+        if !allowed.iter().any(|v| v.eq_ignore_ascii_case(value_str)) {
+            checker.report_diagnostic(
+                &InvalidAttrValue {
+                    value: (*value_str).to_string(),
+                    attribute: "method",
+                    allowed,
+                },
+                (*offset, value_str.len()).into(),
+            );
         }
     }
 }

--- a/crates/djangofmt_lint/src/rules/style/empty_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/style/empty_attr_value.rs
@@ -56,17 +56,18 @@ impl Violation for EmptyAttrValue<'_> {
 
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute { name, value, quote }) = attr else {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            quote,
+        }) = attr
+        else {
             continue;
         };
 
         if !name.eq_ignore_ascii_case("id") && !name.eq_ignore_ascii_case("class") {
             continue;
         }
-
-        let Some((value_str, offset)) = value else {
-            continue;
-        };
 
         if !value_str.is_empty() {
             continue;

--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -69,17 +69,18 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     }
 
     for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute { name, value, .. }) = attr else {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            ..
+        }) = attr
+        else {
             continue;
         };
 
         if !name.eq_ignore_ascii_case("action") {
             continue;
         }
-
-        let Some((value_str, offset)) = value else {
-            continue;
-        };
 
         if contains_interpolation(value_str) {
             continue;

--- a/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
+++ b/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
@@ -80,17 +80,18 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     };
 
     for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute { name, value, quote }) = attr else {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            quote,
+        }) = attr
+        else {
             continue;
         };
 
         if !name.eq_ignore_ascii_case("type") {
             continue;
         }
-
-        let Some((value_str, offset)) = value else {
-            continue;
-        };
 
         if contains_interpolation(value_str) {
             continue;

--- a/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
+++ b/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
@@ -67,17 +67,18 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     }
 
     for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute { name, value, .. }) = attr else {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            ..
+        }) = attr
+        else {
             continue;
         };
 
         if !name.eq_ignore_ascii_case("method") {
             continue;
         }
-
-        let Some((value_str, offset)) = value else {
-            continue;
-        };
 
         if contains_interpolation(value_str) {
             continue;

--- a/crates/djangofmt_lint/src/rules/suspicious/javascript_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/javascript_url.rs
@@ -74,16 +74,18 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         return;
     }
     for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute { name, value, .. }) = attr else {
+        let Attribute::Native(NativeAttribute {
+            name,
+            value: Some((value_str, offset)),
+            ..
+        }) = attr
+        else {
             continue;
         };
         let Some(canonical) = attr_names
             .iter()
             .find(|candidate| candidate.eq_ignore_ascii_case(name))
         else {
-            continue;
-        };
-        let Some((value_str, offset)) = value else {
             continue;
         };
         if contains_interpolation(value_str) {


### PR DESCRIPTION
Replace every: 


```rust
let Attribute::Native(NativeAttribute { name, value, quote }) = attr else {
{
    continue;
};

...

let Some((value_str, offset)) = value else {
    continue;
};

```
with destructuring 
```rust
let Attribute::Native(NativeAttribute { name, value: Some((value_str, offset)), quote }) = attr else {
    continue;
};
```
