### PR TITLE
refactor(test): Share benchmark template list via `ALL_TEMPLATES` const

### DIFF
--- a/crates/djangofmt_benchmark/benches/formatter.rs
+++ b/crates/djangofmt_benchmark/benches/formatter.rs
@@ -2,28 +2,13 @@ use djangofmt::{
     commands::format::{FormatterConfig, format_text},
     line_width::{IndentWidth, LineLength, SelfClosing},
 };
-use djangofmt_benchmark::{
-    DJANGO_TEMPLATE_ATTR_DENSE, DJANGO_TEMPLATE_DEEPLY_NESTED, DJANGO_TEMPLATE_FORM_HEAVY,
-    DJANGO_TEMPLATE_LARGE, DJANGO_TEMPLATE_SMALL, DJANGO_TEMPLATE_TAG_DENSE,
-    DJANGO_TEMPLATE_WITH_SCRIPT_AND_STYLE_TAGS, JINJA_TEMPLATE_FORM_HEAVY, JINJA_TEMPLATE_LARGE,
-    TestFile,
-};
+use djangofmt_benchmark::{ALL_TEMPLATES, TestFile};
 
 fn main() {
     divan::main();
 }
 
-#[divan::bench(args = [
-  &DJANGO_TEMPLATE_SMALL,
-  &DJANGO_TEMPLATE_WITH_SCRIPT_AND_STYLE_TAGS,
-  &DJANGO_TEMPLATE_LARGE,
-  &DJANGO_TEMPLATE_DEEPLY_NESTED,
-  &DJANGO_TEMPLATE_TAG_DENSE,
-  &DJANGO_TEMPLATE_FORM_HEAVY,
-  &DJANGO_TEMPLATE_ATTR_DENSE,
-  &JINJA_TEMPLATE_FORM_HEAVY,
-  &JINJA_TEMPLATE_LARGE]
-)]
+#[divan::bench(args = ALL_TEMPLATES)]
 fn format_templates(bencher: divan::Bencher, template: &'static TestFile) {
     let config = FormatterConfig::new(
         LineLength::default(),

--- a/crates/djangofmt_benchmark/benches/linter.rs
+++ b/crates/djangofmt_benchmark/benches/linter.rs
@@ -1,9 +1,4 @@
-use djangofmt_benchmark::{
-    DJANGO_TEMPLATE_ATTR_DENSE, DJANGO_TEMPLATE_DEEPLY_NESTED, DJANGO_TEMPLATE_FORM_HEAVY,
-    DJANGO_TEMPLATE_LARGE, DJANGO_TEMPLATE_SMALL, DJANGO_TEMPLATE_TAG_DENSE,
-    DJANGO_TEMPLATE_WITH_SCRIPT_AND_STYLE_TAGS, JINJA_TEMPLATE_FORM_HEAVY, JINJA_TEMPLATE_LARGE,
-    TestFile,
-};
+use djangofmt_benchmark::{ALL_TEMPLATES, TestFile};
 use djangofmt_lint::{Settings, check_ast};
 use markup_fmt::parser::Parser;
 
@@ -11,17 +6,7 @@ fn main() {
     divan::main();
 }
 
-#[divan::bench(args = [
-  &DJANGO_TEMPLATE_SMALL,
-  &DJANGO_TEMPLATE_WITH_SCRIPT_AND_STYLE_TAGS,
-  &DJANGO_TEMPLATE_LARGE,
-  &DJANGO_TEMPLATE_DEEPLY_NESTED,
-  &DJANGO_TEMPLATE_TAG_DENSE,
-  &DJANGO_TEMPLATE_FORM_HEAVY,
-  &DJANGO_TEMPLATE_ATTR_DENSE,
-  &JINJA_TEMPLATE_FORM_HEAVY,
-  &JINJA_TEMPLATE_LARGE]
-)]
+#[divan::bench(args = ALL_TEMPLATES)]
 fn check_templates(bencher: divan::Bencher, template: &'static TestFile) {
     let settings = Settings::default();
 

--- a/crates/djangofmt_benchmark/benches/parser.rs
+++ b/crates/djangofmt_benchmark/benches/parser.rs
@@ -1,26 +1,11 @@
-use djangofmt_benchmark::{
-    DJANGO_TEMPLATE_ATTR_DENSE, DJANGO_TEMPLATE_DEEPLY_NESTED, DJANGO_TEMPLATE_FORM_HEAVY,
-    DJANGO_TEMPLATE_LARGE, DJANGO_TEMPLATE_SMALL, DJANGO_TEMPLATE_TAG_DENSE,
-    DJANGO_TEMPLATE_WITH_SCRIPT_AND_STYLE_TAGS, JINJA_TEMPLATE_FORM_HEAVY, JINJA_TEMPLATE_LARGE,
-    TestFile,
-};
+use djangofmt_benchmark::{ALL_TEMPLATES, TestFile};
 use markup_fmt::parser::Parser;
 
 fn main() {
     divan::main();
 }
 
-#[divan::bench(args = [
-  &DJANGO_TEMPLATE_SMALL,
-  &DJANGO_TEMPLATE_WITH_SCRIPT_AND_STYLE_TAGS,
-  &DJANGO_TEMPLATE_LARGE,
-  &DJANGO_TEMPLATE_DEEPLY_NESTED,
-  &DJANGO_TEMPLATE_TAG_DENSE,
-  &DJANGO_TEMPLATE_FORM_HEAVY,
-  &DJANGO_TEMPLATE_ATTR_DENSE,
-  &JINJA_TEMPLATE_FORM_HEAVY,
-  &JINJA_TEMPLATE_LARGE]
-)]
+#[divan::bench(args = ALL_TEMPLATES)]
 fn parse_templates(bencher: divan::Bencher, template: &'static TestFile) {
     bencher
         .counter(divan::counter::BytesCount::of_str(template.code))

--- a/crates/djangofmt_benchmark/src/lib.rs
+++ b/crates/djangofmt_benchmark/src/lib.rs
@@ -49,6 +49,19 @@ pub static JINJA_TEMPLATE_FORM_HEAVY: TestFile = TestFile {
     code: include_str!("../resources/zulip/upgrade.html"),
     profile: Profile::Jinja,
 };
+
+pub static ALL_TEMPLATES: [&TestFile; 9] = [
+    &DJANGO_TEMPLATE_SMALL,
+    &DJANGO_TEMPLATE_WITH_SCRIPT_AND_STYLE_TAGS,
+    &DJANGO_TEMPLATE_LARGE,
+    &DJANGO_TEMPLATE_DEEPLY_NESTED,
+    &DJANGO_TEMPLATE_TAG_DENSE,
+    &DJANGO_TEMPLATE_FORM_HEAVY,
+    &DJANGO_TEMPLATE_ATTR_DENSE,
+    &JINJA_TEMPLATE_FORM_HEAVY,
+    &JINJA_TEMPLATE_LARGE,
+];
+
 #[derive(Clone)]
 pub struct TestFile {
     pub name: &'static str,


### PR DESCRIPTION
Was duplicating import for no reason