### PR TITLE
refactor(lint): check img height/width attributes in a single pass

### DIFF
--- a/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
@@ -53,17 +53,14 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         return;
     }
 
-    let has_height = element
-        .attrs
-        .iter()
-        .any(|attr| declares_native_attr(attr, "height"));
-    let has_width = element
-        .attrs
-        .iter()
-        .any(|attr| declares_native_attr(attr, "width"));
-
-    if has_height && has_width {
-        return;
+    let mut has_height = false;
+    let mut has_width = false;
+    for attr in &element.attrs {
+        has_height = has_height || declares_native_attr(attr, "height");
+        has_width = has_width || declares_native_attr(attr, "width");
+        if has_height && has_width {
+            return;
+        }
     }
 
     let offset = checker.source_offset(element.tag_name);


### PR DESCRIPTION
Merge the two element.attrs scans in `missing_img_dimensions` into a single short-circuiting pass.

The rule previously iterated `element.attrs` twice (once for `height`, once for `width`); it now walks the attribute list once and returns early as soon as both are found. Behaviour is unchanged — a violation is still reported iff an `<img>` is missing `height` and/or `width`. Pure per-element hot-path micro-optimization.