### PR TITLE
refactor(lint): dispatch tag-scoped rules by tag

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -46,6 +46,13 @@ impl<'a> Checker<'a> {
         self.context.is_rule_enabled(rule)
     }
 
+    /// Returns whether any of the given rules should be checked.
+    #[must_use]
+    #[inline]
+    pub const fn any_rule_enabled(&self, rules: &[Rule]) -> bool {
+        self.context.any_rule_enabled(rules)
+    }
+
     /// Report a diagnostic for a rule the caller has already gated on
     /// [`Self::is_rule_enabled`]. Returns a guard whose Drop pushes the
     /// diagnostic into the underlying context.
@@ -129,28 +136,27 @@ impl<'a> Checker<'a> {
             rules::suspicious::empty_tag_pair::check(element, self);
         }
 
-        if self.is_rule_enabled(Rule::UppercaseFormMethod) {
-            rules::style::uppercase_form_method::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::FormActionWhitespace) {
-            rules::style::form_action_whitespace::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::MissingHtmlLang) {
+        // Tag-scoped rules: an element matches at most one tag, so dispatch on
+        // the tag a single time.
+        let tag = element.tag_name;
+        if tag.eq_ignore_ascii_case("form") {
+            if self.is_rule_enabled(Rule::UppercaseFormMethod) {
+                rules::style::uppercase_form_method::check(element, self);
+            }
+            if self.is_rule_enabled(Rule::FormActionWhitespace) {
+                rules::style::form_action_whitespace::check(element, self);
+            }
+        } else if tag.eq_ignore_ascii_case("img") {
+            if self.is_rule_enabled(Rule::MissingImgAlt) {
+                rules::accessibility::missing_img_alt::check(element, self);
+            }
+            if self.is_rule_enabled(Rule::MissingImgDimensions) {
+                rules::accessibility::missing_img_dimensions::check(element, self);
+            }
+        } else if tag.eq_ignore_ascii_case("html") && self.is_rule_enabled(Rule::MissingHtmlLang) {
             rules::accessibility::missing_html_lang::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::MissingTitle) {
+        } else if tag.eq_ignore_ascii_case("head") && self.is_rule_enabled(Rule::MissingTitle) {
             rules::accessibility::missing_title::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::MissingImgAlt) {
-            rules::accessibility::missing_img_alt::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::MissingImgDimensions) {
-            rules::accessibility::missing_img_dimensions::check(element, self);
         }
 
         for attr in &element.attrs {

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -136,26 +136,27 @@ impl<'a> Checker<'a> {
             rules::suspicious::empty_tag_pair::check(element, self);
         }
 
-        // Tag-scoped rules: an element matches at most one tag, so dispatch on
-        // the tag a single time.
-        let tag = element.tag_name;
-        if tag.eq_ignore_ascii_case("form") {
+        if element.tag_name.eq_ignore_ascii_case("form") {
             if self.is_rule_enabled(Rule::UppercaseFormMethod) {
                 rules::style::uppercase_form_method::check(element, self);
             }
             if self.is_rule_enabled(Rule::FormActionWhitespace) {
                 rules::style::form_action_whitespace::check(element, self);
             }
-        } else if tag.eq_ignore_ascii_case("img") {
+        } else if element.tag_name.eq_ignore_ascii_case("img") {
             if self.is_rule_enabled(Rule::MissingImgAlt) {
                 rules::accessibility::missing_img_alt::check(element, self);
             }
             if self.is_rule_enabled(Rule::MissingImgDimensions) {
                 rules::accessibility::missing_img_dimensions::check(element, self);
             }
-        } else if tag.eq_ignore_ascii_case("html") && self.is_rule_enabled(Rule::MissingHtmlLang) {
+        } else if element.tag_name.eq_ignore_ascii_case("html")
+            && self.is_rule_enabled(Rule::MissingHtmlLang)
+        {
             rules::accessibility::missing_html_lang::check(element, self);
-        } else if tag.eq_ignore_ascii_case("head") && self.is_rule_enabled(Rule::MissingTitle) {
+        } else if element.tag_name.eq_ignore_ascii_case("head")
+            && self.is_rule_enabled(Rule::MissingTitle)
+        {
             rules::accessibility::missing_title::check(element, self);
         }
 

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -54,6 +54,13 @@ impl<'a> LintContext<'a> {
         self.settings.is_enabled(rule)
     }
 
+    /// Returns whether any of the given rules should be checked.
+    #[must_use]
+    #[inline]
+    pub const fn any_rule_enabled(&self, rules: &[Rule]) -> bool {
+        self.settings.any_rule_enabled(rules)
+    }
+
     /// Compute the byte offset of `slice` within the source.
     ///
     /// # Panics

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
@@ -49,11 +49,8 @@ impl Violation for MissingHtmlLang {
     }
 }
 
+/// The caller guarantees `element` is an `<html>` element.
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    if !element.tag_name.eq_ignore_ascii_case("html") {
-        return;
-    }
-
     if element
         .attrs
         .iter()

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_img_alt.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_img_alt.rs
@@ -45,11 +45,8 @@ impl Violation for MissingImgAlt {
     }
 }
 
+/// The caller guarantees `element` is an `<img>`.
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    if !element.tag_name.eq_ignore_ascii_case("img") {
-        return;
-    }
-
     if element
         .attrs
         .iter()

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
@@ -48,11 +48,8 @@ impl Violation for MissingImgDimensions {
     }
 }
 
+/// The caller guarantees `element` is an `<img>`.
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    if !element.tag_name.eq_ignore_ascii_case("img") {
-        return;
-    }
-
     let mut has_height = false;
     let mut has_width = false;
     for attr in &element.attrs {

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_title.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_title.rs
@@ -66,11 +66,8 @@ impl Violation for MissingTitle {
     }
 }
 
+/// The caller guarantees `element` is a `<head>`.
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    if !element.tag_name.eq_ignore_ascii_case("head") {
-        return;
-    }
-
     let kind = match classify_title(&element.children) {
         TitleStatus::Present => return,
         TitleStatus::Empty => TitleViolation::Empty,

--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -63,11 +63,8 @@ impl Violation for FormActionWhitespace {
     }
 }
 
+/// The caller guarantees `element` is a `<form>`.
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    if !element.tag_name.eq_ignore_ascii_case("form") {
-        return;
-    }
-
     for attr in &element.attrs {
         let Attribute::Native(NativeAttribute {
             name,

--- a/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
+++ b/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
@@ -61,11 +61,8 @@ impl Violation for UppercaseFormMethod<'_> {
     }
 }
 
+/// The caller guarantees `element` is a `<form>`.
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    if !element.tag_name.eq_ignore_ascii_case("form") {
-        return;
-    }
-
     for attr in &element.attrs {
         let Attribute::Native(NativeAttribute {
             name,

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -55,7 +55,6 @@ mod tests {
         let all = Settings::default();
         assert!(all.any_rule_enabled(&[Rule::UseHttps]));
         assert!(all.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
-        // An empty cluster is vacuously disabled.
         assert!(!all.any_rule_enabled(&[]));
 
         let none = Settings {
@@ -63,9 +62,6 @@ mod tests {
         };
         assert!(!none.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
 
-        // A cluster where only one rule is enabled must still report `true`,
-        // and a slice naming only the disabled rule must report `false` — this
-        // pins the `any` semantics against an `all`/first-only implementation.
         let partial = Settings {
             rules: RuleSet::from_rule(Rule::UseHttps),
         };

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -25,4 +25,51 @@ impl Settings {
     pub const fn is_enabled(&self, rule: Rule) -> bool {
         self.rules.contains(rule)
     }
+
+    /// Check if any of the given rules is enabled.
+    ///
+    /// Cheap pre-filter for a cluster of related rules: each test is a bitset
+    /// lookup, so a fully-disabled cluster can be skipped with one call.
+    #[must_use]
+    #[inline]
+    pub const fn any_rule_enabled(&self, rules: &[Rule]) -> bool {
+        let mut i = 0;
+        while i < rules.len() {
+            if self.is_enabled(rules[i]) {
+                return true;
+            }
+            i += 1;
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Settings;
+    use crate::registry::Rule;
+    use crate::rule_set::RuleSet;
+
+    #[test]
+    fn any_rule_enabled_reflects_membership() {
+        let all = Settings::default();
+        assert!(all.any_rule_enabled(&[Rule::UseHttps]));
+        assert!(all.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
+        // An empty cluster is vacuously disabled.
+        assert!(!all.any_rule_enabled(&[]));
+
+        let none = Settings {
+            rules: RuleSet::default(),
+        };
+        assert!(!none.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
+
+        // A cluster where only one rule is enabled must still report `true`,
+        // and a slice naming only the disabled rule must report `false` — this
+        // pins the `any` semantics against an `all`/first-only implementation.
+        let partial = Settings {
+            rules: RuleSet::from_rule(Rule::UseHttps),
+        };
+        assert!(partial.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
+        assert!(!partial.any_rule_enabled(&[Rule::InvalidAttrValue]));
+    }
 }


### PR DESCRIPTION
Six rules each fire on exactly one tag:
- `UppercaseFormMethod`/`FormActionWhitespace` → `<form>`
- `MissingImgAlt`/`MissingImgDimensions` → `<img>`
- `MissingHtmlLang` → `<html>`
- `MissingTitle` → `<head>`

`visit_element` now classifies the tag once and dispatches with a mutually-exclusive else-if

