### PR TITLE
fix(format): support HTML tags opened/closed in {% if forloop.first/last %} blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,6 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=a124844fa6783925450a48636acb1bbdd90a70fd#a124844fa6783925450a48636acb1bbdd90a70fd"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ignore = { version = "0.4.25" }
 insta = { version = "1.47.2", features = ["filters", "glob", "yaml"] }
 insta-cmd = { version = "0.6.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
-markup_fmt = { git = "https://github.com/UnknownPlatypus/markup_fmt", rev = "a124844fa6783925450a48636acb1bbdd90a70fd" }
+markup_fmt = { path = "/home/matthias/projects/markup_fmt/markup_fmt" }
 miette = { version = "7.6.0", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }

--- a/crates/djangofmt/tests/fmt/conditional_forloop_tags.html
+++ b/crates/djangofmt/tests/fmt/conditional_forloop_tags.html
@@ -1,0 +1,4 @@
+{% for deal in offer.deals.all %}
+  {% if forloop.first %}<br><small>{% translate 'Related deals' %}: {% endif %}
+  {% link_or_none deal %}{% if forloop.last %}</small>{% else %}, {% endif %}
+{% endfor %}

--- a/crates/djangofmt/tests/fmt/conditional_forloop_tags.snap
+++ b/crates/djangofmt/tests/fmt/conditional_forloop_tags.snap
@@ -1,0 +1,8 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+{% for deal in offer.deals.all %}
+    {% if forloop.first %}<br><small>{% translate 'Related deals' %}: {% endif %}
+    {% link_or_none deal %}{% if forloop.last %}</small>{% else %},
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
When <tag> is opened inside {% if forloop.first %} and </tag> is closed inside a separate {% if forloop.last %} block, the formatter previously errored with "expected close tag for opening tag <tag>".
    
The fix is in markup_fmt: when parse_element encounters {% endif %}, {% else %}, or {% elif %} while collecting children, it now returns the element as `open_only` (no close tag emitted) and leaves the end-tag for the Jinja block parser to consume normally. The close tag that appears in a later {% if %} block is already parsed as a text node and preserved verbatim.
    
Fixes https://github.com/UnknownPlatypus/djangofmt/issues/341
