### PR TITLE
Add rule selection (select/ignore + preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### ⛰️ Features
+
+- *(lint)* Add `select` / `ignore` rule-selection configuration with preview/stability gating
+
 ## [0.2.10](https://github.com/UnknownPlatypus/djangofmt/compare/v0.2.9..v0.2.10) - 2026-06-03
 
 ### ⛰️ Features

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Lint rule selection lives in a nested `[tool.djangofmt.lint]` subtable (mirrorin
 
 ```toml
 [tool.djangofmt.lint]
-# Replaces the default rule set when provided (omit to keep "ALL").
+# Replaces the default rule set when provided (omit to keep the default stable set).
 select = ["ALL"]
 # Disable specific rules or whole categories.
 ignore = ["invalid-attr-value"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ Command-line arguments always take precedence over `pyproject.toml` settings.
 
 See [Controlling the formatting](https://unknownplatypus.github.io/djangofmt/docs/formatting/) for the behaviour of each option and how to opt into per-node overrides.
 
+Lint rule selection lives in a nested `[tool.djangofmt.lint]` subtable (mirroring `ruff`). The `check` subcommand is still preview; expect the surface to evolve.
+
+```toml
+[tool.djangofmt.lint]
+# Replaces the default rule set when provided (omit to keep "ALL").
+select = ["ALL"]
+# Disable specific rules or whole categories.
+ignore = ["invalid-attr-value"]
+# Extend, rather than replace, on top of the inherited set.
+extend-select = ["correctness"]
+extend-ignore = []
+# Opt into preview-stability rules.
+preview = false
+```
+
 ## Editor integration
 
 See the [editor integration guide](https://unknownplatypus.github.io/djangofmt/docs/editor-integration/).

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Command-line arguments always take precedence over `pyproject.toml` settings.
 
 See [Controlling the formatting](https://unknownplatypus.github.io/djangofmt/docs/formatting/) for the behaviour of each option and how to opt into per-node overrides.
 
-Lint rule selection lives in a nested `[tool.djangofmt.lint]` subtable (mirroring `ruff`). The `check` subcommand is still preview; expect the surface to evolve.
+Lint rule selection lives in a nested `[tool.djangofmt.lint]` subtable, alongside the formatter options above. The `check` subcommand is still preview; expect the surface to evolve.
 
 ```toml
 [tool.djangofmt.lint]

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -2,11 +2,48 @@ use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 use crate::logging::LogLevel;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
-use djangofmt_lint::RuleSelector;
+use djangofmt_lint::{ParseError, RuleSelector};
 use serde::Deserialize;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use markup_fmt::Language;
+
+/// A comma-separated list of [`RuleSelector`]s parsed from a single CLI flag.
+///
+/// Empty entries — from leading, trailing, or doubled commas — and surrounding
+/// whitespace are ignored, so `--select=correctness,` and `--select=a, b`
+/// parse cleanly. A non-empty but unrecognised entry is still an error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuleSelectors(Vec<RuleSelector>);
+
+impl std::ops::Deref for RuleSelectors {
+    type Target = [RuleSelector];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromStr for RuleSelectors {
+    type Err = ParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(RuleSelector::from_str)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Self)
+    }
+}
+
+impl From<Vec<RuleSelector>> for RuleSelectors {
+    fn from(selectors: Vec<RuleSelector>) -> Self {
+        Self(selectors)
+    }
+}
 
 /// All configuration options that can be passed "globally",
 /// i.e., can be passed to all subcommands
@@ -195,37 +232,17 @@ pub struct CheckCommand {
 
     /// Comma-separated list of rule names or categories to enable (or `ALL`).
     /// Replaces the default rule set when provided.
-    #[arg(
-        long,
-        value_delimiter = ',',
-        value_name = "RULE_OR_CATEGORY",
-        help_heading = "Rule selection"
-    )]
-    pub select: Option<Vec<RuleSelector>>,
+    #[arg(long, value_name = "RULE_OR_CATEGORY", help_heading = "Rule selection")]
+    pub select: Option<RuleSelectors>,
     /// Comma-separated list of rule names or categories to disable.
-    #[arg(
-        long,
-        value_delimiter = ',',
-        value_name = "RULE_OR_CATEGORY",
-        help_heading = "Rule selection"
-    )]
-    pub ignore: Option<Vec<RuleSelector>>,
+    #[arg(long, value_name = "RULE_OR_CATEGORY", help_heading = "Rule selection")]
+    pub ignore: Option<RuleSelectors>,
     /// Like `--select`, but adds on top of the existing rule set instead of replacing it.
-    #[arg(
-        long,
-        value_delimiter = ',',
-        value_name = "RULE_OR_CATEGORY",
-        help_heading = "Rule selection"
-    )]
-    pub extend_select: Option<Vec<RuleSelector>>,
+    #[arg(long, value_name = "RULE_OR_CATEGORY", help_heading = "Rule selection")]
+    pub extend_select: Option<RuleSelectors>,
     /// Like `--ignore`, but adds on top of the existing ignore set instead of replacing it.
-    #[arg(
-        long,
-        value_delimiter = ',',
-        value_name = "RULE_OR_CATEGORY",
-        help_heading = "Rule selection"
-    )]
-    pub extend_ignore: Option<Vec<RuleSelector>>,
+    #[arg(long, value_name = "RULE_OR_CATEGORY", help_heading = "Rule selection")]
+    pub extend_ignore: Option<RuleSelectors>,
     /// Enable preview-stability rules. Use `--no-preview` to disable.
     #[arg(long, overrides_with("no_preview"), help_heading = "Rule selection")]
     pub preview: bool,

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -2,6 +2,7 @@ use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 use crate::logging::LogLevel;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
+use djangofmt_lint::RuleSelector;
 use serde::Deserialize;
 use std::path::PathBuf;
 
@@ -191,6 +192,46 @@ pub struct CheckCommand {
     pub no_show_fixes: bool,
     #[clap(flatten)]
     pub file_selection: FileSelectionArgs,
+
+    /// Comma-separated list of rule codes or categories to enable (or `ALL`).
+    /// Replaces the default rule set when provided.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_OR_CATEGORY",
+        help_heading = "Rule selection"
+    )]
+    pub select: Option<Vec<RuleSelector>>,
+    /// Comma-separated list of rule codes or categories to disable.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_OR_CATEGORY",
+        help_heading = "Rule selection"
+    )]
+    pub ignore: Option<Vec<RuleSelector>>,
+    /// Like `--select`, but adds on top of the existing rule set instead of replacing it.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_OR_CATEGORY",
+        help_heading = "Rule selection"
+    )]
+    pub extend_select: Option<Vec<RuleSelector>>,
+    /// Like `--ignore`, but adds on top of the existing ignore set instead of replacing it.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_OR_CATEGORY",
+        help_heading = "Rule selection"
+    )]
+    pub extend_ignore: Option<Vec<RuleSelector>>,
+    /// Enable preview-stability rules. Use `--no-preview` to disable.
+    #[arg(long, overrides_with("no_preview"), help_heading = "Rule selection")]
+    pub preview: bool,
+    /// Disable preview-stability rules.
+    #[arg(long, overrides_with("preview"), hide = true)]
+    pub no_preview: bool,
 }
 
 #[allow(clippy::module_name_repetitions)]

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -193,7 +193,7 @@ pub struct CheckCommand {
     #[clap(flatten)]
     pub file_selection: FileSelectionArgs,
 
-    /// Comma-separated list of rule codes or categories to enable (or `ALL`).
+    /// Comma-separated list of rule names or categories to enable (or `ALL`).
     /// Replaces the default rule set when provided.
     #[arg(
         long,
@@ -202,7 +202,7 @@ pub struct CheckCommand {
         help_heading = "Rule selection"
     )]
     pub select: Option<Vec<RuleSelector>>,
-    /// Comma-separated list of rule codes or categories to disable.
+    /// Comma-separated list of rule names or categories to disable.
     #[arg(
         long,
         value_delimiter = ',',

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,6 +1,6 @@
 use djangofmt_lint::{
     Applicability, FileDiagnostics, FixerError, PreviewMode, RuleFixSummary, RuleSelection,
-    RuleSelector, Settings, check_ast, lint_fix,
+    Settings, check_ast, lint_fix,
 };
 use markup_fmt::FormatError;
 use markup_fmt::parser::Parser;
@@ -226,9 +226,10 @@ fn print_show_fixes(results: &[CheckResult], total_applied: usize) {
 /// `PreviewMode` precedence is `--preview` > `--no-preview` > pyproject >
 /// disabled.
 fn resolve_settings(cli: &CheckCommand, pyproject: &PyprojectSettings) -> Settings {
-    let pyproject_layer = Layer::from_pyproject(pyproject.lint.as_ref());
-    let cli_layer = Layer::from_cli(cli);
-    let selections = [pyproject_layer.as_selection(), cli_layer.as_selection()];
+    let selections = [
+        pyproject_selection(pyproject.lint.as_ref()),
+        cli_selection(cli),
+    ];
 
     Settings::from_selections(&selections, resolve_preview(cli, pyproject))
 }
@@ -245,54 +246,27 @@ fn resolve_preview(cli: &CheckCommand, pyproject: &PyprojectSettings) -> Preview
         .map_or(PreviewMode::Disabled, PreviewMode::from)
 }
 
-/// Borrowed view of a single rule-selection layer.
+/// Build the pyproject rule-selection layer.
 ///
-/// Mirrors `LintTomlSettings` / `CheckCommand`'s rule-selection fields with
-/// uniform `Option<&[...]>` slots, ready to be converted to a
-/// [`RuleSelection`] for [`Settings::from_selections`].
-struct Layer<'a> {
-    select: Option<&'a [RuleSelector]>,
-    ignore: Option<&'a [RuleSelector]>,
-    extend_select: Option<&'a [RuleSelector]>,
-    extend_ignore: Option<&'a [RuleSelector]>,
+/// A missing `[tool.djangofmt.lint]` table yields an empty layer (`select`
+/// `None`, the rest `&[]`), which extends the implicit default rather than
+/// replacing it.
+fn pyproject_selection(lint: Option<&LintTomlSettings>) -> RuleSelection<'_> {
+    lint.map_or_else(RuleSelection::default, |l| RuleSelection {
+        select: l.select.as_deref(),
+        ignore: l.ignore.as_deref().unwrap_or(&[]),
+        extend_select: l.extend_select.as_deref().unwrap_or(&[]),
+        extend_ignore: l.extend_ignore.as_deref().unwrap_or(&[]),
+    })
 }
 
-impl<'a> Layer<'a> {
-    fn from_pyproject(lint: Option<&'a LintTomlSettings>) -> Self {
-        lint.map_or_else(Self::empty, |l| Self {
-            select: l.select.as_deref(),
-            ignore: l.ignore.as_deref(),
-            extend_select: l.extend_select.as_deref(),
-            extend_ignore: l.extend_ignore.as_deref(),
-        })
-    }
-
-    fn from_cli(cli: &'a CheckCommand) -> Self {
-        Self {
-            select: cli.select.as_deref(),
-            ignore: cli.ignore.as_deref(),
-            extend_select: cli.extend_select.as_deref(),
-            extend_ignore: cli.extend_ignore.as_deref(),
-        }
-    }
-
-    const fn empty() -> Self {
-        Self {
-            select: None,
-            ignore: None,
-            extend_select: None,
-            extend_ignore: None,
-        }
-    }
-
-    /// Convert to a [`RuleSelection`] for the lint crate's resolver.
-    fn as_selection(&self) -> RuleSelection<'a> {
-        RuleSelection {
-            select: self.select,
-            ignore: self.ignore.unwrap_or(&[]),
-            extend_select: self.extend_select.unwrap_or(&[]),
-            extend_ignore: self.extend_ignore.unwrap_or(&[]),
-        }
+/// Build the CLI rule-selection layer.
+fn cli_selection(cli: &CheckCommand) -> RuleSelection<'_> {
+    RuleSelection {
+        select: cli.select.as_deref(),
+        ignore: cli.ignore.as_deref().unwrap_or(&[]),
+        extend_select: cli.extend_select.as_deref().unwrap_or(&[]),
+        extend_ignore: cli.extend_ignore.as_deref().unwrap_or(&[]),
     }
 }
 
@@ -382,7 +356,7 @@ fn check_path(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use djangofmt_lint::{Rule, RuleCategory};
+    use djangofmt_lint::{Rule, RuleCategory, RuleSelector};
     use tracing_test::traced_test;
 
     #[test]

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,5 +1,6 @@
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings, check_ast, lint_fix,
+    Applicability, FileDiagnostics, FixerError, PreviewMode, RuleFixSummary, RuleSelection,
+    RuleSelector, Settings, check_ast, lint_fix,
 };
 use markup_fmt::FormatError;
 use markup_fmt::parser::Parser;
@@ -16,7 +17,7 @@ use crate::ExitStatus;
 use crate::args::{CheckCommand, Profile};
 use crate::error::{CommandError, ParseError, Result};
 use crate::fs::relativize_path;
-use crate::pyproject::PyprojectSettings;
+use crate::pyproject::{LintTomlSettings, PyprojectSettings};
 use crate::resolver::resolve_bool_arg;
 
 /// Resolved fix-related configuration after merging CLI args with pyproject settings.
@@ -64,7 +65,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
     let resolved = super::resolve_command(&args.files, args.profile, &args.file_selection)?;
     let config = CheckConfig::from_args(args, &resolved.pyproject);
 
-    let settings = Settings::default();
+    let settings = resolve_settings(args, &resolved.pyproject);
     let threshold = if config.unsafe_fixes {
         Applicability::Unsafe
     } else {
@@ -213,6 +214,88 @@ fn print_show_fixes(results: &[CheckResult], total_applied: usize) {
     }
 }
 
+/// Resolve the linter [`Settings`] from CLI args and pyproject options.
+///
+/// Builds two [`RuleSelection`] layers (pyproject < CLI) and hands them to
+/// [`Settings::from_selections`], which prepends the implicit `select=[ALL]`
+/// base layer and folds them in order. A layer with `Some(select)` replaces
+/// the running set (this is what makes `--select=ALL` on the CLI cleanly
+/// override `[tool.djangofmt.lint] ignore = [...]` in pyproject), while a
+/// layer with `select == None` extends the running set additively.
+///
+/// `PreviewMode` precedence is `--preview` > `--no-preview` > pyproject >
+/// disabled.
+fn resolve_settings(cli: &CheckCommand, pyproject: &PyprojectSettings) -> Settings {
+    let pyproject_layer = Layer::from_pyproject(pyproject.lint.as_ref());
+    let cli_layer = Layer::from_cli(cli);
+    let selections = [pyproject_layer.as_selection(), cli_layer.as_selection()];
+
+    Settings::from_selections(&selections, resolve_preview(cli, pyproject))
+}
+
+/// Resolve `PreviewMode` from CLI flags and pyproject options.
+fn resolve_preview(cli: &CheckCommand, pyproject: &PyprojectSettings) -> PreviewMode {
+    if let Some(enabled) = resolve_bool_arg(cli.preview, cli.no_preview) {
+        return PreviewMode::from(enabled);
+    }
+    pyproject
+        .lint
+        .as_ref()
+        .and_then(|l| l.preview)
+        .map_or(PreviewMode::Disabled, PreviewMode::from)
+}
+
+/// Borrowed view of a single rule-selection layer.
+///
+/// Mirrors `LintTomlSettings` / `CheckCommand`'s rule-selection fields with
+/// uniform `Option<&[...]>` slots, ready to be converted to a
+/// [`RuleSelection`] for [`Settings::from_selections`].
+struct Layer<'a> {
+    select: Option<&'a [RuleSelector]>,
+    ignore: Option<&'a [RuleSelector]>,
+    extend_select: Option<&'a [RuleSelector]>,
+    extend_ignore: Option<&'a [RuleSelector]>,
+}
+
+impl<'a> Layer<'a> {
+    fn from_pyproject(lint: Option<&'a LintTomlSettings>) -> Self {
+        lint.map_or_else(Self::empty, |l| Self {
+            select: l.select.as_deref(),
+            ignore: l.ignore.as_deref(),
+            extend_select: l.extend_select.as_deref(),
+            extend_ignore: l.extend_ignore.as_deref(),
+        })
+    }
+
+    fn from_cli(cli: &'a CheckCommand) -> Self {
+        Self {
+            select: cli.select.as_deref(),
+            ignore: cli.ignore.as_deref(),
+            extend_select: cli.extend_select.as_deref(),
+            extend_ignore: cli.extend_ignore.as_deref(),
+        }
+    }
+
+    const fn empty() -> Self {
+        Self {
+            select: None,
+            ignore: None,
+            extend_select: None,
+            extend_ignore: None,
+        }
+    }
+
+    /// Convert to a [`RuleSelection`] for the lint crate's resolver.
+    fn as_selection(&self) -> RuleSelection<'a> {
+        RuleSelection {
+            select: self.select,
+            ignore: self.ignore.unwrap_or(&[]),
+            extend_select: self.extend_select.unwrap_or(&[]),
+            extend_ignore: self.extend_ignore.unwrap_or(&[]),
+        }
+    }
+}
+
 /// Check the file at the given [`Path`] for linting issues.
 #[tracing::instrument(
     level = "debug",
@@ -298,9 +381,8 @@ fn check_path(
 
 #[cfg(test)]
 mod tests {
-    use super::{CheckConfig, print_summary};
-    use crate::args::CheckCommand;
-    use crate::pyproject::PyprojectSettings;
+    use super::*;
+    use djangofmt_lint::{Rule, RuleCategory};
     use tracing_test::traced_test;
 
     #[test]
@@ -467,5 +549,156 @@ mod tests {
         assert!(logs_contain("Found 5 errors."));
         assert!(!logs_contain("fixable with"));
         assert!(!logs_contain("hidden"));
+    }
+
+    fn cli_default() -> CheckCommand {
+        CheckCommand::default()
+    }
+
+    #[test]
+    fn defaults_enable_invalid_attr_value() {
+        let cli = cli_default();
+        let pyproject = PyprojectSettings::default();
+        let settings = resolve_settings(&cli, &pyproject);
+        assert!(settings.is_enabled(Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn cli_ignore_disables_rule() {
+        let cli = CheckCommand {
+            ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+            ..cli_default()
+        };
+        let pyproject = PyprojectSettings::default();
+        let settings = resolve_settings(&cli, &pyproject);
+        assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn cli_select_replaces_pyproject_select() {
+        // pyproject says select = []; CLI says select = [ALL] — CLI wins.
+        let cli = CheckCommand {
+            select: Some(vec![RuleSelector::All]),
+            ..cli_default()
+        };
+        let pyproject = PyprojectSettings {
+            lint: Some(LintTomlSettings {
+                select: Some(vec![]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let settings = resolve_settings(&cli, &pyproject);
+        assert!(settings.is_enabled(Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn pyproject_ignore_suppresses_then_cli_select_all_reenables() {
+        // pyproject: ignore=[invalid-attr-value] -> suppressed at default ALL.
+        let pyproject_only = PyprojectSettings {
+            lint: Some(LintTomlSettings {
+                ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let cli_only = cli_default();
+        let settings = resolve_settings(&cli_only, &pyproject_only);
+        assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+
+        // CLI `select=[ALL]` *replaces*: the new running set is recomputed
+        // entirely from the CLI layer's selectors, discarding pyproject's
+        // ignore. Matches ruff's `RuleSelection`-replacement semantics.
+        let cli_with_select = CheckCommand {
+            select: Some(vec![RuleSelector::All]),
+            ..cli_default()
+        };
+        let settings = resolve_settings(&cli_with_select, &pyproject_only);
+        assert!(settings.is_enabled(Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn cli_exact_select_beats_pyproject_category_ignore() {
+        // pyproject: ignore=[correctness] (category level)
+        // CLI: select=[invalid-attr-value] (rule level)
+        // Rule-level specificity beats category-level: rule stays enabled.
+        let pyproject = PyprojectSettings {
+            lint: Some(LintTomlSettings {
+                ignore: Some(vec![RuleSelector::Category(RuleCategory::Correctness)]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let cli = CheckCommand {
+            select: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+            ..cli_default()
+        };
+        let settings = resolve_settings(&cli, &pyproject);
+        assert!(settings.is_enabled(Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn cli_extend_select_extends_pyproject() {
+        // pyproject select = [] (nothing enabled). CLI extend-select=[correctness].
+        let cli = CheckCommand {
+            extend_select: Some(vec![RuleSelector::Category(RuleCategory::Correctness)]),
+            ..cli_default()
+        };
+        let pyproject = PyprojectSettings {
+            lint: Some(LintTomlSettings {
+                select: Some(vec![]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let settings = resolve_settings(&cli, &pyproject);
+        assert!(settings.is_enabled(Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn preview_flag_precedence() {
+        let cli_preview = CheckCommand {
+            preview: true,
+            ..cli_default()
+        };
+        let pyproject = PyprojectSettings {
+            lint: Some(LintTomlSettings {
+                preview: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_preview(&cli_preview, &pyproject),
+            PreviewMode::Enabled
+        );
+
+        let cli_no_preview = CheckCommand {
+            no_preview: true,
+            ..cli_default()
+        };
+        let pyproject_preview = PyprojectSettings {
+            lint: Some(LintTomlSettings {
+                preview: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_preview(&cli_no_preview, &pyproject_preview),
+            PreviewMode::Disabled
+        );
+
+        // Fallback to pyproject.
+        assert_eq!(
+            resolve_preview(&cli_default(), &pyproject_preview),
+            PreviewMode::Enabled
+        );
+
+        // Fallback to disabled.
+        assert_eq!(
+            resolve_preview(&cli_default(), &PyprojectSettings::default()),
+            PreviewMode::Disabled
+        );
     }
 }

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -540,7 +540,7 @@ mod tests {
     #[test]
     fn cli_ignore_disables_rule() {
         let cli = CheckCommand {
-            ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+            ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)].into()),
             ..cli_default()
         };
         let pyproject = PyprojectSettings::default();
@@ -552,7 +552,7 @@ mod tests {
     fn cli_select_replaces_pyproject_select() {
         // pyproject says select = []; CLI says select = [ALL] — CLI wins.
         let cli = CheckCommand {
-            select: Some(vec![RuleSelector::All]),
+            select: Some(vec![RuleSelector::All].into()),
             ..cli_default()
         };
         let pyproject = PyprojectSettings {
@@ -585,7 +585,7 @@ mod tests {
         // ignore. This is the layer-replacement semantics (a layer with
         // `Some(select)` rebuilds the running set from scratch).
         let cli_with_select = CheckCommand {
-            select: Some(vec![RuleSelector::All]),
+            select: Some(vec![RuleSelector::All].into()),
             ..cli_default()
         };
         let settings = resolve_settings(&cli_with_select, &pyproject_only);
@@ -605,7 +605,7 @@ mod tests {
             ..Default::default()
         };
         let cli = CheckCommand {
-            select: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+            select: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)].into()),
             ..cli_default()
         };
         let settings = resolve_settings(&cli, &pyproject);
@@ -616,7 +616,7 @@ mod tests {
     fn cli_extend_select_extends_pyproject() {
         // pyproject select = [] (nothing enabled). CLI extend-select=[correctness].
         let cli = CheckCommand {
-            extend_select: Some(vec![RuleSelector::Category(RuleCategory::Correctness)]),
+            extend_select: Some(vec![RuleSelector::Category(RuleCategory::Correctness)].into()),
             ..cli_default()
         };
         let pyproject = PyprojectSettings {

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -608,7 +608,8 @@ mod tests {
 
         // CLI `select=[ALL]` *replaces*: the new running set is recomputed
         // entirely from the CLI layer's selectors, discarding pyproject's
-        // ignore. Matches ruff's `RuleSelection`-replacement semantics.
+        // ignore. This is the layer-replacement semantics (a layer with
+        // `Some(select)` rebuilds the running set from scratch).
         let cli_with_select = CheckCommand {
             select: Some(vec![RuleSelector::All]),
             ..cli_default()

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -29,6 +29,11 @@ pub struct PyprojectSettings {
     pub unsafe_fixes: Option<bool>,
     pub show_fixes: Option<bool>,
     /// Optional `[tool.djangofmt.lint]` subtable.
+    ///
+    /// Deserialized leniently (see `deserialize_lenient_lint`): a malformed
+    /// lint table (a typo'd selector or unknown key) is dropped with a warning
+    /// rather than discarding the surrounding formatting options.
+    #[serde(default, deserialize_with = "deserialize_lenient_lint")]
     pub lint: Option<LintTomlSettings>,
 }
 
@@ -48,6 +53,30 @@ pub struct LintTomlSettings {
     pub extend_select: Option<Vec<RuleSelector>>,
     pub extend_ignore: Option<Vec<RuleSelector>>,
     pub preview: Option<bool>,
+}
+
+/// Deserialize the optional `[tool.djangofmt.lint]` subtable leniently.
+///
+/// The lint table is buffered into a [`toml::Value`] and then converted to
+/// [`LintTomlSettings`]. A malformed lint table (a typo'd selector or an
+/// unknown key) is dropped with a warning rather than aborting the whole
+/// parse, so a single bad selector can't silently discard unrelated
+/// formatting options like `line-length` or `profile`.
+fn deserialize_lenient_lint<'de, D>(deserializer: D) -> Result<Option<LintTomlSettings>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = toml::Value::deserialize(deserializer)?;
+    let lint: Result<LintTomlSettings, _> = value.try_into();
+    match lint {
+        Ok(lint) => Ok(Some(lint)),
+        Err(err) => {
+            warn!(
+                "Ignoring invalid `[tool.djangofmt.lint]` config (other settings preserved): {err}"
+            );
+            Ok(None)
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -371,18 +400,17 @@ show-fixes = true
     }
 
     #[test]
-    fn test_load_options_unknown_key_in_lint_table_returns_default() {
-        // `deny_unknown_fields` on `LintTomlSettings` should cause the whole
-        // pyproject load to fall back to default (matches existing behavior
-        // for other unknown-key cases).
+    fn test_load_options_unknown_key_in_lint_table_drops_lint() {
+        // `deny_unknown_fields` on `LintTomlSettings` rejects the lint table,
+        // which is then dropped (lint = None); with no other settings present
+        // the result equals the default.
         let content = r#"
         [tool.djangofmt.lint]
         bogus = "value"
     "#;
-        assert_eq!(
-            load_options_from_pyproject_toml(content),
-            PyprojectSettings::default()
-        );
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(result.lint, None);
+        assert_eq!(result, PyprojectSettings::default());
     }
 
     #[test]
@@ -422,15 +450,45 @@ show-fixes = true
     }
 
     #[test]
-    fn test_load_options_rejects_invalid_rule_selector_in_lint_table() {
+    fn test_load_options_drops_invalid_rule_selector_in_lint_table() {
         let content = r#"
         [tool.djangofmt.lint]
         select = ["definitely-not-a-rule"]
     "#;
-        // Falls back to default on parse failure (matches existing behavior).
-        assert_eq!(
-            load_options_from_pyproject_toml(content),
-            PyprojectSettings::default()
-        );
+        // The malformed lint table is dropped (lint = None); with no other
+        // settings present the result equals the default.
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(result.lint, None);
+        assert_eq!(result, PyprojectSettings::default());
+    }
+
+    #[test]
+    fn test_invalid_lint_table_preserves_other_settings() {
+        // A bad selector in `[tool.djangofmt.lint]` must not discard unrelated
+        // formatting options like `line-length`.
+        let content = r#"
+        [tool.djangofmt]
+        line-length = 100
+        [tool.djangofmt.lint]
+        select = ["definitely-not-a-rule"]
+    "#;
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(result.line_length, Some(LineLength::try_from(100).unwrap()));
+        assert_eq!(result.lint, None);
+    }
+
+    #[test]
+    fn test_unknown_key_in_lint_table_preserves_other_settings() {
+        // An unknown key in the lint table (rejected by `deny_unknown_fields`)
+        // is likewise scoped to the lint table only.
+        let content = r"
+        [tool.djangofmt]
+        line-length = 100
+        [tool.djangofmt.lint]
+        not-a-real-key = true
+    ";
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(result.line_length, Some(LineLength::try_from(100).unwrap()));
+        assert_eq!(result.lint, None);
     }
 }

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -1,3 +1,4 @@
+use djangofmt_lint::RuleSelector;
 use serde::Deserialize;
 use std::{
     fs,
@@ -27,6 +28,26 @@ pub struct PyprojectSettings {
     pub fix: Option<bool>,
     pub unsafe_fixes: Option<bool>,
     pub show_fixes: Option<bool>,
+    /// Optional `[tool.djangofmt.lint]` subtable.
+    pub lint: Option<LintTomlSettings>,
+}
+
+/// Serde-only struct for deserializing `[tool.djangofmt.lint]` from
+/// `pyproject.toml`.
+///
+/// `select` is `Option<Vec<RuleSelector>>` (not `Vec<RuleSelector>`) so that
+/// a missing key (`None`) is distinguishable from an explicit empty list
+/// (`Some(vec![])`). This is load-bearing: at the resolver, `Some(select)`
+/// *replaces* the carried select set, whereas `None` extends only via
+/// `extend_select` / `extend_ignore` / `ignore`.
+#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct LintTomlSettings {
+    pub select: Option<Vec<RuleSelector>>,
+    pub ignore: Option<Vec<RuleSelector>>,
+    pub extend_select: Option<Vec<RuleSelector>>,
+    pub extend_ignore: Option<Vec<RuleSelector>>,
+    pub preview: Option<bool>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -297,6 +318,119 @@ show-fixes = true
                 custom_blocks: Some(vec!["cache".to_string()]),
                 ..Default::default()
             }
+        );
+    }
+
+    // ── [tool.djangofmt.lint] ──────────────────────────────────────────
+
+    #[test]
+    fn test_load_options_with_full_lint_table() {
+        use djangofmt_lint::{Rule, RuleCategory, RuleSelector};
+        let content = r#"
+        [tool.djangofmt.lint]
+        select = ["ALL"]
+        ignore = ["invalid-attr-value"]
+        extend-select = ["correctness"]
+        extend-ignore = ["correctness"]
+        preview = true
+    "#;
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(
+            result,
+            PyprojectSettings {
+                lint: Some(LintTomlSettings {
+                    select: Some(vec![RuleSelector::All]),
+                    ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+                    extend_select: Some(vec![RuleSelector::Category(RuleCategory::Correctness)]),
+                    extend_ignore: Some(vec![RuleSelector::Category(RuleCategory::Correctness)]),
+                    preview: Some(true),
+                }),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_load_options_with_partial_lint_table() {
+        use djangofmt_lint::{Rule, RuleSelector};
+        let content = r#"
+        [tool.djangofmt.lint]
+        ignore = ["invalid-attr-value"]
+    "#;
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(
+            result,
+            PyprojectSettings {
+                lint: Some(LintTomlSettings {
+                    ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_load_options_unknown_key_in_lint_table_returns_default() {
+        // `deny_unknown_fields` on `LintTomlSettings` should cause the whole
+        // pyproject load to fall back to default (matches existing behavior
+        // for other unknown-key cases).
+        let content = r#"
+        [tool.djangofmt.lint]
+        bogus = "value"
+    "#;
+        assert_eq!(
+            load_options_from_pyproject_toml(content),
+            PyprojectSettings::default()
+        );
+    }
+
+    #[test]
+    fn test_load_options_with_empty_select_list() {
+        // `select = []` must round-trip as `Some(vec![])` — distinct from
+        // `select` being missing entirely (which is `None`).
+        let content = r"
+        [tool.djangofmt.lint]
+        select = []
+    ";
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(
+            result.lint,
+            Some(LintTomlSettings {
+                select: Some(vec![]),
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn test_load_options_with_missing_select_is_none() {
+        // No `select` key — `lint.select` must be `None`, not `Some(vec![])`.
+        let content = r"
+        [tool.djangofmt.lint]
+        preview = false
+    ";
+        let result = load_options_from_pyproject_toml(content);
+        assert_eq!(
+            result.lint,
+            Some(LintTomlSettings {
+                select: None,
+                preview: Some(false),
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn test_load_options_rejects_invalid_rule_selector_in_lint_table() {
+        let content = r#"
+        [tool.djangofmt.lint]
+        select = ["definitely-not-a-rule"]
+    "#;
+        // Falls back to default on parse failure (matches existing behavior).
+        assert_eq!(
+            load_options_from_pyproject_toml(content),
+            PyprojectSettings::default()
         );
     }
 }

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -30,23 +30,22 @@ pub struct PyprojectSettings {
     pub show_fixes: Option<bool>,
     /// Optional `[tool.djangofmt.lint]` subtable.
     ///
-    /// Deserialized leniently (see `deserialize_lenient_lint`): a malformed
-    /// lint table (a typo'd selector or unknown key) is dropped with a warning
-    /// rather than discarding the surrounding formatting options.
+    /// Deserialized leniently (see `deserialize_lenient_lint`): a key with an
+    /// invalid value or an unknown name is skipped with a warning, keeping the
+    /// other lint keys and the surrounding formatting options.
     #[serde(default, deserialize_with = "deserialize_lenient_lint")]
     pub lint: Option<LintTomlSettings>,
 }
 
-/// Serde-only struct for deserializing `[tool.djangofmt.lint]` from
-/// `pyproject.toml`.
+/// The parsed `[tool.djangofmt.lint]` subtable, built key-by-key by
+/// [`deserialize_lenient_lint`].
 ///
 /// `select` is `Option<Vec<RuleSelector>>` (not `Vec<RuleSelector>`) so that
 /// a missing key (`None`) is distinguishable from an explicit empty list
 /// (`Some(vec![])`). This is load-bearing: at the resolver, `Some(select)`
 /// *replaces* the carried select set, whereas `None` extends only via
 /// `extend_select` / `extend_ignore` / `ignore`.
-#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct LintTomlSettings {
     pub select: Option<Vec<RuleSelector>>,
     pub ignore: Option<Vec<RuleSelector>>,
@@ -57,26 +56,49 @@ pub struct LintTomlSettings {
 
 /// Deserialize the optional `[tool.djangofmt.lint]` subtable leniently.
 ///
-/// The lint table is buffered into a [`toml::Value`] and then converted to
-/// [`LintTomlSettings`]. A malformed lint table (a typo'd selector or an
-/// unknown key) is dropped with a warning rather than aborting the whole
-/// parse, so a single bad selector can't silently discard unrelated
-/// formatting options like `line-length` or `profile`.
+/// The table is buffered into a [`toml::Value`] and each key is converted
+/// independently: a key with an invalid value (e.g. a typo'd selector) or an
+/// unrecognised name is skipped with a warning, while the other lint keys —
+/// and the surrounding formatting options like `line-length` — are preserved.
+/// A single bad key can never discard unrelated configuration.
 fn deserialize_lenient_lint<'de, D>(deserializer: D) -> Result<Option<LintTomlSettings>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let value = toml::Value::deserialize(deserializer)?;
-    let lint: Result<LintTomlSettings, _> = value.try_into();
-    match lint {
-        Ok(lint) => Ok(Some(lint)),
-        Err(err) => {
-            warn!(
-                "Ignoring invalid `[tool.djangofmt.lint]` config (other settings preserved): {err}"
-            );
-            Ok(None)
+    let toml::Value::Table(table) = value else {
+        warn!("Ignoring `[tool.djangofmt.lint]`: expected a table");
+        return Ok(None);
+    };
+
+    let mut lint = LintTomlSettings::default();
+    for (key, value) in table {
+        let result = match key.as_str() {
+            "select" => take_field(&mut lint.select, value),
+            "ignore" => take_field(&mut lint.ignore, value),
+            "extend-select" => take_field(&mut lint.extend_select, value),
+            "extend-ignore" => take_field(&mut lint.extend_ignore, value),
+            "preview" => take_field(&mut lint.preview, value),
+            _ => {
+                warn!("Ignoring unknown `[tool.djangofmt.lint]` key `{key}`");
+                continue;
+            }
+        };
+        if let Err(err) = result {
+            warn!("Ignoring invalid `[tool.djangofmt.lint] {key}`: {err}");
         }
     }
+    Ok(Some(lint))
+}
+
+/// Parse `value` into `slot`, leaving `slot` untouched (and returning the
+/// error) when deserialization fails.
+fn take_field<T: serde::de::DeserializeOwned>(
+    slot: &mut Option<T>,
+    value: toml::Value,
+) -> Result<(), toml::de::Error> {
+    *slot = Some(value.try_into()?);
+    Ok(())
 }
 
 #[derive(Deserialize, Debug)]
@@ -400,17 +422,22 @@ show-fixes = true
     }
 
     #[test]
-    fn test_load_options_unknown_key_in_lint_table_drops_lint() {
-        // `deny_unknown_fields` on `LintTomlSettings` rejects the lint table,
-        // which is then dropped (lint = None); with no other settings present
-        // the result equals the default.
+    fn test_load_options_unknown_key_in_lint_table_is_skipped() {
+        use djangofmt_lint::{Rule, RuleSelector};
+        // An unknown key is skipped with a warning; sibling keys are kept.
         let content = r#"
         [tool.djangofmt.lint]
         bogus = "value"
+        ignore = ["invalid-attr-value"]
     "#;
         let result = load_options_from_pyproject_toml(content);
-        assert_eq!(result.lint, None);
-        assert_eq!(result, PyprojectSettings::default());
+        assert_eq!(
+            result.lint,
+            Some(LintTomlSettings {
+                ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+                ..Default::default()
+            })
+        );
     }
 
     #[test]
@@ -450,16 +477,26 @@ show-fixes = true
     }
 
     #[test]
-    fn test_load_options_drops_invalid_rule_selector_in_lint_table() {
+    fn test_load_options_skips_only_invalid_selector_key() {
+        use djangofmt_lint::{Rule, RuleSelector};
+        // A key whose value has a bad selector is skipped (left as `None`),
+        // while valid sibling keys survive.
         let content = r#"
         [tool.djangofmt.lint]
         select = ["definitely-not-a-rule"]
+        ignore = ["invalid-attr-value"]
+        preview = true
     "#;
-        // The malformed lint table is dropped (lint = None); with no other
-        // settings present the result equals the default.
         let result = load_options_from_pyproject_toml(content);
-        assert_eq!(result.lint, None);
-        assert_eq!(result, PyprojectSettings::default());
+        assert_eq!(
+            result.lint,
+            Some(LintTomlSettings {
+                select: None,
+                ignore: Some(vec![RuleSelector::Rule(Rule::InvalidAttrValue)]),
+                preview: Some(true),
+                ..Default::default()
+            })
+        );
     }
 
     #[test]
@@ -474,13 +511,14 @@ show-fixes = true
     "#;
         let result = load_options_from_pyproject_toml(content);
         assert_eq!(result.line_length, Some(LineLength::try_from(100).unwrap()));
-        assert_eq!(result.lint, None);
+        // The bad `select` is skipped, leaving an otherwise-empty lint table.
+        assert_eq!(result.lint, Some(LintTomlSettings::default()));
     }
 
     #[test]
     fn test_unknown_key_in_lint_table_preserves_other_settings() {
-        // An unknown key in the lint table (rejected by `deny_unknown_fields`)
-        // is likewise scoped to the lint table only.
+        // An unknown key in the lint table is skipped and scoped to the lint
+        // table only, leaving formatting options untouched.
         let content = r"
         [tool.djangofmt]
         line-length = 100
@@ -489,6 +527,6 @@ show-fixes = true
     ";
         let result = load_options_from_pyproject_toml(content);
         assert_eq!(result.line_length, Some(LineLength::try_from(100).unwrap()));
-        assert_eq!(result.lint, None);
+        assert_eq!(result.lint, Some(LintTomlSettings::default()));
     }
 }

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -502,6 +502,27 @@ fn check_select_invalid_attr_value_reports_violations() {
 }
 
 #[test]
+fn check_select_tolerates_whitespace_and_empty_entries() {
+    // Leading/trailing/doubled commas and surrounding whitespace are ignored,
+    // so a sloppy `--select` value still resolves to its real selectors.
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    let output = cli()
+        .arg("check")
+        .arg("--select= invalid-attr-value , ,")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Invalid value 'put' for attribute 'method'"),
+        "expected 'put' violation despite the messy selector value, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn check_ignore_invalid_attr_value_suppresses_violations() {
     let dir = TempDir::new().unwrap();
     let file = write_invalid_form_method_file(&dir);

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -450,3 +450,249 @@ fn check_malformed_file_with_fix_surfaces_parse_error() {
     Couldn't check 1 files!
     "#);
 }
+
+// ── Rule selection (--select / --ignore / --preview) ───────────────
+
+/// Write the canonical `<form method="put">...` 5-violation fixture and
+/// return its path. Tests can run any selector combination against it.
+fn write_invalid_form_method_file(dir: &TempDir) -> std::path::PathBuf {
+    let file = dir.path().join("form_method.invalid.html");
+    std::fs::write(
+        &file,
+        r#"<!-- Invalid methods -->
+<form method="put">Submit</form>
+<form method="delete">Submit</form>
+<form method="patch">Submit</form>
+
+<!-- Nested in Jinja block -->
+{% if show_form %}
+    <form method="invalid">Submit</form>
+{% endif %}
+
+<!-- Nested elements: inner form inside outer div -->
+<div>
+    <form method="patch">Submit</form>
+</div>
+"#,
+    )
+    .expect("Failed to write fixture file");
+    file
+}
+
+#[test]
+fn check_select_invalid_attr_value_reports_violations() {
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    let output = cli()
+        .arg("check")
+        .arg("--select=invalid-attr-value")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Invalid value 'put' for attribute 'method'"),
+        "expected 'put' violation, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Invalid value 'delete' for attribute 'method'"),
+        "expected 'delete' violation, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn check_ignore_invalid_attr_value_suppresses_violations() {
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    assert_cmd_snapshot!(
+        cli()
+            .arg("check")
+            .arg("--ignore=invalid-attr-value")
+            .arg(file.as_os_str()),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    "#);
+}
+
+#[test]
+fn check_select_correctness_category_reports_violations() {
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    let output = cli()
+        .arg("check")
+        .arg("--select=correctness")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid value 'put' for attribute 'method'"));
+}
+
+#[test]
+fn check_exact_select_beats_category_ignore() {
+    // --select=invalid-attr-value (rule level) beats --ignore=correctness
+    // (category level) by specificity.
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    let output = cli()
+        .arg("check")
+        .arg("--select=invalid-attr-value")
+        .arg("--ignore=correctness")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid value 'put' for attribute 'method'"));
+}
+
+#[test]
+fn check_select_all_ignore_specific_disables_rule() {
+    // --select=ALL with --ignore=invalid-attr-value: ignore at same Rule
+    // specificity wins last-in-order.
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    assert_cmd_snapshot!(
+        cli()
+            .arg("check")
+            .arg("--select=ALL")
+            .arg("--ignore=invalid-attr-value")
+            .arg(file.as_os_str()),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    "#);
+}
+
+#[test]
+fn check_unknown_selector_errors() {
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    let output = cli()
+        .arg("check")
+        .arg("--select=nope")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nope"),
+        "expected error to mention 'nope', got:\n{stderr}"
+    );
+}
+
+#[test]
+fn check_preview_flag_does_not_error() {
+    // `--preview` enables preview rules; on a clean file it stays quiet.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.html");
+    std::fs::write(&file, "<form method=\"post\"></form>\n").unwrap();
+    assert_cmd_snapshot!(
+        cli().arg("check").arg("--preview").arg(file.as_os_str()),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    "#);
+}
+
+// ── Rule selection via pyproject.toml ────────────────────────────────
+
+#[test]
+fn check_pyproject_ignore_suppresses_violations() {
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    std::fs::write(
+        dir.path().join("pyproject.toml"),
+        r#"
+[tool.djangofmt.lint]
+ignore = ["invalid-attr-value"]
+"#,
+    )
+    .unwrap();
+
+    let output = cli()
+        .current_dir(dir.path())
+        .arg("check")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "expected check to pass with pyproject ignore, got stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn check_cli_select_all_replaces_pyproject_ignore() {
+    // pyproject: ignore = ["invalid-attr-value"] -> rule suppressed.
+    // CLI: --select=ALL -> the running set is rebuilt from CLI's selectors
+    // alone, dropping pyproject's ignore; rule is re-enabled.
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    std::fs::write(
+        dir.path().join("pyproject.toml"),
+        r#"
+[tool.djangofmt.lint]
+ignore = ["invalid-attr-value"]
+"#,
+    )
+    .expect("Failed to write pyproject.toml");
+
+    let output = cli()
+        .current_dir(dir.path())
+        .arg("check")
+        .arg("--select=ALL")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "expected check to fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid value 'put' for attribute 'method'"));
+}
+
+#[test]
+fn check_cli_select_replaces_pyproject_select() {
+    // pyproject: select = [] (nothing enabled)
+    // CLI: --select=ALL  -> replacement: invalid-attr-value re-enabled.
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    std::fs::write(
+        dir.path().join("pyproject.toml"),
+        r"
+[tool.djangofmt.lint]
+select = []
+",
+    )
+    .unwrap();
+
+    let output = cli()
+        .current_dir(dir.path())
+        .arg("check")
+        .arg("--select=ALL")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "expected check to fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid value 'put' for attribute 'method'"));
+}

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -652,6 +652,93 @@ fn check_preview_rule_gated_by_preview_flag() {
     );
 }
 
+#[test]
+fn check_extend_select_invalid_attr_value_reports_violations() {
+    // `--extend-select` adds on top of the default rule set; the violation is
+    // reported (verifies the flag is wired through to the resolver).
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    let output = cli()
+        .arg("check")
+        .arg("--extend-select=invalid-attr-value")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Invalid value 'put' for attribute 'method'"),
+        "expected 'put' violation, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn check_extend_ignore_invalid_attr_value_suppresses_violations() {
+    // `--extend-ignore` subtracts from the resolved set; the default
+    // `invalid-attr-value` rule is removed and the check passes.
+    let dir = TempDir::new().unwrap();
+    let file = write_invalid_form_method_file(&dir);
+    assert_cmd_snapshot!(
+        cli()
+            .arg("check")
+            .arg("--extend-ignore=invalid-attr-value")
+            .arg(file.as_os_str()),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    "#);
+}
+
+#[test]
+fn check_no_preview_overrides_pyproject_preview() {
+    // `empty-tag-pair` is a preview rule. pyproject enables preview and selects
+    // it; CLI `--no-preview` must win (CLI > pyproject), so the rule does not
+    // run. This exercises the `--preview`/`--no-preview` `overrides_with` flag.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.html");
+    std::fs::write(&file, "<span></span>\n").unwrap();
+    std::fs::write(
+        dir.path().join("pyproject.toml"),
+        r#"
+[tool.djangofmt.lint]
+select = ["empty-tag-pair"]
+preview = true
+"#,
+    )
+    .unwrap();
+
+    // Sanity: with pyproject `preview = true` the preview rule runs.
+    let with = cli()
+        .current_dir(dir.path())
+        .arg("check")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(
+        !with.status.success(),
+        "preview rule should run with pyproject preview = true, got stderr:\n{}",
+        String::from_utf8_lossy(&with.stderr),
+    );
+
+    // `--no-preview` overrides pyproject and turns preview off.
+    let without = cli()
+        .current_dir(dir.path())
+        .arg("check")
+        .arg("--no-preview")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(
+        without.status.success(),
+        "`--no-preview` must override pyproject preview = true, got stderr:\n{}",
+        String::from_utf8_lossy(&without.stderr),
+    );
+}
+
 // ── Rule selection via pyproject.toml ────────────────────────────────
 
 #[test]

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -613,6 +613,45 @@ fn check_preview_flag_does_not_error() {
     "#);
 }
 
+#[test]
+fn check_preview_rule_gated_by_preview_flag() {
+    // `empty-tag-pair` is a preview rule. Exact-selecting it must NOT enable
+    // it without `--preview` (matches ruff: preview rules require preview
+    // mode); with `--preview` it runs and flags the empty pair.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.html");
+    std::fs::write(&file, "<span></span>\n").unwrap();
+
+    let without = cli()
+        .arg("check")
+        .arg("--select=empty-tag-pair")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(
+        without.status.success(),
+        "preview rule should stay off without --preview, got stderr:\n{}",
+        String::from_utf8_lossy(&without.stderr),
+    );
+
+    let with = cli()
+        .arg("check")
+        .arg("--select=empty-tag-pair")
+        .arg("--preview")
+        .arg(file.as_os_str())
+        .output()
+        .unwrap();
+    assert!(
+        !with.status.success(),
+        "preview rule should run with --preview"
+    );
+    let stderr = String::from_utf8_lossy(&with.stderr);
+    assert!(
+        stderr.contains("Empty `<span>` tag pair"),
+        "expected empty-tag-pair violation, got:\n{stderr}"
+    );
+}
+
 // ── Rule selection via pyproject.toml ────────────────────────────────
 
 #[test]

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -616,8 +616,8 @@ fn check_preview_flag_does_not_error() {
 #[test]
 fn check_preview_rule_gated_by_preview_flag() {
     // `empty-tag-pair` is a preview rule. Exact-selecting it must NOT enable
-    // it without `--preview` (matches ruff: preview rules require preview
-    // mode); with `--preview` it runs and flags the empty pair.
+    // it without `--preview` (preview rules require preview mode); with
+    // `--preview` it runs and flags the empty pair.
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("empty.html");
     std::fs::write(&file, "<span></span>\n").unwrap();

--- a/crates/djangofmt_benchmark/benches/linter.rs
+++ b/crates/djangofmt_benchmark/benches/linter.rs
@@ -1,5 +1,5 @@
 use djangofmt_benchmark::{ALL_TEMPLATES, TestFile};
-use djangofmt_lint::{Settings, check_ast};
+use djangofmt_lint::{PreviewMode, RuleSelector, Settings, check_ast};
 use markup_fmt::parser::Parser;
 
 fn main() {
@@ -8,7 +8,10 @@ fn main() {
 
 #[divan::bench(args = ALL_TEMPLATES)]
 fn check_templates(bencher: divan::Bencher, template: &'static TestFile) {
-    let settings = Settings::default();
+    // Benchmark every rule, including preview ones, so throughput stays
+    // comparable across commits regardless of a rule's stability group.
+    let settings =
+        Settings::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Enabled);
 
     bencher
         .counter(divan::counter::BytesCount::of_str(template.code))

--- a/crates/djangofmt_benchmark/benches/linter.rs
+++ b/crates/djangofmt_benchmark/benches/linter.rs
@@ -1,5 +1,5 @@
 use djangofmt_benchmark::{ALL_TEMPLATES, TestFile};
-use djangofmt_lint::{PreviewMode, RuleSelector, Settings, check_ast};
+use djangofmt_lint::{PreviewMode, Settings, check_ast};
 use markup_fmt::parser::Parser;
 
 fn main() {
@@ -10,8 +10,7 @@ fn main() {
 fn check_templates(bencher: divan::Bencher, template: &'static TestFile) {
     // Benchmark every rule, including preview ones, so throughput stays
     // comparable across commits regardless of a rule's stability group.
-    let settings =
-        Settings::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Enabled);
+    let settings = Settings::all_rules(PreviewMode::Enabled);
 
     bencher
         .counter(divan::counter::BytesCount::of_str(template.code))

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -21,6 +21,7 @@ mod checker;
 pub mod fix;
 pub mod lint_context;
 pub mod registry;
+pub mod rule_selector;
 pub mod rule_set;
 mod rules;
 pub mod settings;
@@ -34,8 +35,9 @@ pub use fix::apply::{
 pub use fix::{Applicability, Edit, Fix, FixAvailability, IsolationLevel};
 pub use lint_context::{DiagnosticGuard, LintContext};
 pub use registry::{Rule, RuleCategory, RuleGroup};
+pub use rule_selector::{ParseError, RuleSelector, Specificity};
 pub use rule_set::RuleSet;
-pub use settings::Settings;
+pub use settings::{PreviewMode, RuleSelection, Settings};
 pub use violation::{Violation, ViolationMetadata};
 
 use markup_fmt::ast::Root;

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -37,8 +37,22 @@ impl RuleGroup {
 
 /// Functional categories for lint rules.
 ///
-/// Categories help users enable/disable groups of related rules.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, EnumString, Serialize, Deserialize)]
+/// Categories help users enable/disable groups of related rules. Stability
+/// (`Stable`/`Preview`/`Deprecated`/`Removed`) is orthogonal and lives on
+/// [`RuleGroup`].
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    EnumIter,
+    EnumString,
+    strum::Display,
+    Serialize,
+    Deserialize,
+)]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 pub enum RuleCategory {

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -16,9 +16,10 @@ pub enum RuleGroup {
     Stable { since: &'static str },
     /// Unstable since the given djangofmt version; requires preview mode.
     Preview { since: &'static str },
-    /// Deprecated since the given djangofmt version; warns on selection.
+    /// Deprecated since the given djangofmt version; still functional, but only
+    /// selectable by exact name (never via `ALL` or a category).
     Deprecated { since: &'static str },
-    /// Removed in the given djangofmt version; docs kept for history.
+    /// Removed in the given djangofmt version; never selectable, docs kept for history.
     Removed { since: &'static str },
 }
 

--- a/crates/djangofmt_lint/src/rule_selector.rs
+++ b/crates/djangofmt_lint/src/rule_selector.rs
@@ -92,9 +92,11 @@ impl RuleSelector {
     ///
     /// Filtering rules:
     /// - [`RuleGroup::Stable`] — always included
-    /// - [`RuleGroup::Preview`] — included if `preview == Enabled` *or* the
-    ///   selector is exact (the exact-selector escape hatch matches ruff's
-    ///   default `require_explicit = false` behavior)
+    /// - [`RuleGroup::Preview`] — included only when `preview == Enabled`.
+    ///   This matches ruff with its default `require_explicit = false`: an
+    ///   exact selector does *not* pull a preview rule in while preview is
+    ///   off (ruff gates the exact-selector relaxation behind `preview &&`,
+    ///   so preview rules never run without preview mode).
     /// - [`RuleGroup::Deprecated`] — only when `preview == Disabled` *and* the
     ///   selector is exact
     /// - [`RuleGroup::Removed`] — only when the selector is exact
@@ -105,7 +107,7 @@ impl RuleSelector {
 
         Box::new(self.all_rules().filter(move |rule| match rule.group() {
             RuleGroup::Stable { .. } => true,
-            RuleGroup::Preview { .. } => preview_enabled || is_exact,
+            RuleGroup::Preview { .. } => preview_enabled,
             RuleGroup::Deprecated { .. } => !preview_enabled && is_exact,
             RuleGroup::Removed { .. } => is_exact,
         }))
@@ -277,6 +279,21 @@ mod tests {
     fn rules_filter_includes_stable_with_preview_disabled() {
         let rules: Vec<_> = RuleSelector::All.rules(PreviewMode::Disabled).collect();
         assert!(rules.contains(&Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn exact_selector_does_not_bypass_preview_gating() {
+        // A preview rule selected by exact name is still gated behind preview
+        // mode (matches ruff: preview rules never run without `--preview`).
+        let preview_rule = RuleSelector::Rule(Rule::EmptyTagPair);
+        assert!(
+            preview_rule.rules(PreviewMode::Disabled).next().is_none(),
+            "preview rule must stay disabled without preview, even when named exactly",
+        );
+        assert_eq!(
+            preview_rule.rules(PreviewMode::Enabled).collect::<Vec<_>>(),
+            vec![Rule::EmptyTagPair],
+        );
     }
 
     #[test]

--- a/crates/djangofmt_lint/src/rule_selector.rs
+++ b/crates/djangofmt_lint/src/rule_selector.rs
@@ -90,13 +90,15 @@ impl RuleSelector {
     /// Rules matched by this selector after applying stability filtering.
     ///
     /// Filtering rules:
-    /// - [`RuleGroup::Stable`] — always included
+    /// - [`RuleGroup::Stable`] — always included.
     /// - [`RuleGroup::Preview`] — included only when `preview == Enabled`. An
     ///   exact selector does *not* pull a preview rule in while preview is
     ///   off, so preview rules never run without preview mode.
-    /// - [`RuleGroup::Deprecated`] — only when `preview == Disabled` *and* the
-    ///   selector is exact
-    /// - [`RuleGroup::Removed`] — only when the selector is exact
+    /// - [`RuleGroup::Deprecated`] — still functional, so it is included when
+    ///   named by an exact selector (in any mode), but never pulled in by
+    ///   `ALL` or a category selector.
+    /// - [`RuleGroup::Removed`] — never included; a removed rule does not run
+    ///   even when named exactly.
     #[must_use]
     pub fn rules(&self, preview: PreviewMode) -> Box<dyn Iterator<Item = Rule> + '_> {
         let is_exact = self.is_exact();
@@ -105,8 +107,8 @@ impl RuleSelector {
         Box::new(self.all_rules().filter(move |rule| match rule.group() {
             RuleGroup::Stable { .. } => true,
             RuleGroup::Preview { .. } => preview_enabled,
-            RuleGroup::Deprecated { .. } => !preview_enabled && is_exact,
-            RuleGroup::Removed { .. } => is_exact,
+            RuleGroup::Deprecated { .. } => is_exact,
+            RuleGroup::Removed { .. } => false,
         }))
     }
 }

--- a/crates/djangofmt_lint/src/rule_selector.rs
+++ b/crates/djangofmt_lint/src/rule_selector.rs
@@ -1,0 +1,288 @@
+//! User-facing rule selectors (e.g. `ALL`, `correctness`, `invalid-attr-value`).
+//!
+//! Mirrors ruff's `RuleSelector` (`crates/ruff_linter/src/rule_selector.rs`)
+//! at djangofmt scale. djangofmt has no rule codes or linter-prefix taxonomy,
+//! so selectors are limited to:
+//!
+//! - [`RuleSelector::All`] — every registered rule
+//! - [`RuleSelector::Category`] — every rule of a given functional category
+//! - [`RuleSelector::Rule`] — a single rule, addressed by its kebab-case name
+//!
+//! The two-step expansion (`all_rules` then `rules(preview)`) mirrors ruff so
+//! that the `Deprecated`/`Removed` stability paths fit cleanly without further
+//! refactoring once we start using them.
+
+use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
+
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Serialize};
+use strum::{EnumIter, IntoEnumIterator};
+
+use crate::registry::{Rule, RuleCategory, RuleGroup};
+use crate::settings::PreviewMode;
+
+/// A selector that expands into zero or more concrete [`Rule`]s.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RuleSelector {
+    /// Select every registered rule.
+    All,
+    /// Select every rule belonging to the given category.
+    Category(RuleCategory),
+    /// Select a single rule by its kebab-case name.
+    Rule(Rule),
+}
+
+/// Specificity of a [`RuleSelector`] within a resolution layer.
+///
+/// Resolution iterates from broadest (`All`) to narrowest (`Rule`); at each
+/// step, selects/extends are applied additively and ignores subtractively.
+/// The ordering on this enum (broad < narrow) drives that traversal.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, EnumIter)]
+pub enum Specificity {
+    /// `ALL`-style selectors.
+    All,
+    /// Category selectors (e.g. `correctness`).
+    Category,
+    /// Exact-rule selectors (e.g. `invalid-attr-value`).
+    Rule,
+}
+
+/// Error returned by [`RuleSelector::from_str`] for unparsable input.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ParseError {
+    /// The given string did not match `ALL`, any known rule, or any known category.
+    #[error("Unknown rule selector: `{0}`")]
+    Unknown(String),
+}
+
+impl RuleSelector {
+    /// Returns the [`Specificity`] of this selector.
+    #[must_use]
+    pub const fn specificity(&self) -> Specificity {
+        match self {
+            Self::All => Specificity::All,
+            Self::Category(_) => Specificity::Category,
+            Self::Rule(_) => Specificity::Rule,
+        }
+    }
+
+    /// Returns `true` if this selector targets a single rule by name.
+    #[must_use]
+    pub const fn is_exact(&self) -> bool {
+        matches!(self, Self::Rule(_))
+    }
+
+    /// All rules matched by this selector, regardless of stability group.
+    ///
+    /// Use [`Self::rules`] when applying preview/stability filtering.
+    #[must_use]
+    pub fn all_rules(&self) -> Box<dyn Iterator<Item = Rule> + '_> {
+        match self {
+            Self::All => Box::new(Rule::iter()),
+            Self::Category(category) => {
+                let category = *category;
+                Box::new(Rule::iter().filter(move |r| r.category() == category))
+            }
+            Self::Rule(rule) => Box::new(std::iter::once(*rule)),
+        }
+    }
+
+    /// Rules matched by this selector after applying stability filtering.
+    ///
+    /// Filtering rules:
+    /// - [`RuleGroup::Stable`] — always included
+    /// - [`RuleGroup::Preview`] — included if `preview == Enabled` *or* the
+    ///   selector is exact (the exact-selector escape hatch matches ruff's
+    ///   default `require_explicit = false` behavior)
+    /// - [`RuleGroup::Deprecated`] — only when `preview == Disabled` *and* the
+    ///   selector is exact
+    /// - [`RuleGroup::Removed`] — only when the selector is exact
+    #[must_use]
+    pub fn rules(&self, preview: PreviewMode) -> Box<dyn Iterator<Item = Rule> + '_> {
+        let is_exact = self.is_exact();
+        let preview_enabled = preview == PreviewMode::Enabled;
+
+        Box::new(self.all_rules().filter(move |rule| match rule.group() {
+            RuleGroup::Stable { .. } => true,
+            RuleGroup::Preview { .. } => preview_enabled || is_exact,
+            RuleGroup::Deprecated { .. } => !preview_enabled && is_exact,
+            RuleGroup::Removed { .. } => is_exact,
+        }))
+    }
+}
+
+impl FromStr for RuleSelector {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Order matters: try literal `ALL` first, then exact rule names, then
+        // category names. This keeps the lookup unambiguous even if a future
+        // rule name happens to collide with a category name.
+        if s == "ALL" {
+            return Ok(Self::All);
+        }
+        if let Ok(rule) = Rule::from_str(s) {
+            return Ok(Self::Rule(rule));
+        }
+        if let Ok(category) = RuleCategory::from_str(s) {
+            return Ok(Self::Category(category));
+        }
+        Err(ParseError::Unknown(s.to_string()))
+    }
+}
+
+impl Display for RuleSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::All => f.write_str("ALL"),
+            Self::Category(c) => Display::fmt(c, f),
+            Self::Rule(r) => Display::fmt(r, f),
+        }
+    }
+}
+
+impl Serialize for RuleSelector {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for RuleSelector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(SelectorVisitor)
+    }
+}
+
+struct SelectorVisitor;
+
+impl Visitor<'_> for SelectorVisitor {
+    type Value = RuleSelector;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter.write_str(
+            "expected a rule selector: `ALL`, a category name, or a kebab-case rule name",
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        FromStr::from_str(v).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_accepts_all_keyword() {
+        assert_eq!(RuleSelector::from_str("ALL").unwrap(), RuleSelector::All);
+    }
+
+    #[test]
+    fn from_str_accepts_rule_name() {
+        assert_eq!(
+            RuleSelector::from_str("invalid-attr-value").unwrap(),
+            RuleSelector::Rule(Rule::InvalidAttrValue),
+        );
+    }
+
+    #[test]
+    fn from_str_accepts_category_name() {
+        assert_eq!(
+            RuleSelector::from_str("correctness").unwrap(),
+            RuleSelector::Category(RuleCategory::Correctness),
+        );
+    }
+
+    #[test]
+    fn from_str_rejects_unknown() {
+        let err = RuleSelector::from_str("nope").unwrap_err();
+        assert!(matches!(err, ParseError::Unknown(ref s) if s == "nope"));
+    }
+
+    #[test]
+    fn from_str_rejects_lowercase_all() {
+        // We intentionally only accept the canonical `ALL`; "all" is treated
+        // as an unknown rule/category name.
+        let err = RuleSelector::from_str("all").unwrap_err();
+        assert!(matches!(err, ParseError::Unknown(_)));
+    }
+
+    #[test]
+    fn display_roundtrips() {
+        for selector in [
+            RuleSelector::All,
+            RuleSelector::Category(RuleCategory::Correctness),
+            RuleSelector::Rule(Rule::InvalidAttrValue),
+        ] {
+            let s = selector.to_string();
+            let parsed = RuleSelector::from_str(&s).unwrap();
+            assert_eq!(parsed, selector);
+        }
+    }
+
+    #[test]
+    fn specificity_ordering_is_broad_to_narrow() {
+        assert!(Specificity::All < Specificity::Category);
+        assert!(Specificity::Category < Specificity::Rule);
+    }
+
+    #[test]
+    fn specificity_iter_traverses_broad_to_narrow() {
+        let collected: Vec<_> = Specificity::iter().collect();
+        assert_eq!(
+            collected,
+            vec![Specificity::All, Specificity::Category, Specificity::Rule]
+        );
+    }
+
+    #[test]
+    fn all_rules_includes_invalid_attr_value() {
+        let rules: Vec<_> = RuleSelector::All.all_rules().collect();
+        assert!(rules.contains(&Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn category_filters_by_category() {
+        let rules: Vec<_> = RuleSelector::Category(RuleCategory::Correctness)
+            .all_rules()
+            .collect();
+        assert!(rules.contains(&Rule::InvalidAttrValue));
+        // Complexity has no rules yet.
+        let no_rules: Vec<_> = RuleSelector::Category(RuleCategory::Complexity)
+            .all_rules()
+            .collect();
+        assert!(no_rules.is_empty());
+    }
+
+    #[test]
+    fn rule_selector_yields_single_rule() {
+        let rules: Vec<_> = RuleSelector::Rule(Rule::InvalidAttrValue)
+            .all_rules()
+            .collect();
+        assert_eq!(rules, vec![Rule::InvalidAttrValue]);
+    }
+
+    #[test]
+    fn rules_filter_includes_stable_with_preview_disabled() {
+        let rules: Vec<_> = RuleSelector::All.rules(PreviewMode::Disabled).collect();
+        assert!(rules.contains(&Rule::InvalidAttrValue));
+    }
+
+    #[test]
+    fn is_exact_only_for_rule_variant() {
+        assert!(!RuleSelector::All.is_exact());
+        assert!(!RuleSelector::Category(RuleCategory::Correctness).is_exact());
+        assert!(RuleSelector::Rule(Rule::InvalidAttrValue).is_exact());
+    }
+}

--- a/crates/djangofmt_lint/src/rule_selector.rs
+++ b/crates/djangofmt_lint/src/rule_selector.rs
@@ -1,16 +1,15 @@
 //! User-facing rule selectors (e.g. `ALL`, `correctness`, `invalid-attr-value`).
 //!
-//! Mirrors ruff's `RuleSelector` (`crates/ruff_linter/src/rule_selector.rs`)
-//! at djangofmt scale. djangofmt has no rule codes or linter-prefix taxonomy,
-//! so selectors are limited to:
+//! djangofmt has no rule codes or linter-prefix taxonomy, so selectors are
+//! limited to:
 //!
 //! - [`RuleSelector::All`] — every registered rule
 //! - [`RuleSelector::Category`] — every rule of a given functional category
 //! - [`RuleSelector::Rule`] — a single rule, addressed by its kebab-case name
 //!
-//! The two-step expansion (`all_rules` then `rules(preview)`) mirrors ruff so
-//! that the `Deprecated`/`Removed` stability paths fit cleanly without further
-//! refactoring once we start using them.
+//! The two-step expansion (`all_rules` then `rules(preview)`) keeps the
+//! `Deprecated`/`Removed` stability paths cleanly separable for when they are
+//! used.
 
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
@@ -92,11 +91,9 @@ impl RuleSelector {
     ///
     /// Filtering rules:
     /// - [`RuleGroup::Stable`] — always included
-    /// - [`RuleGroup::Preview`] — included only when `preview == Enabled`.
-    ///   This matches ruff with its default `require_explicit = false`: an
+    /// - [`RuleGroup::Preview`] — included only when `preview == Enabled`. An
     ///   exact selector does *not* pull a preview rule in while preview is
-    ///   off (ruff gates the exact-selector relaxation behind `preview &&`,
-    ///   so preview rules never run without preview mode).
+    ///   off, so preview rules never run without preview mode.
     /// - [`RuleGroup::Deprecated`] — only when `preview == Disabled` *and* the
     ///   selector is exact
     /// - [`RuleGroup::Removed`] — only when the selector is exact
@@ -284,7 +281,7 @@ mod tests {
     #[test]
     fn exact_selector_does_not_bypass_preview_gating() {
         // A preview rule selected by exact name is still gated behind preview
-        // mode (matches ruff: preview rules never run without `--preview`).
+        // mode: preview rules never run without `--preview`.
         let preview_rule = RuleSelector::Rule(Rule::EmptyTagPair);
         assert!(
             preview_rule.rules(PreviewMode::Disabled).next().is_none(),

--- a/crates/djangofmt_lint/src/rule_set.rs
+++ b/crates/djangofmt_lint/src/rule_set.rs
@@ -109,14 +109,6 @@ impl FromIterator<Rule> for RuleSet {
     }
 }
 
-impl Extend<Rule> for RuleSet {
-    fn extend<I: IntoIterator<Item = Rule>>(&mut self, iter: I) {
-        for rule in iter {
-            self.insert(rule);
-        }
-    }
-}
-
 impl IntoIterator for RuleSet {
     type Item = Rule;
     type IntoIter = RuleSetIterator;

--- a/crates/djangofmt_lint/src/rule_set.rs
+++ b/crates/djangofmt_lint/src/rule_set.rs
@@ -20,6 +20,13 @@ const SLICE_BITS: u16 = u64::BITS as u16;
 pub struct RuleSet([u64; RULESET_SIZE]);
 
 impl RuleSet {
+    /// An empty set.
+    #[must_use]
+    #[inline]
+    pub const fn empty() -> Self {
+        Self([0u64; RULESET_SIZE])
+    }
+
     /// A set containing only `rule`.
     #[must_use]
     #[inline]
@@ -38,6 +45,15 @@ impl RuleSet {
         self.0[index] |= 1u64 << shift;
     }
 
+    /// Remove `rule` from the set.
+    #[inline]
+    pub const fn remove(&mut self, rule: Rule) {
+        let rule = rule as u16;
+        let index = rule as usize / SLICE_BITS as usize;
+        let shift = rule % SLICE_BITS;
+        self.0[index] &= !(1u64 << shift);
+    }
+
     /// Whether `rule` is in the set.
     #[must_use]
     #[inline]
@@ -46,6 +62,20 @@ impl RuleSet {
         let index = rule as usize / SLICE_BITS as usize;
         let shift = rule % SLICE_BITS;
         self.0[index] & (1u64 << shift) != 0
+    }
+
+    /// Whether the set contains no rules.
+    #[must_use]
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        let mut i = 0;
+        while i < RULESET_SIZE {
+            if self.0[i] != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
     }
 
     /// Union `other` into this set in place.
@@ -76,6 +106,14 @@ impl FromIterator<Rule> for RuleSet {
             set.insert(rule);
         }
         set
+    }
+}
+
+impl Extend<Rule> for RuleSet {
+    fn extend<I: IntoIterator<Item = Rule>>(&mut self, iter: I) {
+        for rule in iter {
+            self.insert(rule);
+        }
     }
 }
 

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -65,7 +65,7 @@ pub struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
-        Self::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Disabled)
+        Self::all_rules(PreviewMode::Disabled)
     }
 }
 
@@ -99,6 +99,16 @@ impl Settings {
             }],
             preview,
         )
+    }
+
+    /// Build [`Settings`] with every registered rule selected.
+    ///
+    /// Convenience for embedders, benchmarks, and tests that want the full
+    /// rule set; `preview` controls whether preview-stability rules are
+    /// included.
+    #[must_use]
+    pub fn all_rules(preview: PreviewMode) -> Self {
+        Self::from_selectors(&[RuleSelector::All], &[], &[], &[], preview)
     }
 
     /// Build [`Settings`] from a sequence of [`RuleSelection`] layers.
@@ -141,14 +151,23 @@ impl Settings {
         let ignore_iter = || layer.ignore.iter();
         let extend_ignore_iter = || layer.extend_ignore.iter();
 
-        let mut updates: Vec<(Rule, bool)> = Vec::new();
+        // A layer with `Some(select)` rebuilds from scratch (replacement
+        // semantics, dropping prior state including ignores); otherwise it
+        // merges onto the running set. The base is fixed before any update, so
+        // selects/ignores can apply directly per specificity level.
+        let mut next = if layer.select.is_some() {
+            RuleSet::empty()
+        } else {
+            running
+        };
+
         for spec in Specificity::iter() {
             for selector in select_iter()
                 .chain(extend_select_iter())
                 .filter(|s| s.specificity() == spec)
             {
                 for rule in selector.rules(preview) {
-                    updates.push((rule, true));
+                    next.insert(rule);
                 }
             }
             for selector in ignore_iter()
@@ -156,22 +175,8 @@ impl Settings {
                 .filter(|s| s.specificity() == spec)
             {
                 for rule in selector.rules(preview) {
-                    updates.push((rule, false));
+                    next.remove(rule);
                 }
-            }
-        }
-
-        let mut next = if layer.select.is_some() {
-            // Replacement semantics: drop everything carried so far.
-            RuleSet::empty()
-        } else {
-            running
-        };
-        for (rule, enabled) in updates {
-            if enabled {
-                next.insert(rule);
-            } else {
-                next.remove(rule);
             }
         }
         next

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -5,13 +5,15 @@
 //! rules) and the [`PreviewMode`] used to filter preview rules during
 //! resolution.
 //!
-//! Higher layers (CLI / pyproject) construct selectors and call
-//! [`Settings::from_selectors`] to fold them into a [`RuleSet`] using
-//! ruff-style specificity ordering: broadest selectors (`ALL`) apply first,
-//! then category-level, then exact rule selectors. At each level selects /
-//! extends are applied additively and ignores are applied subtractively, so
-//! `select = ["ALL"], ignore = ["invalid-attr-value"]` resolves correctly
-//! without ad-hoc precedence logic.
+//! Higher layers (CLI / pyproject) construct one [`RuleSelection`] per
+//! configuration source and call [`Settings::from_selections`] to fold them
+//! into a [`RuleSet`] using ruff-style specificity ordering: broadest
+//! selectors (`ALL`) apply first, then category-level, then exact rule
+//! selectors. At each level selects / extends are applied additively and
+//! ignores are applied subtractively, so `select = ["ALL"], ignore =
+//! ["invalid-attr-value"]` resolves correctly without ad-hoc precedence logic.
+//! [`Settings::from_selectors`] is a single-layer convenience that delegates
+//! to [`Settings::from_selections`].
 
 use strum::IntoEnumIterator;
 
@@ -72,19 +74,15 @@ impl Default for Settings {
 const DEFAULT_SELECTORS: &[RuleSelector] = &[RuleSelector::All];
 
 impl Settings {
-    /// Build [`Settings`] by resolving a single layer of selectors.
+    /// Build [`Settings`] from a single layer of selectors.
     ///
-    /// Resolution mirrors ruff's `LintConfiguration::as_rule_table` for a
-    /// single layer:
-    ///
-    /// 1. Iterate [`Specificity`] from broadest (`All`) to narrowest (`Rule`).
-    /// 2. At each level, apply `select`/`extend_select` additively, then
-    ///    `ignore`/`extend_ignore` subtractively.
-    ///
-    /// `select` and `extend_select` are treated identically at this layer —
-    /// the replacement-vs-extend distinction belongs to the multi-layer
-    /// resolver in the binary crate, which decides whether a layer's
-    /// `Some(select)` *replaces* the carried set before calling this method.
+    /// A convenience wrapper over [`Settings::from_selections`] for callers
+    /// (defaults, tests, one-shot embedders) that have exactly one layer. The
+    /// selectors are wrapped in a single [`RuleSelection`] whose `Some(select)`
+    /// *replaces* the implicit `ALL` base, so the result is just this layer
+    /// resolved with ruff-style specificity ordering — `select`/`extend_select`
+    /// additive, `ignore`/`extend_ignore` subtractive, narrower selectors
+    /// winning.
     #[must_use]
     pub fn from_selectors(
         select: &[RuleSelector],
@@ -93,28 +91,15 @@ impl Settings {
         extend_ignore: &[RuleSelector],
         preview: PreviewMode,
     ) -> Self {
-        let mut rules = RuleSet::empty();
-
-        for spec in Specificity::iter() {
-            for selector in select
-                .iter()
-                .chain(extend_select.iter())
-                .filter(|s| s.specificity() == spec)
-            {
-                rules.extend(selector.rules(preview));
-            }
-            for selector in ignore
-                .iter()
-                .chain(extend_ignore.iter())
-                .filter(|s| s.specificity() == spec)
-            {
-                for rule in selector.rules(preview) {
-                    rules.remove(rule);
-                }
-            }
-        }
-
-        Self { rules, preview }
+        Self::from_selections(
+            &[RuleSelection {
+                select: Some(select),
+                ignore,
+                extend_select,
+                extend_ignore,
+            }],
+            preview,
+        )
     }
 
     /// Build [`Settings`] from a sequence of [`RuleSelection`] layers.

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -1,24 +1,198 @@
+//! Resolved linter configuration.
+//!
+//! [`Settings`] is the immutable, fully-resolved configuration consumed by
+//! [`crate::check_ast`]. It carries the active [`RuleSet`] (bitset of enabled
+//! rules) and the [`PreviewMode`] used to filter preview rules during
+//! resolution.
+//!
+//! Higher layers (CLI / pyproject) construct selectors and call
+//! [`Settings::from_selectors`] to fold them into a [`RuleSet`] using
+//! ruff-style specificity ordering: broadest selectors (`ALL`) apply first,
+//! then category-level, then exact rule selectors. At each level selects /
+//! extends are applied additively and ignores are applied subtractively, so
+//! `select = ["ALL"], ignore = ["invalid-attr-value"]` resolves correctly
+//! without ad-hoc precedence logic.
+
 use strum::IntoEnumIterator;
 
 use crate::registry::Rule;
+use crate::rule_selector::{RuleSelector, Specificity};
 use crate::rule_set::RuleSet;
+
+/// Whether preview (unstable) rules are eligible for selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PreviewMode {
+    #[default]
+    Disabled,
+    Enabled,
+}
+
+impl From<bool> for PreviewMode {
+    fn from(enabled: bool) -> Self {
+        if enabled {
+            Self::Enabled
+        } else {
+            Self::Disabled
+        }
+    }
+}
+
+/// A single rule-selection layer.
+///
+/// Mirrors ruff's `RuleSelection` (`crates/ruff_workspace/src/configuration.rs`).
+/// A layer carries the four selector lists that the user can express in one
+/// "place" (defaults, pyproject, CLI flags). The `select` slot is
+/// `Option<&[...]>` so the caller can distinguish a missing `select`
+/// (`None` — extend behavior) from an explicit empty list (`Some(&[])` —
+/// replacement with zero rules).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RuleSelection<'a> {
+    pub select: Option<&'a [RuleSelector]>,
+    pub ignore: &'a [RuleSelector],
+    pub extend_select: &'a [RuleSelector],
+    pub extend_ignore: &'a [RuleSelector],
+}
 
 /// Configuration settings for the linter.
 #[derive(Debug, Clone)]
 pub struct Settings {
     /// The set of rules that are active for this run.
     pub rules: RuleSet,
+    /// Whether preview-stability rules are eligible for selection.
+    pub preview: PreviewMode,
 }
 
 impl Default for Settings {
     fn default() -> Self {
-        Self {
-            rules: Rule::iter().collect(),
-        }
+        Self::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Disabled)
     }
 }
 
+/// The implicit base layer's `select` list (`["ALL"]`).
+const DEFAULT_SELECTORS: &[RuleSelector] = &[RuleSelector::All];
+
 impl Settings {
+    /// Build [`Settings`] by resolving a single layer of selectors.
+    ///
+    /// Resolution mirrors ruff's `LintConfiguration::as_rule_table` for a
+    /// single layer:
+    ///
+    /// 1. Iterate [`Specificity`] from broadest (`All`) to narrowest (`Rule`).
+    /// 2. At each level, apply `select`/`extend_select` additively, then
+    ///    `ignore`/`extend_ignore` subtractively.
+    ///
+    /// `select` and `extend_select` are treated identically at this layer —
+    /// the replacement-vs-extend distinction belongs to the multi-layer
+    /// resolver in the binary crate, which decides whether a layer's
+    /// `Some(select)` *replaces* the carried set before calling this method.
+    #[must_use]
+    pub fn from_selectors(
+        select: &[RuleSelector],
+        ignore: &[RuleSelector],
+        extend_select: &[RuleSelector],
+        extend_ignore: &[RuleSelector],
+        preview: PreviewMode,
+    ) -> Self {
+        let mut rules = RuleSet::empty();
+
+        for spec in Specificity::iter() {
+            for selector in select
+                .iter()
+                .chain(extend_select.iter())
+                .filter(|s| s.specificity() == spec)
+            {
+                rules.extend(selector.rules(preview));
+            }
+            for selector in ignore
+                .iter()
+                .chain(extend_ignore.iter())
+                .filter(|s| s.specificity() == spec)
+            {
+                for rule in selector.rules(preview) {
+                    rules.remove(rule);
+                }
+            }
+        }
+
+        Self { rules, preview }
+    }
+
+    /// Build [`Settings`] from a sequence of [`RuleSelection`] layers.
+    ///
+    /// Mirrors ruff's `LintConfiguration::as_rule_table` multi-layer
+    /// resolution. An implicit base layer (`select = ["ALL"]`) is prepended
+    /// so the very first layer's `extend_select` / `ignore` behave the way
+    /// users expect (additive on the default rule set). The layers in
+    /// `selections` are then applied in order, each one either *replacing*
+    /// the running set (when it has `Some(select)`) or *extending* it
+    /// (when `select` is `None`).
+    #[must_use]
+    pub fn from_selections(selections: &[RuleSelection<'_>], preview: PreviewMode) -> Self {
+        let default_layer = RuleSelection {
+            select: Some(DEFAULT_SELECTORS),
+            ignore: &[],
+            extend_select: &[],
+            extend_ignore: &[],
+        };
+
+        let mut rules = RuleSet::empty();
+        for layer in std::iter::once(&default_layer).chain(selections.iter()) {
+            rules = Self::apply_layer(rules, layer, preview);
+        }
+
+        Self { rules, preview }
+    }
+
+    /// Apply a single [`RuleSelection`] layer to a running [`RuleSet`].
+    ///
+    /// Per-specificity loop matches `Settings::from_selectors`: at each
+    /// specificity level, `select`/`extend_select` apply additively, then
+    /// `ignore`/`extend_ignore` apply subtractively. If the layer has
+    /// `Some(select)`, the running set is rebuilt from this layer's updates
+    /// (dropping prior state, including ignores). Otherwise the updates are
+    /// merged on top.
+    fn apply_layer(running: RuleSet, layer: &RuleSelection<'_>, preview: PreviewMode) -> RuleSet {
+        let select_iter = || layer.select.iter().copied().flatten();
+        let extend_select_iter = || layer.extend_select.iter();
+        let ignore_iter = || layer.ignore.iter();
+        let extend_ignore_iter = || layer.extend_ignore.iter();
+
+        let mut updates: Vec<(Rule, bool)> = Vec::new();
+        for spec in Specificity::iter() {
+            for selector in select_iter()
+                .chain(extend_select_iter())
+                .filter(|s| s.specificity() == spec)
+            {
+                for rule in selector.rules(preview) {
+                    updates.push((rule, true));
+                }
+            }
+            for selector in ignore_iter()
+                .chain(extend_ignore_iter())
+                .filter(|s| s.specificity() == spec)
+            {
+                for rule in selector.rules(preview) {
+                    updates.push((rule, false));
+                }
+            }
+        }
+
+        let mut next = if layer.select.is_some() {
+            // Replacement semantics: drop everything carried so far.
+            RuleSet::empty()
+        } else {
+            running
+        };
+        for (rule, enabled) in updates {
+            if enabled {
+                next.insert(rule);
+            } else {
+                next.remove(rule);
+            }
+        }
+        next
+    }
+
     /// Check if a specific rule is enabled.
     #[must_use]
     #[inline]
@@ -46,7 +220,7 @@ impl Settings {
 
 #[cfg(test)]
 mod tests {
-    use super::Settings;
+    use super::{PreviewMode, Settings};
     use crate::registry::Rule;
     use crate::rule_set::RuleSet;
 
@@ -58,12 +232,14 @@ mod tests {
         assert!(!all.any_rule_enabled(&[]));
 
         let none = Settings {
-            rules: RuleSet::default(),
+            rules: RuleSet::empty(),
+            preview: PreviewMode::Disabled,
         };
         assert!(!none.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
 
         let partial = Settings {
             rules: RuleSet::from_rule(Rule::UseHttps),
+            preview: PreviewMode::Disabled,
         };
         assert!(partial.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
         assert!(!partial.any_rule_enabled(&[Rule::InvalidAttrValue]));

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -7,7 +7,7 @@
 //!
 //! Higher layers (CLI / pyproject) construct one [`RuleSelection`] per
 //! configuration source and call [`Settings::from_selections`] to fold them
-//! into a [`RuleSet`] using ruff-style specificity ordering: broadest
+//! into a [`RuleSet`] using specificity ordering: broadest
 //! selectors (`ALL`) apply first, then category-level, then exact rule
 //! selectors. At each level selects / extends are applied additively and
 //! ignores are applied subtractively, so `select = ["ALL"], ignore =
@@ -41,7 +41,6 @@ impl From<bool> for PreviewMode {
 
 /// A single rule-selection layer.
 ///
-/// Mirrors ruff's `RuleSelection` (`crates/ruff_workspace/src/configuration.rs`).
 /// A layer carries the four selector lists that the user can express in one
 /// "place" (defaults, pyproject, CLI flags). The `select` slot is
 /// `Option<&[...]>` so the caller can distinguish a missing `select`
@@ -80,7 +79,7 @@ impl Settings {
     /// (defaults, tests, one-shot embedders) that have exactly one layer. The
     /// selectors are wrapped in a single [`RuleSelection`] whose `Some(select)`
     /// *replaces* the implicit `ALL` base, so the result is just this layer
-    /// resolved with ruff-style specificity ordering — `select`/`extend_select`
+    /// resolved with specificity ordering — `select`/`extend_select`
     /// additive, `ignore`/`extend_ignore` subtractive, narrower selectors
     /// winning.
     #[must_use]
@@ -104,8 +103,8 @@ impl Settings {
 
     /// Build [`Settings`] from a sequence of [`RuleSelection`] layers.
     ///
-    /// Mirrors ruff's `LintConfiguration::as_rule_table` multi-layer
-    /// resolution. An implicit base layer (`select = ["ALL"]`) is prepended
+    /// Folds a sequence of selection layers into a single rule set. An
+    /// implicit base layer (`select = ["ALL"]`) is prepended
     /// so the very first layer's `extend_select` / `ignore` behave the way
     /// users expect (additive on the default rule set). The layers in
     /// `selections` are then applied in order, each one either *replacing*

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -3,7 +3,8 @@ mod common;
 
 use common::build_settings;
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, LintDiagnostic, Settings, check_ast, fix_ast,
+    Applicability, FileDiagnostics, LintDiagnostic, PreviewMode, RuleSelector, Settings, check_ast,
+    fix_ast,
 };
 
 use insta::{assert_snapshot, glob};
@@ -63,14 +64,14 @@ fn fix_snapshot() {
             .unwrap_or_else(|err| panic!("Failed to parse {}: {err:?}", path.display()));
         let stem = path.file_stem().unwrap().to_str().unwrap();
 
-        let safe = fix_ast(&input, &ast, &Settings::default(), Applicability::Safe);
+        let safe = fix_ast(&input, &ast, &test_settings(), Applicability::Safe);
         if safe.applied_count > 0 {
             build_settings(path).bind(|| {
                 assert_snapshot!(format!("{stem}.fixed"), safe.output);
             });
         }
 
-        let unsafe_fixed = fix_ast(&input, &ast, &Settings::default(), Applicability::Unsafe);
+        let unsafe_fixed = fix_ast(&input, &ast, &test_settings(), Applicability::Unsafe);
         if unsafe_fixed.applied_count > safe.applied_count {
             build_settings(path).bind(|| {
                 assert_snapshot!(format!("{stem}.unsafe-fixed"), unsafe_fixed.output);
@@ -81,10 +82,16 @@ fn fix_snapshot() {
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
+/// Settings for fixture tests: every rule, including preview ones, so that a
+/// rule's fixtures are exercised regardless of its stability group.
+fn test_settings() -> Settings {
+    Settings::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Enabled)
+}
+
 fn collect_diagnostics(input: &str) -> Vec<LintDiagnostic> {
     let mut parser = Parser::new(input, Language::Django, vec![]);
     let ast = parser.parse_root().expect("Failed to parse AST in test");
-    let settings = Settings::default();
+    let settings = test_settings();
     check_ast(input, &ast, &settings)
 }
 

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -3,8 +3,7 @@ mod common;
 
 use common::build_settings;
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, LintDiagnostic, PreviewMode, RuleSelector, Settings, check_ast,
-    fix_ast,
+    Applicability, FileDiagnostics, LintDiagnostic, PreviewMode, Settings, check_ast, fix_ast,
 };
 
 use insta::{assert_snapshot, glob};
@@ -85,7 +84,7 @@ const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 /// Settings for fixture tests: every rule, including preview ones, so that a
 /// rule's fixtures are exercised regardless of its stability group.
 fn test_settings() -> Settings {
-    Settings::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Enabled)
+    Settings::all_rules(PreviewMode::Enabled)
 }
 
 fn collect_diagnostics(input: &str) -> Vec<LintDiagnostic> {

--- a/crates/djangofmt_lint/tests/settings.rs
+++ b/crates/djangofmt_lint/tests/settings.rs
@@ -114,6 +114,56 @@ fn extend_ignore_subtracts_after_select() {
 }
 
 #[test]
+fn same_specificity_ignore_beats_select() {
+    // select and ignore of the same category are both at Category specificity;
+    // within a level ignores apply after selects, so the rule ends disabled.
+    let settings = Settings::from_selectors(
+        &[category(RuleCategory::Correctness)],
+        &[category(RuleCategory::Correctness)],
+        &[],
+        &[],
+        PreviewMode::Disabled,
+    );
+    assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+    assert!(settings.rules.is_empty());
+}
+
+#[test]
+fn extend_select_does_not_override_same_specificity_ignore() {
+    // extend_select and ignore both target the rule at Rule specificity; the
+    // ignore is applied after the selects in that level, so extend_select
+    // cannot rescue a rule that is also ignored.
+    let settings = Settings::from_selectors(
+        &[RuleSelector::All],
+        &[rule(Rule::InvalidAttrValue)],
+        &[rule(Rule::InvalidAttrValue)],
+        &[],
+        PreviewMode::Disabled,
+    );
+    assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+}
+
+#[test]
+fn full_lint_table_combination_resolves_as_expected() {
+    // Mirrors the `test_load_options_with_full_lint_table` fixture and asserts
+    // the *resolved* set: select=[ALL] with a rule-level ignore and a
+    // category-level extend_ignore both disable invalid-attr-value, while
+    // rules outside the ignored category stay enabled.
+    let settings = Settings::from_selectors(
+        &[RuleSelector::All],
+        &[rule(Rule::InvalidAttrValue)],
+        &[category(RuleCategory::Correctness)],
+        &[category(RuleCategory::Correctness)],
+        PreviewMode::Disabled,
+    );
+    assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+    assert!(
+        !settings.rules.is_empty(),
+        "rules outside the ignored correctness category should remain enabled",
+    );
+}
+
+#[test]
 fn preview_mode_field_propagated() {
     let settings = Settings::from_selectors(&[], &[], &[], &[], PreviewMode::Enabled);
     assert_eq!(settings.preview, PreviewMode::Enabled);

--- a/crates/djangofmt_lint/tests/settings.rs
+++ b/crates/djangofmt_lint/tests/settings.rs
@@ -1,0 +1,126 @@
+//! Resolver tests for `Settings::from_selectors`.
+//!
+//! Exercises the specificity-ordered layered resolver against the Stable rule
+//! `invalid-attr-value`. Preview/stability gating is asserted at the unit-test
+//! level on `RuleSelector::rules`; these resolver tests run with
+//! `PreviewMode::Disabled` so they stay agnostic to which rules are in preview.
+
+use djangofmt_lint::{PreviewMode, Rule, RuleCategory, RuleSelector, Settings};
+
+const fn category(c: RuleCategory) -> RuleSelector {
+    RuleSelector::Category(c)
+}
+
+const fn rule(r: Rule) -> RuleSelector {
+    RuleSelector::Rule(r)
+}
+
+#[test]
+fn default_enables_invalid_attr_value() {
+    let settings = Settings::default();
+    assert!(settings.is_enabled(Rule::InvalidAttrValue));
+    assert_eq!(settings.preview, PreviewMode::Disabled);
+}
+
+#[test]
+fn select_all_includes_stable_rules() {
+    let settings =
+        Settings::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Disabled);
+    assert!(settings.is_enabled(Rule::InvalidAttrValue));
+}
+
+#[test]
+fn empty_select_disables_everything() {
+    let settings = Settings::from_selectors(&[], &[], &[], &[], PreviewMode::Disabled);
+    assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+    assert!(settings.rules.is_empty());
+}
+
+#[test]
+fn exact_ignore_beats_all_select() {
+    let settings = Settings::from_selectors(
+        &[RuleSelector::All],
+        &[rule(Rule::InvalidAttrValue)],
+        &[],
+        &[],
+        PreviewMode::Disabled,
+    );
+    assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+}
+
+#[test]
+fn exact_select_beats_category_ignore() {
+    // Even though `correctness` is ignored at the category level, the exact
+    // `invalid-attr-value` selector is more specific and should re-enable it.
+    let settings = Settings::from_selectors(
+        &[rule(Rule::InvalidAttrValue)],
+        &[category(RuleCategory::Correctness)],
+        &[],
+        &[],
+        PreviewMode::Disabled,
+    );
+    assert!(settings.is_enabled(Rule::InvalidAttrValue));
+}
+
+#[test]
+fn category_select_enables_matching_rules() {
+    let settings = Settings::from_selectors(
+        &[category(RuleCategory::Correctness)],
+        &[],
+        &[],
+        &[],
+        PreviewMode::Disabled,
+    );
+    assert!(settings.is_enabled(Rule::InvalidAttrValue));
+}
+
+#[test]
+fn category_select_for_unmatched_category_enables_nothing() {
+    let settings = Settings::from_selectors(
+        &[category(RuleCategory::Complexity)],
+        &[],
+        &[],
+        &[],
+        PreviewMode::Disabled,
+    );
+    assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+    assert!(settings.rules.is_empty());
+}
+
+#[test]
+fn extend_select_adds_on_top_of_select() {
+    // select=[Complexity] enables nothing today; extend_select=[Correctness]
+    // adds invalid-attr-value on top.
+    let settings = Settings::from_selectors(
+        &[category(RuleCategory::Complexity)],
+        &[],
+        &[category(RuleCategory::Correctness)],
+        &[],
+        PreviewMode::Disabled,
+    );
+    assert!(settings.is_enabled(Rule::InvalidAttrValue));
+}
+
+#[test]
+fn extend_ignore_subtracts_after_select() {
+    let settings = Settings::from_selectors(
+        &[RuleSelector::All],
+        &[],
+        &[],
+        &[rule(Rule::InvalidAttrValue)],
+        PreviewMode::Disabled,
+    );
+    assert!(!settings.is_enabled(Rule::InvalidAttrValue));
+}
+
+#[test]
+fn preview_mode_field_propagated() {
+    let settings = Settings::from_selectors(&[], &[], &[], &[], PreviewMode::Enabled);
+    assert_eq!(settings.preview, PreviewMode::Enabled);
+}
+
+#[test]
+fn preview_mode_from_bool() {
+    assert_eq!(PreviewMode::from(true), PreviewMode::Enabled);
+    assert_eq!(PreviewMode::from(false), PreviewMode::Disabled);
+}

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,7 +2,7 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, Settings, check_ast};
+use djangofmt_lint::{FileDiagnostics, PreviewMode, RuleSelector, Settings, check_ast};
 use markup_fmt::parser::Parser;
 use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use serde::Serialize;
@@ -202,7 +202,10 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
         }
     };
 
-    let settings = Settings::default();
+    // The playground showcases every rule, including preview ones, so the
+    // default stable-only rule set is widened here.
+    let settings =
+        Settings::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Enabled);
     let diagnostics = check_ast(source, &ast, &settings);
     let error_count = diagnostics.len();
 

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,7 +2,7 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, PreviewMode, RuleSelector, Settings, check_ast};
+use djangofmt_lint::{FileDiagnostics, PreviewMode, Settings, check_ast};
 use markup_fmt::parser::Parser;
 use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use serde::Serialize;
@@ -204,8 +204,7 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
 
     // The playground showcases every rule, including preview ones, so the
     // default stable-only rule set is widened here.
-    let settings =
-        Settings::from_selectors(&[RuleSelector::All], &[], &[], &[], PreviewMode::Enabled);
+    let settings = Settings::all_rules(PreviewMode::Enabled);
     let diagnostics = check_ast(source, &ast, &settings);
     let error_count = diagnostics.len();
 


### PR DESCRIPTION
I tried with claude but this is just a pile of overly complicated bad designed shit so let's think this through before handing of the coding

Fixes #288 

## Todos
- [x]  wait for the ruleset bitset refactor and build on it


## What's here
- **`RuleSelector`** (`ALL` / category / rule) with specificity-ordered, layered resolution (`Settings::from_selections`, with `from_selectors` as a single-layer convenience).
- **`RuleSet`** bitset replacing the old `FxHashSet<Rule>`.
- **`[tool.djangofmt.lint]`** pyproject keys: `select` / `ignore` / `extend-select` / `extend-ignore` / `preview`.
- **CLI flags** on the (hidden) `check` subcommand: `--select`, `--ignore`, `--extend-select`, `--extend-ignore`, `--preview` / `--no-preview`.
