### PR TITLE
perf(lint): Use a BitSet to store enabled rules

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -42,7 +42,7 @@ impl<'a> Checker<'a> {
     /// Returns whether the given rule should be checked.
     #[must_use]
     #[inline]
-    pub fn is_rule_enabled(&self, rule: Rule) -> bool {
+    pub const fn is_rule_enabled(&self, rule: Rule) -> bool {
         self.context.is_rule_enabled(rule)
     }
 

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -21,6 +21,7 @@ mod checker;
 pub mod fix;
 pub mod lint_context;
 pub mod registry;
+pub mod rule_set;
 mod rules;
 pub mod settings;
 mod violation;
@@ -33,6 +34,7 @@ pub use fix::apply::{
 pub use fix::{Applicability, Edit, Fix, FixAvailability, IsolationLevel};
 pub use lint_context::{DiagnosticGuard, LintContext};
 pub use registry::{Rule, RuleCategory, RuleGroup};
+pub use rule_set::RuleSet;
 pub use settings::Settings;
 pub use violation::{Violation, ViolationMetadata};
 

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -50,7 +50,7 @@ impl<'a> LintContext<'a> {
     /// Returns whether the given rule should be checked.
     #[must_use]
     #[inline]
-    pub fn is_rule_enabled(&self, rule: Rule) -> bool {
+    pub const fn is_rule_enabled(&self, rule: Rule) -> bool {
         self.settings.is_enabled(rule)
     }
 

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use strum::{EnumIter, EnumString};
+use strum::{EnumCount, EnumIter, EnumString};
 
 use crate::fix::FixAvailability;
 use crate::rules;
@@ -111,11 +111,14 @@ define_rules {
             Eq,
             Hash,
             EnumIter,
+            EnumCount,
             EnumString,
             strum::Display,
+            strum::FromRepr,
             Serialize,
             Deserialize
         )]
+        #[repr(u16)]
         #[strum(serialize_all = "kebab-case")]
         #[serde(rename_all = "kebab-case")]
         pub enum Rule {

--- a/crates/djangofmt_lint/src/rule_set.rs
+++ b/crates/djangofmt_lint/src/rule_set.rs
@@ -1,39 +1,26 @@
-//! Bitset-backed set of enabled lint rules.
-//!
-//! Mirrors Ruff's `rule_set.rs` design as closely as is reasonable: the set is
-//! backed by a `[u64; RULESET_SIZE]` array, membership is a branchless bit
-//! test, and the set is built once via `FromIterator<Rule>`.
-//!
-//! # Deliberate divergence from Ruff
-//! Ruff also has a `RuleTable { enabled, should_fix }` containing a second
-//! bitset gating per-rule autofix application.  djangofmt does NOT gate fixes
-//! per-rule (applicability is checked at apply time via `Applicability`), so
-//! `RuleTable` / a `should_fix` bitset are intentionally absent.
+//! Bitset of enabled lint rules: one bit per `Rule`, membership is a branchless
+//! bit test, built once via `FromIterator`.
 
 use strum::EnumCount as _;
 
 use crate::registry::Rule;
 
-/// Number of `u64` words needed to hold one bit per `Rule` variant.
-/// Computed from `Rule::COUNT` so it scales automatically as rules are added.
-/// Written as `(N + 63) / 64` rather than `N.div_ceil(64)` to stay const-safe
-/// on the MSRV (`div_ceil` is not yet const-stable).
+/// `u64` words needed for one bit per `Rule`, derived from `Rule::COUNT` so it
+/// scales as rules are added. Manual `(N + 63) / 64` stays const on the MSRV.
 #[allow(clippy::manual_div_ceil)]
 const RULESET_SIZE: usize = (Rule::COUNT + 63) / 64;
 
-/// Number of bits in each backing word.
+/// Bits per backing word.
 #[allow(clippy::cast_possible_truncation)] // u64::BITS is 64, fits in u16
 const SLICE_BITS: u16 = u64::BITS as u16;
 
-/// A compact bitset storing the set of enabled lint rules.
-///
-/// Each rule occupies exactly one bit.  Membership testing is a single
-/// array-index + shift, with no hashing.
+/// A compact bitset of enabled lint rules: one bit per rule, tested with an
+/// array index + shift.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RuleSet([u64; RULESET_SIZE]);
 
 impl RuleSet {
-    /// Return a `RuleSet` with a single rule set.
+    /// A set containing only `rule`.
     #[must_use]
     #[inline]
     pub const fn from_rule(rule: Rule) -> Self {
@@ -45,7 +32,7 @@ impl RuleSet {
         set
     }
 
-    /// Insert a rule into the set.
+    /// Add `rule` to the set.
     #[inline]
     pub const fn insert(&mut self, rule: Rule) {
         let rule = rule as u16;
@@ -54,7 +41,7 @@ impl RuleSet {
         self.0[index] |= 1u64 << shift;
     }
 
-    /// Return whether `rule` is in the set.
+    /// Whether `rule` is in the set.
     #[must_use]
     #[inline]
     pub const fn contains(&self, rule: Rule) -> bool {
@@ -64,7 +51,7 @@ impl RuleSet {
         self.0[index] & (1u64 << shift) != 0
     }
 
-    /// Merge another `RuleSet` into this one (union in place).
+    /// Union `other` into this set in place.
     #[inline]
     pub const fn union(&mut self, other: &Self) {
         let mut i = 0;
@@ -74,7 +61,7 @@ impl RuleSet {
         }
     }
 
-    /// Iterate over all rules in the set in ascending discriminant order.
+    /// Iterate the rules in ascending discriminant order.
     #[must_use]
     pub const fn iter(&self) -> RuleSetIterator {
         RuleSetIterator {
@@ -113,10 +100,8 @@ impl IntoIterator for &RuleSet {
     }
 }
 
-/// Iterator over the rules in a [`RuleSet`].
-///
-/// Uses `trailing_zeros()` to find each set bit without examining zero words,
-/// mirroring Ruff's iterator design.
+/// Iterator over the rules in a [`RuleSet`], using `trailing_zeros()` to skip
+/// zero words.
 pub struct RuleSetIterator {
     set: RuleSet,
     word_index: usize,
@@ -127,7 +112,7 @@ impl Iterator for RuleSetIterator {
     type Item = Rule;
 
     fn next(&mut self) -> Option<Rule> {
-        // Advance past any exhausted words.
+        // Skip fully-consumed words.
         while self.word == 0 {
             self.word_index += 1;
             if self.word_index >= RULESET_SIZE {

--- a/crates/djangofmt_lint/src/rule_set.rs
+++ b/crates/djangofmt_lint/src/rule_set.rs
@@ -25,10 +25,7 @@ impl RuleSet {
     #[inline]
     pub const fn from_rule(rule: Rule) -> Self {
         let mut set = Self([0u64; RULESET_SIZE]);
-        let rule = rule as u16;
-        let index = rule as usize / SLICE_BITS as usize;
-        let shift = rule % SLICE_BITS;
-        set.0[index] |= 1u64 << shift;
+        set.insert(rule);
         set
     }
 
@@ -112,19 +109,25 @@ impl Iterator for RuleSetIterator {
     type Item = Rule;
 
     fn next(&mut self) -> Option<Rule> {
-        // Skip fully-consumed words.
-        while self.word == 0 {
-            self.word_index += 1;
-            if self.word_index >= RULESET_SIZE {
-                return None;
+        loop {
+            // Skip fully-consumed words.
+            while self.word == 0 {
+                self.word_index += 1;
+                if self.word_index >= RULESET_SIZE {
+                    return None;
+                }
+                self.word = self.set.0[self.word_index];
             }
-            self.word = self.set.0[self.word_index];
+            let bit = self.word.trailing_zeros();
+            // Clear the lowest set bit.
+            self.word &= self.word - 1;
+            let global_index = self.word_index * SLICE_BITS as usize + bit as usize;
+            // A bit with no matching `Rule` (e.g. padding in the final word) is
+            // skipped rather than ending iteration.
+            #[allow(clippy::cast_possible_truncation)]
+            if let Some(rule) = Rule::from_repr(global_index as u16) {
+                return Some(rule);
+            }
         }
-        let bit = self.word.trailing_zeros();
-        // Clear the lowest set bit.
-        self.word &= self.word - 1;
-        let global_index = self.word_index * SLICE_BITS as usize + bit as usize;
-        #[allow(clippy::cast_possible_truncation)]
-        Rule::from_repr(global_index as u16)
     }
 }

--- a/crates/djangofmt_lint/src/rule_set.rs
+++ b/crates/djangofmt_lint/src/rule_set.rs
@@ -1,0 +1,145 @@
+//! Bitset-backed set of enabled lint rules.
+//!
+//! Mirrors Ruff's `rule_set.rs` design as closely as is reasonable: the set is
+//! backed by a `[u64; RULESET_SIZE]` array, membership is a branchless bit
+//! test, and the set is built once via `FromIterator<Rule>`.
+//!
+//! # Deliberate divergence from Ruff
+//! Ruff also has a `RuleTable { enabled, should_fix }` containing a second
+//! bitset gating per-rule autofix application.  djangofmt does NOT gate fixes
+//! per-rule (applicability is checked at apply time via `Applicability`), so
+//! `RuleTable` / a `should_fix` bitset are intentionally absent.
+
+use strum::EnumCount as _;
+
+use crate::registry::Rule;
+
+/// Number of `u64` words needed to hold one bit per `Rule` variant.
+/// Computed from `Rule::COUNT` so it scales automatically as rules are added.
+/// Written as `(N + 63) / 64` rather than `N.div_ceil(64)` to stay const-safe
+/// on the MSRV (`div_ceil` is not yet const-stable).
+#[allow(clippy::manual_div_ceil)]
+const RULESET_SIZE: usize = (Rule::COUNT + 63) / 64;
+
+/// Number of bits in each backing word.
+#[allow(clippy::cast_possible_truncation)] // u64::BITS is 64, fits in u16
+const SLICE_BITS: u16 = u64::BITS as u16;
+
+/// A compact bitset storing the set of enabled lint rules.
+///
+/// Each rule occupies exactly one bit.  Membership testing is a single
+/// array-index + shift, with no hashing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuleSet([u64; RULESET_SIZE]);
+
+impl RuleSet {
+    /// Return a `RuleSet` with a single rule set.
+    #[must_use]
+    #[inline]
+    pub const fn from_rule(rule: Rule) -> Self {
+        let mut set = Self([0u64; RULESET_SIZE]);
+        let rule = rule as u16;
+        let index = rule as usize / SLICE_BITS as usize;
+        let shift = rule % SLICE_BITS;
+        set.0[index] |= 1u64 << shift;
+        set
+    }
+
+    /// Insert a rule into the set.
+    #[inline]
+    pub const fn insert(&mut self, rule: Rule) {
+        let rule = rule as u16;
+        let index = rule as usize / SLICE_BITS as usize;
+        let shift = rule % SLICE_BITS;
+        self.0[index] |= 1u64 << shift;
+    }
+
+    /// Return whether `rule` is in the set.
+    #[must_use]
+    #[inline]
+    pub const fn contains(&self, rule: Rule) -> bool {
+        let rule = rule as u16;
+        let index = rule as usize / SLICE_BITS as usize;
+        let shift = rule % SLICE_BITS;
+        self.0[index] & (1u64 << shift) != 0
+    }
+
+    /// Merge another `RuleSet` into this one (union in place).
+    #[inline]
+    pub const fn union(&mut self, other: &Self) {
+        let mut i = 0;
+        while i < RULESET_SIZE {
+            self.0[i] |= other.0[i];
+            i += 1;
+        }
+    }
+
+    /// Iterate over all rules in the set in ascending discriminant order.
+    #[must_use]
+    pub const fn iter(&self) -> RuleSetIterator {
+        RuleSetIterator {
+            set: *self,
+            word_index: 0,
+            word: self.0[0],
+        }
+    }
+}
+
+impl FromIterator<Rule> for RuleSet {
+    fn from_iter<I: IntoIterator<Item = Rule>>(iter: I) -> Self {
+        let mut set = Self::default();
+        for rule in iter {
+            set.insert(rule);
+        }
+        set
+    }
+}
+
+impl IntoIterator for RuleSet {
+    type Item = Rule;
+    type IntoIter = RuleSetIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl IntoIterator for &RuleSet {
+    type Item = Rule;
+    type IntoIter = RuleSetIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over the rules in a [`RuleSet`].
+///
+/// Uses `trailing_zeros()` to find each set bit without examining zero words,
+/// mirroring Ruff's iterator design.
+pub struct RuleSetIterator {
+    set: RuleSet,
+    word_index: usize,
+    word: u64,
+}
+
+impl Iterator for RuleSetIterator {
+    type Item = Rule;
+
+    fn next(&mut self) -> Option<Rule> {
+        // Advance past any exhausted words.
+        while self.word == 0 {
+            self.word_index += 1;
+            if self.word_index >= RULESET_SIZE {
+                return None;
+            }
+            self.word = self.set.0[self.word_index];
+        }
+        let bit = self.word.trailing_zeros();
+        // Clear the lowest set bit.
+        self.word &= self.word - 1;
+        let global_index = self.word_index * SLICE_BITS as usize + bit as usize;
+        #[allow(clippy::cast_possible_truncation)]
+        Rule::from_repr(global_index as u16)
+    }
+}

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -1,13 +1,13 @@
-use rustc_hash::FxHashSet;
 use strum::IntoEnumIterator;
 
 use crate::registry::Rule;
+use crate::rule_set::RuleSet;
 
 /// Configuration settings for the linter.
 #[derive(Debug, Clone)]
 pub struct Settings {
     /// The set of rules that are active for this run.
-    pub rules: FxHashSet<Rule>,
+    pub rules: RuleSet,
 }
 
 impl Default for Settings {
@@ -22,7 +22,7 @@ impl Settings {
     /// Check if a specific rule is enabled.
     #[must_use]
     #[inline]
-    pub fn is_enabled(&self, rule: Rule) -> bool {
-        self.rules.contains(&rule)
+    pub const fn is_enabled(&self, rule: Rule) -> bool {
+        self.rules.contains(rule)
     }
 }


### PR DESCRIPTION
Repeated hashset lookups start to be expensive. Instead we can use a bitset inspired from ruff 