### PR TITLE
refactor(lint): Dispatch per-attribute rules from a single attribut visitor

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -1,4 +1,6 @@
-use markup_fmt::ast::{Attribute, Element, JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
+use markup_fmt::ast::{
+    Attribute, Element, JinjaBlock, JinjaTagOrChildren, NativeAttribute, Node, NodeKind, Root,
+};
 use miette::SourceSpan;
 
 use crate::LintDiagnostic;
@@ -100,50 +102,15 @@ impl<'a> Checker<'a> {
     }
 
     fn visit_element(&mut self, element: &Element<'_>) {
-        if self.is_rule_enabled(Rule::InvalidAttrValue) {
-            rules::correctness::invalid_attr_value::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::EmptyAttrValue) {
-            rules::style::empty_attr_value::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::RedundantTypeAttr) {
-            rules::style::redundant_type_attr::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::DjangoStaticUrl) {
-            rules::suspicious::django_static_url::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::DjangoUrlPattern) {
-            rules::suspicious::django_url_pattern::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::JavascriptUrl) {
-            rules::suspicious::javascript_url::check(element, self);
-        }
-
         if self.is_rule_enabled(Rule::DuplicateAttr) {
             rules::suspicious::duplicate_attr::check(element, self);
-        }
-
-        if self.is_rule_enabled(Rule::UseHttps) {
-            rules::suspicious::use_https::check(element, self);
         }
 
         if self.is_rule_enabled(Rule::EmptyTagPair) {
             rules::suspicious::empty_tag_pair::check(element, self);
         }
 
-        if element.tag_name.eq_ignore_ascii_case("form") {
-            if self.is_rule_enabled(Rule::UppercaseFormMethod) {
-                rules::style::uppercase_form_method::check(element, self);
-            }
-            if self.is_rule_enabled(Rule::FormActionWhitespace) {
-                rules::style::form_action_whitespace::check(element, self);
-            }
-        } else if element.tag_name.eq_ignore_ascii_case("img") {
+        if element.tag_name.eq_ignore_ascii_case("img") {
             if self.is_rule_enabled(Rule::MissingImgAlt) {
                 rules::accessibility::missing_img_alt::check(element, self);
             }
@@ -161,7 +128,7 @@ impl<'a> Checker<'a> {
         }
 
         for attr in &element.attrs {
-            self.visit_attribute(attr);
+            self.visit_attribute(attr, element);
         }
 
         for child in &element.children {
@@ -169,9 +136,50 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn visit_attribute(&mut self, attr: &Attribute<'_>) {
-        if let Attribute::JinjaBlock(block) = attr {
-            self.visit_jinja_attr_block(block);
+    fn visit_attribute(&mut self, attr: &Attribute<'_>, element: &Element<'_>) {
+        match attr {
+            Attribute::Native(native) => self.visit_native_attribute(native, element),
+            Attribute::JinjaBlock(block) => self.visit_jinja_attr_block(block, element),
+            _ => {}
+        }
+    }
+
+    fn visit_native_attribute(&self, attr: &NativeAttribute<'_>, element: &Element<'_>) {
+        if self.is_rule_enabled(Rule::InvalidAttrValue) {
+            rules::correctness::invalid_attr_value::check(attr, element, self);
+        }
+
+        if self.is_rule_enabled(Rule::EmptyAttrValue) {
+            rules::style::empty_attr_value::check(attr, self);
+        }
+
+        if self.is_rule_enabled(Rule::RedundantTypeAttr) {
+            rules::style::redundant_type_attr::check(attr, element, self);
+        }
+
+        if self.is_rule_enabled(Rule::DjangoStaticUrl) {
+            rules::suspicious::django_static_url::check(attr, element, self);
+        }
+
+        if self.is_rule_enabled(Rule::DjangoUrlPattern) {
+            rules::suspicious::django_url_pattern::check(attr, element, self);
+        }
+
+        if self.is_rule_enabled(Rule::JavascriptUrl) {
+            rules::suspicious::javascript_url::check(attr, element, self);
+        }
+
+        if self.is_rule_enabled(Rule::UseHttps) {
+            rules::suspicious::use_https::check(attr, self);
+        }
+
+        if element.tag_name.eq_ignore_ascii_case("form") {
+            if self.is_rule_enabled(Rule::UppercaseFormMethod) {
+                rules::style::uppercase_form_method::check(attr, self);
+            }
+            if self.is_rule_enabled(Rule::FormActionWhitespace) {
+                rules::style::form_action_whitespace::check(attr, self);
+            }
         }
     }
 
@@ -189,11 +197,15 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn visit_jinja_attr_block(&mut self, block: &JinjaBlock<'_, Attribute<'_>>) {
+    fn visit_jinja_attr_block(
+        &mut self,
+        block: &JinjaBlock<'_, Attribute<'_>>,
+        element: &Element<'_>,
+    ) {
         for item in &block.body {
             if let JinjaTagOrChildren::Children(children) = item {
                 for child in children {
-                    self.visit_attribute(child);
+                    self.visit_attribute(child, element);
                 }
             }
         }

--- a/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::{Element, NativeAttribute};
 
 use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
@@ -65,43 +65,41 @@ impl Violation for InvalidAttrValue {
     }
 }
 
-/// Check an element's attributes for invalid enum values.
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+/// Check a single attribute for an invalid enum value.
+pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checker<'_>) {
     // Pending implementation of djangofmt_html_spec.
     // Currently only checks for <form method="...">.
     if !element.tag_name.eq_ignore_ascii_case("form") {
         return;
     }
 
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            ..
-        }) = attr
-        else {
-            continue;
-        };
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        ..
+    } = attr
+    else {
+        return;
+    };
 
-        if !name.eq_ignore_ascii_case("method") {
-            continue;
-        }
+    if !name.eq_ignore_ascii_case("method") {
+        return;
+    }
 
-        // Skip interpolated values
-        if contains_interpolation(value_str) {
-            continue;
-        }
+    // Skip interpolated values
+    if contains_interpolation(value_str) {
+        return;
+    }
 
-        let allowed: &[&str] = &["get", "post", "dialog"];
-        if !allowed.iter().any(|v| v.eq_ignore_ascii_case(value_str)) {
-            checker.report_diagnostic(
-                &InvalidAttrValue {
-                    value: (*value_str).to_string(),
-                    attribute: "method",
-                    allowed,
-                },
-                (*offset, value_str.len()).into(),
-            );
-        }
+    let allowed: &[&str] = &["get", "post", "dialog"];
+    if !allowed.iter().any(|v| v.eq_ignore_ascii_case(value_str)) {
+        checker.report_diagnostic(
+            &InvalidAttrValue {
+                value: (*value_str).to_string(),
+                attribute: "method",
+                allowed,
+            },
+            (*offset, value_str.len()).into(),
+        );
     }
 }

--- a/crates/djangofmt_lint/src/rules/style/empty_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/style/empty_attr_value.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::NativeAttribute;
 
 use crate::Checker;
 use crate::fix::FixAvailability;
@@ -54,36 +54,34 @@ impl Violation for EmptyAttrValue<'_> {
     }
 }
 
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            quote,
-        }) = attr
-        else {
-            continue;
-        };
+pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        quote,
+    } = attr
+    else {
+        return;
+    };
 
-        if !name.eq_ignore_ascii_case("id") && !name.eq_ignore_ascii_case("class") {
-            continue;
-        }
-
-        if !value_str.is_empty() {
-            continue;
-        }
-
-        let mut guard = checker.report_diagnostic(
-            &EmptyAttrValue { attr: name },
-            (*offset, value_str.len()).into(),
-        );
-
-        guard.set_fix(delete_attr_fix(
-            checker.context(),
-            name,
-            value_str,
-            *offset,
-            quote.is_some(),
-        ));
+    if !name.eq_ignore_ascii_case("id") && !name.eq_ignore_ascii_case("class") {
+        return;
     }
+
+    if !value_str.is_empty() {
+        return;
+    }
+
+    let mut guard = checker.report_diagnostic(
+        &EmptyAttrValue { attr: name },
+        (*offset, value_str.len()).into(),
+    );
+
+    guard.set_fix(delete_attr_fix(
+        checker.context(),
+        name,
+        value_str,
+        *offset,
+        quote.is_some(),
+    ));
 }

--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::NativeAttribute;
 
 use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
@@ -63,39 +63,37 @@ impl Violation for FormActionWhitespace {
     }
 }
 
-/// The caller guarantees `element` is a `<form>`.
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            ..
-        }) = attr
-        else {
-            continue;
-        };
+/// The caller guarantees the attribute belongs to a `<form>`.
+pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        ..
+    } = attr
+    else {
+        return;
+    };
 
-        if !name.eq_ignore_ascii_case("action") {
-            continue;
-        }
-
-        if contains_interpolation(value_str) {
-            continue;
-        }
-
-        let trimmed = value_str.trim_ascii();
-        if trimmed.len() == value_str.len() {
-            continue;
-        }
-
-        let span = (*offset, value_str.len()).into();
-        let mut guard = checker.report_diagnostic(&FormActionWhitespace, span);
-
-        let edit = if trimmed.is_empty() {
-            Edit::deletion(span)
-        } else {
-            Edit::replacement(trimmed.to_string(), span)
-        };
-        guard.set_fix(Fix::safe_edit(edit));
+    if !name.eq_ignore_ascii_case("action") {
+        return;
     }
+
+    if contains_interpolation(value_str) {
+        return;
+    }
+
+    let trimmed = value_str.trim_ascii();
+    if trimmed.len() == value_str.len() {
+        return;
+    }
+
+    let span = (*offset, value_str.len()).into();
+    let mut guard = checker.report_diagnostic(&FormActionWhitespace, span);
+
+    let edit = if trimmed.is_empty() {
+        Edit::deletion(span)
+    } else {
+        Edit::replacement(trimmed.to_string(), span)
+    };
+    guard.set_fix(Fix::safe_edit(edit));
 }

--- a/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
+++ b/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::{Element, NativeAttribute};
 
 use crate::Checker;
 use crate::fix::FixAvailability;
@@ -69,7 +69,7 @@ impl Violation for RedundantTypeAttr {
     }
 }
 
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checker<'_>) {
     let tag = element.tag_name;
 
     let default_type = if tag.eq_ignore_ascii_case("script") {
@@ -80,42 +80,40 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         return;
     };
 
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            quote,
-        }) = attr
-        else {
-            continue;
-        };
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        quote,
+    } = attr
+    else {
+        return;
+    };
 
-        if !name.eq_ignore_ascii_case("type") {
-            continue;
-        }
-
-        if contains_interpolation(value_str) {
-            continue;
-        }
-
-        if !value_str.eq_ignore_ascii_case(default_type) {
-            continue;
-        }
-
-        let mut guard = checker.report_diagnostic(
-            &RedundantTypeAttr {
-                tag: tag.to_string(),
-                type_value: (*value_str).to_string(),
-            },
-            (*offset, value_str.len()).into(),
-        );
-
-        guard.set_fix(delete_attr_fix(
-            checker.context(),
-            name,
-            value_str,
-            *offset,
-            quote.is_some(),
-        ));
+    if !name.eq_ignore_ascii_case("type") {
+        return;
     }
+
+    if contains_interpolation(value_str) {
+        return;
+    }
+
+    if !value_str.eq_ignore_ascii_case(default_type) {
+        return;
+    }
+
+    let mut guard = checker.report_diagnostic(
+        &RedundantTypeAttr {
+            tag: tag.to_string(),
+            type_value: (*value_str).to_string(),
+        },
+        (*offset, value_str.len()).into(),
+    );
+
+    guard.set_fix(delete_attr_fix(
+        checker.context(),
+        name,
+        value_str,
+        *offset,
+        quote.is_some(),
+    ));
 }

--- a/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
+++ b/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::NativeAttribute;
 
 use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
@@ -61,38 +61,36 @@ impl Violation for UppercaseFormMethod<'_> {
     }
 }
 
-/// The caller guarantees `element` is a `<form>`.
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            ..
-        }) = attr
-        else {
-            continue;
-        };
+/// The caller guarantees the attribute belongs to a `<form>`.
+pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        ..
+    } = attr
+    else {
+        return;
+    };
 
-        if !name.eq_ignore_ascii_case("method") {
-            continue;
-        }
-
-        if contains_interpolation(value_str) {
-            continue;
-        }
-
-        if !value_str.chars().any(|c| c.is_ascii_uppercase()) {
-            continue;
-        }
-
-        let mut guard = checker.report_diagnostic(
-            &UppercaseFormMethod { value: value_str },
-            (*offset, value_str.len()).into(),
-        );
-
-        guard.set_fix(Fix::safe_edit(Edit::replacement(
-            value_str.to_ascii_lowercase(),
-            (*offset, value_str.len()).into(),
-        )));
+    if !name.eq_ignore_ascii_case("method") {
+        return;
     }
+
+    if contains_interpolation(value_str) {
+        return;
+    }
+
+    if !value_str.chars().any(|c| c.is_ascii_uppercase()) {
+        return;
+    }
+
+    let mut guard = checker.report_diagnostic(
+        &UppercaseFormMethod { value: value_str },
+        (*offset, value_str.len()).into(),
+    );
+
+    guard.set_fix(Fix::safe_edit(Edit::replacement(
+        value_str.to_ascii_lowercase(),
+        (*offset, value_str.len()).into(),
+    )));
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::{Element, NativeAttribute};
 
 use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
@@ -69,38 +69,36 @@ fn starts_with_static_path(value: &str) -> bool {
     matches!(after.as_bytes().first(), Some(b'/'))
 }
 
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checker<'_>) {
     // Fast-path to skip processing tag that cannot have a static url.
     if !is_asset_tag(element.tag_name) {
         return;
     }
 
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            ..
-        }) = attr
-        else {
-            continue;
-        };
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        ..
+    } = attr
+    else {
+        return;
+    };
 
-        let Some(canonical) = URL_ATTRIBUTES
-            .iter()
-            .find(|candidate| candidate.eq_ignore_ascii_case(name))
-        else {
-            continue;
-        };
+    let Some(canonical) = URL_ATTRIBUTES
+        .iter()
+        .find(|candidate| candidate.eq_ignore_ascii_case(name))
+    else {
+        return;
+    };
 
-        // `srcset` is a comma-separated candidate list; every other attribute
-        // holds a single URL.
-        if *canonical == "srcset" {
-            for (url, at) in srcset_candidates(value_str, *offset) {
-                report_static_path(url, at, canonical, checker);
-            }
-        } else {
-            report_static_path(value_str, *offset, canonical, checker);
+    // `srcset` is a comma-separated candidate list; every other attribute
+    // holds a single URL.
+    if *canonical == "srcset" {
+        for (url, at) in srcset_candidates(value_str, *offset) {
+            report_static_path(url, at, canonical, checker);
         }
+    } else {
+        report_static_path(value_str, *offset, canonical, checker);
     }
 }
 

--- a/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::{Element, NativeAttribute};
 
 use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
@@ -67,37 +67,35 @@ const fn url_attributes_for(tag_name: &str) -> &'static [&'static str] {
     &[]
 }
 
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checker<'_>) {
     let attr_names = url_attributes_for(element.tag_name);
     if attr_names.is_empty() {
         return;
     }
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            ..
-        }) = attr
-        else {
-            continue;
-        };
-        let Some(canonical) = attr_names
-            .iter()
-            .find(|candidate| candidate.eq_ignore_ascii_case(name))
-        else {
-            continue;
-        };
-        if contains_interpolation(value_str) {
-            continue;
-        }
-        if is_hardcoded_internal_path(value_str) {
-            checker.report_diagnostic(
-                &DjangoUrlPattern {
-                    attribute: canonical,
-                },
-                (*offset, value_str.len()).into(),
-            );
-        }
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        ..
+    } = attr
+    else {
+        return;
+    };
+    let Some(canonical) = attr_names
+        .iter()
+        .find(|candidate| candidate.eq_ignore_ascii_case(name))
+    else {
+        return;
+    };
+    if contains_interpolation(value_str) {
+        return;
+    }
+    if is_hardcoded_internal_path(value_str) {
+        checker.report_diagnostic(
+            &DjangoUrlPattern {
+                attribute: canonical,
+            },
+            (*offset, value_str.len()).into(),
+        );
     }
 }
 

--- a/crates/djangofmt_lint/src/rules/suspicious/javascript_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/javascript_url.rs
@@ -1,4 +1,4 @@
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::{Element, NativeAttribute};
 
 use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
@@ -68,40 +68,38 @@ const fn url_attributes_for(tag_name: &str) -> &'static [&'static str] {
     &[]
 }
 
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checker<'_>) {
     let attr_names = url_attributes_for(element.tag_name);
     if attr_names.is_empty() {
         return;
     }
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            ..
-        }) = attr
-        else {
-            continue;
-        };
-        let Some(canonical) = attr_names
-            .iter()
-            .find(|candidate| candidate.eq_ignore_ascii_case(name))
-        else {
-            continue;
-        };
-        if contains_interpolation(value_str) {
-            continue;
-        }
-        if value_str
-            .trim_start()
-            .get(..JS_SCHEME.len())
-            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(JS_SCHEME))
-        {
-            checker.report_diagnostic(
-                &JavascriptUrl {
-                    attribute: canonical,
-                },
-                (*offset, value_str.len()).into(),
-            );
-        }
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        ..
+    } = attr
+    else {
+        return;
+    };
+    let Some(canonical) = attr_names
+        .iter()
+        .find(|candidate| candidate.eq_ignore_ascii_case(name))
+    else {
+        return;
+    };
+    if contains_interpolation(value_str) {
+        return;
+    }
+    if value_str
+        .trim_start()
+        .get(..JS_SCHEME.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(JS_SCHEME))
+    {
+        checker.report_diagnostic(
+            &JavascriptUrl {
+                attribute: canonical,
+            },
+            (*offset, value_str.len()).into(),
+        );
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use markup_fmt::ast::{Attribute, Element, NativeAttribute};
+use markup_fmt::ast::NativeAttribute;
 
 use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
@@ -64,30 +64,28 @@ impl Violation for UseHttps {
 const HTTP_SCHEME: &str = "http://";
 const HTTPS_SCHEME: &str = "https://";
 
-pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
-    for attr in &element.attrs {
-        let Attribute::Native(NativeAttribute {
-            name,
-            value: Some((value_str, offset)),
-            ..
-        }) = attr
-        else {
-            continue;
-        };
+pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
+    let NativeAttribute {
+        name,
+        value: Some((value_str, offset)),
+        ..
+    } = attr
+    else {
+        return;
+    };
 
-        let Some(canonical) = canonical_url_attr(name) else {
-            continue;
-        };
+    let Some(canonical) = canonical_url_attr(name) else {
+        return;
+    };
 
-        // `srcset` is a comma-separated candidate list; every other attribute
-        // holds a single URL.
-        if canonical == "srcset" {
-            for (url, at) in srcset_candidates(value_str, *offset) {
-                report_http_scheme(url, at, canonical, checker);
-            }
-        } else {
-            report_http_scheme(value_str, *offset, canonical, checker);
+    // `srcset` is a comma-separated candidate list; every other attribute
+    // holds a single URL.
+    if canonical == "srcset" {
+        for (url, at) in srcset_candidates(value_str, *offset) {
+            report_http_scheme(url, at, canonical, checker);
         }
+    } else {
+        report_http_scheme(value_str, *offset, canonical, checker);
     }
 }
 

--- a/crates/djangofmt_lint/tests/check/form_method/form_method.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/form_method/form_method.invalid.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
-  × Found 5 lint error(s)
+  × Found 6 lint error(s)
 
 Error: 
   × Invalid value 'put' for attribute 'method'.
@@ -55,5 +55,15 @@ Error:
     ·                   ──┬──
     ·                     ╰── here
  14 │ </div>
+    ╰────
+  help: Use one of: get, post, dialog
+
+Error: 
+  × Invalid value 'delete' for attribute 'method'.
+    ╭─[tests/check/form_method/form_method.invalid.html:17:28]
+ 16 │ <!-- Jinja block as attribute -->
+ 17 │ <form {% if show %}method="delete"{% endif %}>Submit</form>
+    ·                            ───┬──
+    ·                               ╰── here
     ╰────
   help: Use one of: get, post, dialog


### PR DESCRIPTION
Missed this in the previous implementation but each checker was looping on the attribute in a buggy way instead of registering at the correct place. Claude is hard to tame :)

We now correctly flag errors in Jinja blocks in attrs like this which is nice :partying_face: :

```
Error: 
  × Invalid value 'delete' for attribute 'method'.
    ╭─[tests/check/form_method/form_method.invalid.html:17:28]
 16 │ <!-- Jinja block as attribute -->
 17 │ <form {% if show %}method="delete"{% endif %}>Submit</form>
    ·                            ───┬──
    ·                               ╰── here
    ╰────
  help: Use one of: get, post, dialog
```