### PR TITLE
feat(format): allow `{# djangofmt:ignore #}` to disable formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=23bc3e2c32d7a2a6955380168aa11a7983b4a301#23bc3e2c32d7a2a6955380168aa11a7983b4a301"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=e7fc8597645730c18826ff7c9c665ddaf0dbfe24#e7fc8597645730c18826ff7c9c665ddaf0dbfe24"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ignore = { version = "0.4.25" }
 insta = { version = "1.47.2", features = ["filters", "glob", "yaml"] }
 insta-cmd = { version = "0.6.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "23bc3e2c32d7a2a6955380168aa11a7983b4a301" }
+markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "e7fc8597645730c18826ff7c9c665ddaf0dbfe24" }
 miette = { version = "7.6.0", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -105,6 +105,7 @@ macro_rules! ignore_directive {
 }
 const DJANGOFMT_IGNORE_COMMENT_DIRECTIVE: &str = ignore_directive!();
 const DJANGOFMT_IGNORE_COMMENT: &str = concat!("<!-- ", ignore_directive!(), " -->");
+const DJANGOFMT_IGNORE_COMMENT_JINJA: &str = concat!("{# ", ignore_directive!(), " #}");
 
 /// Build default `markup_fmt` options for HTML/Jinja formatting.
 #[must_use]
@@ -263,7 +264,9 @@ pub fn format_text(
     config: &FormatterConfig,
     profile: Profile,
 ) -> std::result::Result<Option<String>, markup_fmt::FormatError> {
-    if source.starts_with(DJANGOFMT_IGNORE_COMMENT) {
+    if source.starts_with(DJANGOFMT_IGNORE_COMMENT)
+        || source.starts_with(DJANGOFMT_IGNORE_COMMENT_JINJA)
+    {
         return Ok(None);
     }
     markup_fmt::format_text(

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -70,6 +70,24 @@ fn format_file_with_ignore_directive() {
 }
 
 #[test]
+fn format_file_with_jinja_ignore_directive() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.html");
+    let original = "{# djangofmt:ignore #}\n<div   class=\"foo\"  ></div>\n";
+    std::fs::write(&file, original).unwrap();
+    assert_cmd_snapshot!(cli().arg(file.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    1 file skipped !
+    "#);
+    let content = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(content, original);
+}
+
+#[test]
 fn format_nonexistent_file() {
     assert_cmd_snapshot!(cli().arg("/nonexistent/path.html"), @r#"
     success: false
@@ -185,6 +203,22 @@ fn format_stdin_ignore_directive() {
     exit_code: 0
     ----- stdout -----
     <!-- djangofmt:ignore -->
+    <div   class="foo"  ></div>
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn format_stdin_jinja_ignore_directive() {
+    let source = "{# djangofmt:ignore #}\n<div   class=\"foo\"  ></div>\n";
+    assert_cmd_snapshot!(
+        cli().arg("-").pass_stdin(source),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {# djangofmt:ignore #}
     <div   class="foo"  ></div>
 
     ----- stderr -----

--- a/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive_jinja.html
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive_jinja.html
@@ -1,0 +1,6 @@
+<div>
+    {# djangofmt:ignore #}
+    <p     class="unformatted"      >This should not be formatted</p>
+    {# end djangofmt:ignore #}
+</div>
+<p     class="formatted"     >This should be formatted</p>

--- a/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive_jinja.snap
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive_jinja.snap
@@ -1,0 +1,9 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<div>
+    {# djangofmt:ignore #}
+    <p     class="unformatted"      >This should not be formatted</p>
+    {# end djangofmt:ignore #}
+</div>
+<p class="formatted">This should be formatted</p>

--- a/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.html
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.html
@@ -1,0 +1,8 @@
+{# djangofmt:ignore #}
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>
+
+{# Broken code don't crash djangofmt if there is a toplevel ignore #}
+<div id=>
+</div>

--- a/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.snap
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.snap
@@ -1,0 +1,11 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+{# djangofmt:ignore #}
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>
+
+{# Broken code don't crash djangofmt if there is a toplevel ignore #}
+<div id=>
+</div>

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -72,3 +72,11 @@ To disable formatting for a specific node, prefix it with the same comment:
 <div   class="keep-this-unformatted"   >Content</div>
 <div class="this-will-be-formatted">Content</div>
 ```
+
+A Django/Jinja comment works the same way, both inline and at the top of a file.
+Unlike an HTML comment, it isn't rendered to the client:
+
+```html
+{# djangofmt:ignore #}
+<div   class="keep-this-unformatted"   >Content</div>
+```


### PR DESCRIPTION
Disable formatting inline or for a whole file with a Django/Jinja `{# djangofmt:ignore #}` comment, in addition to the existing `<!-- djangofmt:ignore -->`.

Fixes #328