### PR TITLE
refactor(lint): extract jinja-aware attr-presence helper

### DIFF
--- a/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
@@ -1,7 +1,8 @@
-use markup_fmt::ast::{Attribute, Element, JinjaBlock, JinjaTagOrChildren};
+use markup_fmt::ast::Element;
 
 use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::declares_native_attr;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 
 /// ## What it does
@@ -53,25 +54,14 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         return;
     }
 
-    if element.attrs.iter().any(attr_declares_lang) {
+    if element
+        .attrs
+        .iter()
+        .any(|attr| declares_native_attr(attr, "lang"))
+    {
         return;
     }
 
     let offset = checker.source_offset(element.tag_name);
     checker.report_diagnostic(&MissingHtmlLang, (offset, element.tag_name.len()).into());
-}
-
-fn attr_declares_lang(attr: &Attribute<'_>) -> bool {
-    match attr {
-        Attribute::Native(native) => native.name.eq_ignore_ascii_case("lang"),
-        Attribute::JinjaBlock(block) => jinja_block_declares_lang(block),
-        _ => false,
-    }
-}
-
-fn jinja_block_declares_lang(block: &JinjaBlock<'_, Attribute<'_>>) -> bool {
-    block.body.iter().any(|item| match item {
-        JinjaTagOrChildren::Children(children) => children.iter().any(attr_declares_lang),
-        JinjaTagOrChildren::Tag(_) => false,
-    })
 }

--- a/crates/djangofmt_lint/src/rules/helpers.rs
+++ b/crates/djangofmt_lint/src/rules/helpers.rs
@@ -1,3 +1,5 @@
+use markup_fmt::ast::{Attribute, JinjaBlock, JinjaTagOrChildren};
+
 /// Returns true if the value contains Jinja/Django interpolation markers.
 ///
 /// Values with `{{` or `{%` are dynamic and should be skipped by most rules.
@@ -20,6 +22,29 @@ pub fn srcset_candidates(value: &str, base: usize) -> impl Iterator<Item = (&str
         let trimmed = candidate.trim_start_matches(|c: char| c.is_ascii_whitespace());
         let url = trimmed.split_ascii_whitespace().next()?;
         Some((url, base + start + candidate.len() - trimmed.len()))
+    })
+}
+
+/// Returns true if `attr` declares a native HTML attribute named `name`
+/// (case-insensitive), either directly or recursively inside any branch of a
+/// Jinja `{% if %}…{% endif %}` block.
+///
+/// Jinja `Tag` items are treated as non-declaring; we don't peek inside other
+/// tag bodies.
+pub fn declares_native_attr(attr: &Attribute<'_>, name: &str) -> bool {
+    match attr {
+        Attribute::Native(native) => native.name.eq_ignore_ascii_case(name),
+        Attribute::JinjaBlock(block) => jinja_block_declares_native_attr(block, name),
+        _ => false,
+    }
+}
+
+fn jinja_block_declares_native_attr(block: &JinjaBlock<'_, Attribute<'_>>, name: &str) -> bool {
+    block.body.iter().any(|item| match item {
+        JinjaTagOrChildren::Children(children) => {
+            children.iter().any(|attr| declares_native_attr(attr, name))
+        }
+        JinjaTagOrChildren::Tag(_) => false,
     })
 }
 


### PR DESCRIPTION
Pulls the `attr_declares_lang` / `jinja_block_declares_lang` pair out of `missing_html_lang.rs` into a shared `declares_native_attr(attr, name)` helper in `rules::helpers`. The helper recurses through Jinja `{% if %}` branches so rules that need "is this attribute present, including dynamically?" semantics can share a single implementation.

Three upcoming rule branches (`missing-img-alt`, `missing-img-dimensions`, `missing-title`) duplicate the same shape; they'll adopt this helper on rebase.