### PR TITLE
chore(deps): Renovate config fixes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,15 +2,19 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   dependencyDashboard: true,
   suppressNotifications: ["prEditedNotification"],
-  extends: ["config:best-practices", "group:allNonMajor", "helpers:pinGitHubActionDigestsToSemver"],
+  extends: [
+    "config:best-practices",
+    "group:allNonMajor",
+    "helpers:pinGitHubActionDigestsToSemver",
+    // Update annotated `*_VERSION` env vars in workflow files.
+    "customManagers:githubActionsVersions",
+  ],
   labels: ["dependencies"],
   schedule: ["before 4am on Monday"],
   separateMajorMinor: false,
-  // Wait a week before proposing updates to mitigate supply chain attacks
-  // via compromised releases that get yanked shortly after publication.
+  // Wait a week before proposing updates to mitigate supply chain attacks via compromised releases that get yanked shortly after publication.
   minimumReleaseAge: "7 days",
-  // Disable lock file maintenance (enabled by `config:best-practices`),
-  // it refreshes transitive deps to releases younger than `minimumReleaseAge`.
+  // Disable lock file maintenance (enabled by `config:best-practices`), it refreshes transitive deps to releases younger than `minimumReleaseAge`.
   lockFileMaintenance: { enabled: false },
   prHourlyLimit: 10,
   enabledManagers: ["github-actions", "cargo", "pep621", "npm", "deno", "custom.regex"],
@@ -36,8 +40,7 @@
       versioning: "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
     },
     {
-      // Group upload/download artifact updates, the versions are dependent
-      // only match git tags too otherwise this spams too much.
+      // Group upload/download artifact updates, the versions are dependent only match git tags too otherwise this spams too much.
       groupName: "Artifact GitHub Actions dependencies",
       matchManagers: ["github-actions"],
       matchDatasources: ["gitea-tags", "github-tags"],
@@ -45,9 +48,7 @@
       description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {
-      // This package rule disables updates for GitHub runners:
-      // we'd only pin them to a specific version
-      // if there was a deliberate reason to do so
+      // This package rule disables updates for GitHub runners: we'd only pin them to a specific version if there was a deliberate reason to do so
       groupName: "GitHub runners",
       matchManagers: ["github-actions"],
       matchDatasources: ["github-runners"],
@@ -60,8 +61,7 @@
       "enabled": false
     },
     {
-      // Disable automatic updates for markup_fmt, updates are handled manually
-      matchManagers: ["cargo"],
+      // Disable automatic updates for markup_fmt (cargo dep and dprint plugin), updates are handled manually.
       matchDepNames: ["markup_fmt"],
       enabled: false,
       description: "Disable updates for markup_fmt due to known issue"
@@ -90,7 +90,6 @@
       // We have a rolling support policy for the MSRV
       // 2 releases back * 6 weeks per release * 7 days per week + 1
       minimumReleaseAge: "85 days",
-      internalChecksFilter: "strict",
       groupName: "MSRV",
     },
     {
@@ -138,9 +137,46 @@
       packageNameTemplate: "rust-lang/rust",
       datasourceTemplate: "github-releases",
     },
+    // Deno version used in setup-deno
+    {
+      customType: "regex",
+      managerFilePatterns: ["/.github/workflows/publish-playground-and-docs\\.yml$/"],
+      matchStrings: ['deno-version: "(?<currentValue>\\d+\\.\\d+\\.\\d+)"'],
+      depNameTemplate: "deno",
+      packageNameTemplate: "denoland/deno",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$",
+    },
+    // wasm-pack version used in wasm-pack-action
+    {
+      customType: "regex",
+      managerFilePatterns: ["/.github/workflows/publish-playground-and-docs\\.yml$/"],
+      matchStrings: ["version: (?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
+      depNameTemplate: "wasm-pack",
+      packageNameTemplate: "rustwasm/wasm-pack",
+      datasourceTemplate: "github-releases",
+    },
+    // Official dprint plugins (plugins.dprint.dev/<name>-<version>.wasm)
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^dprint\\.json$/"],
+      matchStrings: ['"https://plugins\\.dprint\\.dev/(?<depName>[a-z0-9_]+)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.wasm"'],
+      packageNameTemplate: "dprint/dprint-plugin-{{depName}}",
+      datasourceTemplate: "github-releases",
+    },
+    // g-plane dprint plugins (plugins.dprint.dev/g-plane/<name>-v<version>.wasm)
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^dprint\\.json$/"],
+      matchStrings: ['"https://plugins\\.dprint\\.dev/g-plane/(?<depName>[a-z0-9_]+)-(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\.wasm"'],
+      packageNameTemplate: "g-plane/{{depName}}",
+      datasourceTemplate: "github-releases",
+    },
   ],
   vulnerabilityAlerts: {
     commitMessageSuffix: "",
     labels: ["dependencies", "security"],
   },
+  // Also source vulnerability alerts from OSV (better crates.io coverage).
+  osvVulnerabilityAlerts: true,
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,7 +44,7 @@
       groupName: "Artifact GitHub Actions dependencies",
       matchManagers: ["github-actions"],
       matchDatasources: ["gitea-tags", "github-tags"],
-      matchPackageNames: ["actions/.*-artifact"],
+      matchPackageNames: ["actions/*-artifact"],
       description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,8 +9,11 @@
   // Wait a week before proposing updates to mitigate supply chain attacks
   // via compromised releases that get yanked shortly after publication.
   minimumReleaseAge: "7 days",
+  // Disable lock file maintenance (enabled by `config:best-practices`),
+  // it refreshes transitive deps to releases younger than `minimumReleaseAge`.
+  lockFileMaintenance: { enabled: false },
   prHourlyLimit: 10,
-  enabledManagers: ["github-actions","cargo", "pep621", "npm", "bun", "custom.regex"],
+  enabledManagers: ["github-actions", "cargo", "pep621", "npm", "deno", "custom.regex"],
   pinDigests: true, // Pin GitHub Actions to immutable SHAs.
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
@@ -20,6 +23,10 @@
     // The default for this package manager is to only search for `pyproject.toml` files
     // found at the repository root: https://docs.renovatebot.com/modules/manager/pep621/#file-matching
     managerFilePatterns: ["/^python/.*pyproject\\.toml$/"],
+  },
+  npm: {
+    // Only python/benchmarks uses npm; the deno manager owns playground/package.json.
+    managerFilePatterns: ["/^python/.*package\\.json$/"],
   },
   packageRules: [
     {
@@ -71,7 +78,7 @@
       // (`Missing field tsconfigPaths on BindingViteResolvePluginConfig.resolveOptions`).
       // The aliasOnly:false change from tailwindlabs/tailwindcss#19803 triggers
       // an oxc resolve path that requires tsconfigPaths, which vite 8 doesn't pass.
-      matchManagers: ["npm", "bun"],
+      matchManagers: ["deno"],
       matchDepNames: ["@tailwindcss/vite", "tailwindcss"],
       allowedVersions: "<=4.2.2",
       description: "Pin tailwindcss to 4.2.2 due to vite 8 / rolldown incompatibility",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: false
 
       - name: Install rustywind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # renovate: datasource=github-releases depName=astral-sh/uv
   UV_VERSION: 0.9.13
   # Make sure CI fails on all warnings, including Clippy lints
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
Tries to fix:
  - lock file maintenance (https://github.com/UnknownPlatypus/djangofmt/pull/340) open in a separate pr to all non major                                        
  (https://github.com/UnknownPlatypus/djangofmt/pull/338) but usually all non major cannot compile if lockfile is not up to date so it should be all at once or 
  another way                                                                                                                                                   
  - pr open before the stability day periods https://github.com/UnknownPlatypus/djangofmt/pull/340, this is anoying because I cannot merge thme directly        
  - deno lockfile is not updated which mpakes ci fail here https://github.com/UnknownPlatypus/djangofmt/actions/runs/27215774822/job/80356736248?pr=338 