### PR TITLE
feat(lint): Add `same-file-partial-include` lint rule

### DIFF
--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -252,7 +252,7 @@ fn check_path(
     };
 
     if fix {
-        match lint_fix(&source, settings, profile.into(), threshold) {
+        match lint_fix(&source, settings, profile.into(), threshold, Some(path)) {
             Ok(result) => {
                 if result.applied_count > 0 && result.source != source {
                     fs::write(path, &result.source)
@@ -288,7 +288,7 @@ fn check_path(
         }
     }
 
-    let diagnostics = check_ast(&source, &ast, settings);
+    let diagnostics = check_ast(&source, &ast, settings, Some(path));
     let file_diagnostics = if diagnostics.is_empty() {
         FileDiagnostics::empty()
     } else {

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -309,7 +309,14 @@ fn check_path(
         .map_err(|err| CommandError::Read(Some(path.to_path_buf()), err))?;
 
     if fix {
-        match lint_fix(&source, settings, profile.into(), custom_blocks, threshold) {
+        match lint_fix(
+            &source,
+            settings,
+            profile.into(),
+            custom_blocks,
+            threshold,
+            Some(path),
+        ) {
             Ok(result) => {
                 if result.applied_count > 0 && result.source != source {
                     fs::write(path, &result.source)
@@ -353,16 +360,17 @@ fn check_path(
         }
     }
 
-    let diagnostics = match lint_source(&source, profile.into(), custom_blocks, settings) {
-        Ok(diagnostics) => diagnostics,
-        Err(err) => {
-            return Err(Box::new(CommandError::Parse(ParseError::new(
-                Some(path.to_path_buf()),
-                source,
-                &FormatError::Syntax(err),
-            ))));
-        }
-    };
+    let diagnostics =
+        match lint_source(&source, profile.into(), custom_blocks, settings, Some(path)) {
+            Ok(diagnostics) => diagnostics,
+            Err(err) => {
+                return Err(Box::new(CommandError::Parse(ParseError::new(
+                    Some(path.to_path_buf()),
+                    source,
+                    &FormatError::Syntax(err),
+                ))));
+            }
+        };
     let file_diagnostics = if diagnostics.is_empty() {
         FileDiagnostics::empty()
     } else {

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -485,6 +485,46 @@ fn check_fixable_file_with_fix() {
 }
 
 #[test]
+fn check_passes_file_path_to_path_aware_rules() {
+    // `same-file-partial-include` only fires when the checked file's path reaches the rule:
+    // cover both the report path (`lint_source`) and the fix path (`lint_fix`).
+    let project = Project::new().file(
+        "app/page.html",
+        "{% partialdef nav %}<a>Home</a>{% endpartialdef %}\n{% include \"app/page.html#nav\" %}\n",
+    );
+    let args = [
+        "check",
+        "--preview",
+        "--select",
+        "same-file-partial-include",
+    ];
+    assert_cmd_snapshot_tmpdir!(
+        cli().args(args).args(["--output-format", "concise"]).arg(project.join("app/page.html")),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    [TMP]/page.html:2:1: same-file-partial-include [*] Same-file partial `nav` rendered via `{% include %}`.
+    Found 1 errors. [*] 1 fixable with the --fix option.
+    "###
+    );
+    assert_cmd_snapshot!(cli().args(args).arg("--fix").arg(project.join("app/page.html")), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Found 1 errors (1 fixed, 0 remaining).
+    "###);
+    assert_eq!(
+        project.read("app/page.html"),
+        "{% partialdef nav %}<a>Home</a>{% endpartialdef %}\n{% partial nav %}\n"
+    );
+}
+
+#[test]
 fn check_fixable_file_with_show_fixes() {
     let project = Project::new().file(
         "test.html",

--- a/crates/djangofmt_benchmark/benches/linter.rs
+++ b/crates/djangofmt_benchmark/benches/linter.rs
@@ -23,6 +23,7 @@ fn check_templates(bencher: divan::Bencher, template: &'static TestFile) {
                 divan::black_box(template.code),
                 divan::black_box(&ast),
                 divan::black_box(&settings),
+                divan::black_box(None),
             )
         });
 }

--- a/crates/djangofmt_benchmark/benches/linter.rs
+++ b/crates/djangofmt_benchmark/benches/linter.rs
@@ -43,6 +43,7 @@ fn bench_check(bencher: divan::Bencher, template: &TestFile, settings: &Settings
                 divan::black_box(template.code),
                 divan::black_box(&ast),
                 divan::black_box(settings),
+                divan::black_box(None),
             )
         });
 }

--- a/crates/djangofmt_benchmark/benches/reporter.rs
+++ b/crates/djangofmt_benchmark/benches/reporter.rs
@@ -26,6 +26,7 @@ fn render(bencher: divan::Bencher, template: &'static TestFile) {
         template.profile.into(),
         &[],
         &Settings::all(),
+        None,
     )
     .expect("Parsing to succeed");
     assert!(!diagnostics.is_empty(), "{} tripped no rule", template.name);

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+
 use markup_fmt::ast::{
-    Attribute, Element, JinjaBlock, JinjaTagOrChildren, NativeAttribute, Node, NodeKind, Root,
+    Attribute, Element, JinjaBlock, JinjaTag, JinjaTagOrChildren, NativeAttribute, Node, NodeKind,
+    Root,
 };
 use miette::SourceSpan;
 
@@ -17,9 +20,9 @@ pub struct Checker<'a> {
 
 impl<'a> Checker<'a> {
     #[must_use]
-    pub const fn new(source: &'a str, settings: &'a Settings) -> Self {
+    pub const fn new(source: &'a str, settings: &'a Settings, path: Option<&'a Path>) -> Self {
         Self {
-            context: LintContext::new(source, settings),
+            context: LintContext::new(source, settings, path),
         }
     }
 
@@ -97,7 +100,14 @@ impl<'a> Checker<'a> {
         match &node.kind {
             NodeKind::Element(element) => self.visit_element(element),
             NodeKind::JinjaBlock(block) => self.visit_jinja_block(block),
+            NodeKind::JinjaTag(tag) => self.visit_jinja_tag(tag),
             _ => {}
+        }
+    }
+
+    fn visit_jinja_tag(&self, tag: &JinjaTag<'_>) {
+        if self.is_rule_enabled(Rule::SameFilePartialInclude) {
+            rules::style::same_file_partial_include::check(tag, self);
         }
     }
 
@@ -140,6 +150,7 @@ impl<'a> Checker<'a> {
         match attr {
             Attribute::Native(native) => self.visit_native_attribute(native, element),
             Attribute::JinjaBlock(block) => self.visit_jinja_attr_block(block, element),
+            Attribute::JinjaTag(tag) => self.visit_jinja_tag(tag),
             _ => {}
         }
     }

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+
 use markup_fmt::ast::{
-    Attribute, Element, JinjaBlock, JinjaTagOrChildren, NativeAttribute, Node, NodeKind, Root,
+    Attribute, Element, JinjaBlock, JinjaTag, JinjaTagOrChildren, NativeAttribute, Node, NodeKind,
+    Root,
 };
 use miette::SourceSpan;
 use smallvec::SmallVec;
@@ -22,9 +25,9 @@ pub struct Checker<'a> {
 
 impl<'a> Checker<'a> {
     #[must_use]
-    pub const fn new(source: &'a str, settings: &'a Settings) -> Self {
+    pub const fn new(source: &'a str, settings: &'a Settings, path: Option<&'a Path>) -> Self {
         Self {
-            context: LintContext::new(source, settings),
+            context: LintContext::new(source, settings, path),
             block_names: SmallVec::new_const(),
         }
     }
@@ -114,7 +117,14 @@ impl<'a> Checker<'a> {
         match &node.kind {
             NodeKind::Element(element) => self.visit_element(element),
             NodeKind::JinjaBlock(block) => self.visit_jinja_block(block),
+            NodeKind::JinjaTag(tag) => self.visit_jinja_tag(tag),
             _ => {}
+        }
+    }
+
+    fn visit_jinja_tag(&self, tag: &JinjaTag<'_>) {
+        if self.is_rule_enabled(Rule::SameFilePartialInclude) {
+            rules::style::same_file_partial_include::check(tag, self);
         }
     }
 
@@ -161,6 +171,7 @@ impl<'a> Checker<'a> {
         match attr {
             Attribute::Native(native) => self.visit_native_attribute(native, element),
             Attribute::JinjaBlock(block) => self.visit_jinja_attr_block(block, element),
+            Attribute::JinjaTag(tag) => self.visit_jinja_tag(tag),
             _ => {}
         }
     }

--- a/crates/djangofmt_lint/src/fix/apply.rs
+++ b/crates/djangofmt_lint/src/fix/apply.rs
@@ -6,6 +6,7 @@
 //! lint, apply, re-parse) up to [`MAX_FIX_ITERATIONS`].
 
 use std::borrow::Cow;
+use std::path::Path;
 
 use markup_fmt::SyntaxError;
 use markup_fmt::ast::Root;
@@ -162,8 +163,9 @@ pub fn fix_ast(
     ast: &Root<'_>,
     settings: &Settings,
     threshold: Applicability,
+    path: Option<&Path>,
 ) -> ApplyResult {
-    let diagnostics = check_ast(source, ast, settings);
+    let diagnostics = check_ast(source, ast, settings, path);
     apply_fixes(source, &diagnostics, threshold)
 }
 
@@ -212,11 +214,14 @@ pub enum FixerError {
 ///    syntax error in source that previously parsed.
 /// 4. On convergence-failure (iteration limit reached with more fixes
 ///    pending), log a warning and return the work done so far.
+///
+/// `path` is forwarded to path-aware rules; pass [`None`] when there is no backing file.
 pub fn lint_fix(
     source: &str,
     settings: &Settings,
     profile: markup_fmt::Language,
     threshold: Applicability,
+    path: Option<&Path>,
 ) -> Result<FixerResult, FixerError> {
     let mut current: Cow<'_, str> = Cow::Borrowed(source);
     let mut total_applied = 0usize;
@@ -269,7 +274,7 @@ pub fn lint_fix(
             }
         };
 
-        let diagnostics = check_ast(&current, &ast, settings);
+        let diagnostics = check_ast(&current, &ast, settings, path);
         let result = apply_fixes(&current, &diagnostics, threshold);
         total_skipped += result.skipped_count;
         for applied in &result.applied_fixes {
@@ -489,6 +494,7 @@ mod tests {
             &settings,
             markup_fmt::Language::Django,
             Applicability::Safe,
+            None,
         )
         .expect("lint_fix");
         assert_eq!(result.source, source);

--- a/crates/djangofmt_lint/src/fix/apply.rs
+++ b/crates/djangofmt_lint/src/fix/apply.rs
@@ -6,6 +6,7 @@
 //! lint, apply, re-parse) up to [`MAX_FIX_ITERATIONS`].
 
 use std::borrow::Cow;
+use std::path::Path;
 
 use markup_fmt::SyntaxError;
 use markup_fmt::ast::Root;
@@ -131,8 +132,9 @@ pub fn fix_ast(
     ast: &Root<'_>,
     settings: &Settings,
     threshold: Applicability,
+    path: Option<&Path>,
 ) -> ApplyResult {
-    let diagnostics = check_ast(source, ast, settings);
+    let diagnostics = check_ast(source, ast, settings, path);
     apply_fixes(source, &diagnostics, threshold)
 }
 
@@ -182,12 +184,15 @@ pub enum FixerError {
 ///    or [`FixerError::SyntaxRegression`] if a fix broke source that previously parsed.
 /// 4. On convergence-failure (iteration limit reached with more fixes pending),
 ///    log a warning and return the work done so far.
+///
+/// `path` is forwarded to path-aware rules; pass [`None`] when there is no backing file.
 pub fn lint_fix(
     source: &str,
     settings: &Settings,
     profile: markup_fmt::Language,
     custom_blocks: &[String],
     threshold: Applicability,
+    path: Option<&Path>,
 ) -> Result<FixerResult, FixerError> {
     let mut current: Cow<'_, str> = Cow::Borrowed(source);
     let mut total_applied = 0usize;
@@ -230,7 +235,7 @@ pub fn lint_fix(
             Err(err) => return Err(FixerError::InitialParse(err)),
         };
 
-        let diagnostics = check_ast(&current, &ast, settings);
+        let diagnostics = check_ast(&current, &ast, settings, path);
         let result = apply_fixes(&current, &diagnostics, threshold);
         total_skipped += result.skipped_count;
         for applied in &result.applied_fixes {
@@ -420,6 +425,7 @@ mod tests {
             markup_fmt::Language::Django,
             &[],
             Applicability::Safe,
+            None,
         )
         .expect("lint_fix");
         assert_eq!(result.source, source);

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -13,7 +13,7 @@
 //! let mut parser = Parser::new(source, Language::Jinja, vec![]);
 //! let ast = parser.parse_root().unwrap();
 //!
-//! let diagnostics = check_ast(source, &ast, &Settings::default());
+//! let diagnostics = check_ast(source, &ast, &Settings::default(), None);
 //! assert_eq!(diagnostics.len(), 1);
 //! ```
 
@@ -39,6 +39,8 @@ pub use rule_selector::{RuleSelector, SelectionWarning, SelectorParseError};
 pub use rule_set::RuleSet;
 pub use settings::{RuleSelection, Settings};
 pub use violation::{Violation, ViolationMetadata};
+
+use std::path::Path;
 
 use markup_fmt::ast::Root;
 use miette::{Diagnostic, NamedSource, SourceSpan};
@@ -122,9 +124,16 @@ impl FileDiagnostics {
 /// Check the AST for lint errors.
 ///
 /// Traverses the AST and runs all enabled lint rules, returning any diagnostics found.
+///
+/// `path` enables path-aware rules; pass [`None`] when linting a buffer without a backing file.
 #[must_use]
-pub fn check_ast(source: &str, ast: &Root<'_>, settings: &Settings) -> Vec<LintDiagnostic> {
-    let mut checker = Checker::new(source, settings);
+pub fn check_ast(
+    source: &str,
+    ast: &Root<'_>,
+    settings: &Settings,
+    path: Option<&Path>,
+) -> Vec<LintDiagnostic> {
+    let mut checker = Checker::new(source, settings, path);
     checker.visit_root(ast);
     checker.into_diagnostics()
 }

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -10,7 +10,7 @@
 //! use markup_fmt::Language;
 //!
 //! let source = r#"<form method="put"></form>"#;
-//! let diagnostics = lint_source(source, Language::Jinja, &[], &Settings::default()).unwrap();
+//! let diagnostics = lint_source(source, Language::Jinja, &[], &Settings::default(), None).unwrap();
 //! assert_eq!(diagnostics.len(), 1);
 //! ```
 
@@ -38,6 +38,7 @@ pub use settings::{RuleSelection, Settings};
 pub use violation::{Violation, ViolationMetadata};
 
 use std::borrow::Cow;
+use std::path::Path;
 
 use markup_fmt::ast::Root;
 use markup_fmt::parser::Parser;
@@ -155,13 +156,16 @@ impl FileDiagnostics {
 /// Check the AST for lint errors.
 ///
 /// Traverses the AST and runs all enabled lint rules, returning any diagnostics found.
+///
+/// `path` enables path-aware rules; pass [`None`] when linting a buffer without a backing file.
 #[must_use]
 pub fn check_ast<'a>(
     source: &'a str,
     ast: &Root<'a>,
     settings: &'a Settings,
+    path: Option<&'a Path>,
 ) -> Vec<LintDiagnostic> {
-    let mut checker = Checker::new(source, settings);
+    let mut checker = Checker::new(source, settings, path);
     checker.visit_root(ast);
     checker.into_diagnostics()
 }
@@ -180,12 +184,15 @@ pub fn parse<'a>(
 }
 
 /// Parse and lint `source` in one call.
+///
+/// `path` is forwarded to path-aware rules; pass [`None`] when there is no backing file.
 pub fn lint_source(
     source: &str,
     language: Language,
     custom_blocks: &[String],
     settings: &Settings,
+    path: Option<&Path>,
 ) -> Result<Vec<LintDiagnostic>, SyntaxError> {
     let ast = parse(source, language, custom_blocks)?;
-    Ok(check_ast(source, &ast, settings))
+    Ok(check_ast(source, &ast, settings, path))
 }

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -6,6 +6,7 @@
 
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
+use std::path::Path;
 
 use miette::SourceSpan;
 
@@ -23,14 +24,16 @@ pub struct LintContext<'a> {
     diagnostics: RefCell<Vec<LintDiagnostic>>,
     source: &'a str,
     settings: &'a Settings,
+    path: Option<&'a Path>,
 }
 
 impl<'a> LintContext<'a> {
     #[must_use]
-    pub const fn new(source: &'a str, settings: &'a Settings) -> Self {
+    pub const fn new(source: &'a str, settings: &'a Settings, path: Option<&'a Path>) -> Self {
         Self {
             source,
             settings,
+            path,
             diagnostics: RefCell::new(Vec::new()),
         }
     }
@@ -39,6 +42,12 @@ impl<'a> LintContext<'a> {
     #[must_use]
     pub const fn source(&self) -> &'a str {
         self.source
+    }
+
+    /// The path of the file being linted, or [`None`] when there is no backing file.
+    #[must_use]
+    pub const fn path(&self) -> Option<&'a Path> {
+        self.path
     }
 
     /// The settings active for this run.

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -5,6 +5,7 @@
 //! pushes it into the context's buffer.
 
 use std::cell::RefCell;
+use std::path::Path;
 
 use miette::SourceSpan;
 
@@ -22,14 +23,16 @@ pub struct LintContext<'a> {
     diagnostics: RefCell<Vec<LintDiagnostic>>,
     source: &'a str,
     settings: &'a Settings,
+    path: Option<&'a Path>,
 }
 
 impl<'a> LintContext<'a> {
     #[must_use]
-    pub const fn new(source: &'a str, settings: &'a Settings) -> Self {
+    pub const fn new(source: &'a str, settings: &'a Settings, path: Option<&'a Path>) -> Self {
         Self {
             source,
             settings,
+            path,
             diagnostics: RefCell::new(Vec::new()),
         }
     }
@@ -38,6 +41,12 @@ impl<'a> LintContext<'a> {
     #[must_use]
     pub const fn source(&self) -> &'a str {
         self.source
+    }
+
+    /// The path of the file being linted, or [`None`] when there is no backing file.
+    #[must_use]
+    pub const fn path(&self) -> Option<&'a Path> {
+        self.path
     }
 
     /// The settings active for this run.

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -259,4 +259,5 @@ define_rules! {
     (MissingTitle, rules::accessibility::missing_title::MissingTitle),
     (MissingImgAlt, rules::accessibility::missing_img_alt::MissingImgAlt),
     (MissingImgDimensions, rules::accessibility::missing_img_dimensions::MissingImgDimensions),
+    (SameFilePartialInclude, rules::style::same_file_partial_include::SameFilePartialInclude),
 }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -262,4 +262,5 @@ define_rules! {
     (MissingImgAlt, rules::accessibility::missing_img_alt::MissingImgAlt),
     (MissingImgDimensions, rules::accessibility::missing_img_dimensions::MissingImgDimensions),
     (TableHeaderMissingScope, rules::accessibility::table_header_missing_scope::TableHeaderMissingScope),
+    (SameFilePartialInclude, rules::style::same_file_partial_include::SameFilePartialInclude),
 }

--- a/crates/djangofmt_lint/src/rules/style/mod.rs
+++ b/crates/djangofmt_lint/src/rules/style/mod.rs
@@ -2,4 +2,5 @@ pub mod empty_attr_value;
 pub mod form_action_whitespace;
 pub mod missing_doctype;
 pub mod redundant_type_attr;
+pub mod same_file_partial_include;
 pub mod uppercase_form_method;

--- a/crates/djangofmt_lint/src/rules/style/same_file_partial_include.rs
+++ b/crates/djangofmt_lint/src/rules/style/same_file_partial_include.rs
@@ -1,0 +1,161 @@
+use markup_fmt::ast::JinjaTag;
+use markup_fmt::parser::parse_jinja_tag_name;
+
+use crate::Checker;
+use crate::fix::{Edit, Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::contains_interpolation;
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for `{% include %}` tags that render a partial defined in the same template file: the
+/// include's template path (before `#`) is a suffix of the linted file's path and a matching
+/// `{% partialdef %}` exists in the file. Dynamic template names and includes passing `with` /
+/// `only` context are left alone, and the rule is skipped when the file path is unknown (e.g.
+/// the playground).
+///
+/// ## Why is this bad?
+/// `{% include "file.html#name" %}` reloads the template from disk to extract the `name` partial.
+/// When that partial lives in the same file, `{% partial name %}` renders it directly without the
+/// extra load and makes the same-file relationship explicit.
+///
+/// ## Example
+/// ```html
+/// {% partialdef item-list %}...{% endpartialdef %}
+/// {% include "my_app/items_list.html#item-list" %}
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {% partialdef item-list %}...{% endpartialdef %}
+/// {% partial item-list %}
+/// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as safe: it only fires when the include's template path matches the
+/// file being linted and the partial is defined in it, so `{% partial %}` renders the same partial
+/// `{% include %}` would load. Whitespace-control markers (`{%-` / `-%}`) are preserved.
+///
+/// ## References
+/// - [django-template-partials](https://github.com/carltongibson/django-template-partials)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(preview_since = "0.2.11")]
+pub struct SameFilePartialInclude<'a> {
+    pub name: &'a str,
+}
+
+impl Violation for SameFilePartialInclude<'_> {
+    const RULE: Rule = Rule::SameFilePartialInclude;
+    const CATEGORY: RuleCategory = RuleCategory::Style;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!(
+            "Same-file partial `{}` rendered via `{{% include %}}`.",
+            self.name
+        )
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(format!(
+            "Render it with `{{% partial {} %}}` to avoid reloading the template from disk.",
+            self.name
+        ))
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Replace `{% include %}` with `{% partial %}`".to_string())
+    }
+}
+
+pub fn check(tag: &JinjaTag<'_>, checker: &Checker<'_>) {
+    // Same-file detection needs the linted file's path (absent in e.g. the WASM playground).
+    let Some(current_path) = checker.context().path() else {
+        return;
+    };
+
+    let tag_name = parse_jinja_tag_name(tag);
+    if tag_name != "include" {
+        return;
+    }
+
+    let Some((template_path, fragment)) = parse_partial_include(tag, tag_name) else {
+        return;
+    };
+
+    if !current_path.ends_with(template_path) {
+        return;
+    }
+
+    // Without a local partialdef, the suffix-matched include necessarily resolves to another file.
+    if !defines_partial(checker.context().source(), fragment) {
+        return;
+    }
+
+    let span = (tag.start - "{%".len(), tag.content.len() + "{%%}".len()).into();
+    let mut guard = checker.report_diagnostic(&SameFilePartialInclude { name: fragment }, span);
+
+    // Carry the tag's whitespace-control markers over to the replacement.
+    let lead = whitespace_control_marker(tag.content.chars().next());
+    let trail = whitespace_control_marker(tag.content.chars().next_back());
+    guard.set_fix(Fix::safe_edit(Edit::replacement(
+        format!("{{%{lead} partial {fragment} {trail}%}}"),
+        span,
+    )));
+}
+
+/// The whitespace-control marker (`-` / `+`) at the given edge of a tag's `content`, or `""`.
+const fn whitespace_control_marker(edge: Option<char>) -> &'static str {
+    match edge {
+        Some('-') => "-",
+        Some('+') => "+",
+        _ => "",
+    }
+}
+
+/// Split an include tag into `(template_path, fragment)`, or [`None`] if it is not static.
+fn parse_partial_include<'s>(tag: &JinjaTag<'s>, tag_name: &str) -> Option<(&'s str, &'s str)> {
+    // The arguments after the tag name, with whitespace-control markers stripped from both edges.
+    let args = tag
+        .content
+        .trim_matches(['-', '+'])
+        .trim()
+        .strip_prefix(tag_name)?
+        .trim();
+
+    // The template name must be a string literal; a variable name is dynamic and left alone.
+    let quote = args.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let (template_ref, rest) = args[1..].split_once(quote)?;
+
+    // Trailing tokens (`with`, `only`, a filter, ...) and interpolation have no `{% partial %}`
+    // equivalent.
+    if !rest.trim().is_empty() || contains_interpolation(template_ref) {
+        return None;
+    }
+
+    let (template_path, fragment) = template_ref.split_once('#')?;
+    if template_path.is_empty() || fragment.is_empty() || fragment.contains(char::is_whitespace) {
+        return None;
+    }
+
+    Some((template_path, fragment))
+}
+
+/// Whether the source contains a `{% partialdef <name> %}` opening tag.
+fn defines_partial(source: &str, name: &str) -> bool {
+    // Each `{%`-delimited chunk that opens with `partialdef <name>` as whole tokens. Splitting on
+    // `{%` rejects `endpartialdef` for free (its chunk starts with `end`).
+    source.split("{%").skip(1).any(|tag| {
+        tag.trim_start_matches(['-', '+'])
+            .trim_start()
+            .strip_prefix("partialdef")
+            .filter(|rest| rest.starts_with(char::is_whitespace))
+            .map(str::trim_start)
+            .and_then(|rest| rest.strip_prefix(name))
+            .is_some_and(|rest| rest.starts_with(|c: char| c.is_whitespace() || c == '%'))
+    })
+}

--- a/crates/djangofmt_lint/src/rules/style/same_file_partial_include.rs
+++ b/crates/djangofmt_lint/src/rules/style/same_file_partial_include.rs
@@ -1,0 +1,167 @@
+use std::borrow::Cow;
+
+use markup_fmt::ast::JinjaTag;
+use markup_fmt::parser::parse_jinja_tag_name;
+
+use crate::fix::{Edit, Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::contains_interpolation;
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+use crate::{Checker, span};
+
+/// ## What it does
+/// Checks for `{% include %}` tags that render a partial defined in the same template file: the
+/// include's template path (before `#`) is a suffix of the linted file's path and a matching
+/// `{% partialdef %}` exists in the file. Dynamic template names and includes passing `with` /
+/// `only` context are left alone, and the rule is skipped when the file path is unknown (e.g.
+/// the playground).
+///
+/// ## Why is this bad?
+/// `{% include "file.html#name" %}` reloads the template from disk to extract the `name` partial.
+/// When that partial lives in the same file, `{% partial name %}` renders it directly without the
+/// extra load and makes the same-file relationship explicit.
+///
+/// ## Example
+/// ```html
+/// {% partialdef item-list %}...{% endpartialdef %}
+/// {% include "my_app/items_list.html#item-list" %}
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {% partialdef item-list %}...{% endpartialdef %}
+/// {% partial item-list %}
+/// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as safe: it only fires when the include's template path matches the
+/// file being linted and the partial is defined in it, so `{% partial %}` renders the same partial
+/// `{% include %}` would load. Whitespace-control markers (`{%-` / `-%}`) are preserved.
+///
+/// ## References
+/// - [django-template-partials](https://github.com/carltongibson/django-template-partials)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(preview_since = "0.2.13")]
+pub struct SameFilePartialInclude<'a> {
+    pub name: &'a str,
+}
+
+impl Violation for SameFilePartialInclude<'_> {
+    const RULE: Rule = Rule::SameFilePartialInclude;
+    const CATEGORY: RuleCategory = RuleCategory::Style;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> Cow<'static, str> {
+        format!(
+            "Same-file partial `{}` rendered via `{{% include %}}`.",
+            self.name
+        )
+        .into()
+    }
+
+    fn help(&self) -> Option<Cow<'static, str>> {
+        Some(
+            format!(
+                "Render it with `{{% partial {} %}}` to avoid reloading the template from disk.",
+                self.name
+            )
+            .into(),
+        )
+    }
+
+    fn fix_title(&self) -> Option<&'static str> {
+        Some("Replace `{% include %}` with `{% partial %}`")
+    }
+}
+
+pub fn check(tag: &JinjaTag<'_>, checker: &Checker<'_>) {
+    // Same-file detection needs the linted file's path (absent in e.g. the WASM playground).
+    let Some(current_path) = checker.context().path() else {
+        return;
+    };
+
+    let tag_name = parse_jinja_tag_name(tag);
+    if tag_name != "include" {
+        return;
+    }
+
+    let Some((template_path, fragment)) = parse_partial_include(tag, tag_name) else {
+        return;
+    };
+
+    if !current_path.ends_with(template_path) {
+        return;
+    }
+
+    // Without a local partialdef, the suffix-matched include necessarily resolves to another file.
+    if !defines_partial(checker.context().source(), fragment) {
+        return;
+    }
+
+    let span = span(tag.start - "{%".len(), tag.content.len() + "{%%}".len());
+    let mut guard = checker.report_diagnostic(&SameFilePartialInclude { name: fragment }, span);
+
+    // Carry the tag's whitespace-control markers over to the replacement.
+    let lead = whitespace_control_marker(tag.content.chars().next());
+    let trail = whitespace_control_marker(tag.content.chars().next_back());
+    guard.set_fix(Fix::safe_edit(Edit::replacement(
+        format!("{{%{lead} partial {fragment} {trail}%}}"),
+        span,
+    )));
+}
+
+/// The whitespace-control marker (`-` / `+`) at the given edge of a tag's `content`, or `""`.
+const fn whitespace_control_marker(edge: Option<char>) -> &'static str {
+    match edge {
+        Some('-') => "-",
+        Some('+') => "+",
+        _ => "",
+    }
+}
+
+/// Split an include tag into `(template_path, fragment)`, or [`None`] if it is not static.
+fn parse_partial_include<'s>(tag: &JinjaTag<'s>, tag_name: &str) -> Option<(&'s str, &'s str)> {
+    // The arguments after the tag name, with whitespace-control markers stripped from both edges.
+    let args = tag
+        .content
+        .trim_matches(['-', '+'])
+        .trim()
+        .strip_prefix(tag_name)?
+        .trim();
+
+    // The template name must be a string literal; a variable name is dynamic and left alone.
+    let quote = args.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let (template_ref, rest) = args[1..].split_once(quote)?;
+
+    // Trailing tokens (`with`, `only`, a filter, ...) and interpolation have no `{% partial %}`
+    // equivalent.
+    if !rest.trim().is_empty() || contains_interpolation(template_ref) {
+        return None;
+    }
+
+    let (template_path, fragment) = template_ref.split_once('#')?;
+    if template_path.is_empty() || fragment.is_empty() || fragment.contains(char::is_whitespace) {
+        return None;
+    }
+
+    Some((template_path, fragment))
+}
+
+/// Whether the source contains a `{% partialdef <name> %}` opening tag.
+fn defines_partial(source: &str, name: &str) -> bool {
+    // Each `{%`-delimited chunk that opens with `partialdef <name>` as whole tokens. Splitting on
+    // `{%` rejects `endpartialdef` for free (its chunk starts with `end`).
+    source.split("{%").skip(1).any(|tag| {
+        tag.trim_start_matches(['-', '+'])
+            .trim_start()
+            .strip_prefix("partialdef")
+            .filter(|rest| rest.starts_with(char::is_whitespace))
+            .map(str::trim_start)
+            .and_then(|rest| rest.strip_prefix(name))
+            .is_some_and(|rest| rest.starts_with(|c: char| c.is_whitespace() || c == '%'))
+    })
+}

--- a/crates/djangofmt_lint/src/rules/style/same_file_partial_include.rs
+++ b/crates/djangofmt_lint/src/rules/style/same_file_partial_include.rs
@@ -10,11 +10,7 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 use crate::{Checker, span};
 
 /// ## What it does
-/// Checks for `{% include %}` tags that render a partial defined in the same template file: the
-/// include's template path (before `#`) is a suffix of the linted file's path and a matching
-/// `{% partialdef %}` exists in the file. Dynamic template names and includes passing `with` /
-/// `only` context are left alone, and the rule is skipped when the file path is unknown (e.g.
-/// the playground).
+/// Checks for `{% include %}` tags that render a partial defined in the same template file.
 ///
 /// ## Why is this bad?
 /// `{% include "file.html#name" %}` reloads the template from disk to extract the `name` partial.
@@ -36,7 +32,7 @@ use crate::{Checker, span};
 /// ## Fix safety
 /// This rule's fix is marked as safe: it only fires when the include's template path matches the
 /// file being linted and the partial is defined in it, so `{% partial %}` renders the same partial
-/// `{% include %}` would load. Whitespace-control markers (`{%-` / `-%}`) are preserved.
+/// `{% include %}` would load.
 ///
 /// ## References
 /// - [django-template-partials](https://github.com/carltongibson/django-template-partials)

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -19,7 +19,7 @@ fn check_valid() {
     glob!("**/*.valid.html", |path| {
         build_settings(path).bind(|| {
             let input = fs::read_to_string(path).unwrap();
-            let diagnostics = collect_diagnostics(&input);
+            let diagnostics = collect_diagnostics(&input, path);
             assert!(
                 diagnostics.is_empty(),
                 "Expected no diagnostics for {}, but found {}:\n{}",
@@ -36,7 +36,7 @@ fn check_valid() {
 fn check_invalid() {
     glob!("**/*.invalid.html", |path| {
         let input = fs::read_to_string(path).unwrap();
-        let file_diagnostics = collect_diagnostics(&input);
+        let file_diagnostics = collect_diagnostics(&input, path);
         assert!(
             !file_diagnostics.is_empty(),
             "Expected diagnostics, got none"
@@ -63,14 +63,26 @@ fn fix_snapshot() {
             .unwrap_or_else(|err| panic!("Failed to parse {}: {err:?}", path.display()));
         let stem = path.file_stem().unwrap().to_str().unwrap();
 
-        let safe = fix_ast(&input, &ast, &Settings::all(), Applicability::Safe);
+        let safe = fix_ast(
+            &input,
+            &ast,
+            &Settings::all(),
+            Applicability::Safe,
+            Some(path),
+        );
         if safe.applied_count > 0 {
             build_settings(path).bind(|| {
                 assert_snapshot!(format!("{stem}.fixed"), safe.output);
             });
         }
 
-        let unsafe_fixed = fix_ast(&input, &ast, &Settings::all(), Applicability::Unsafe);
+        let unsafe_fixed = fix_ast(
+            &input,
+            &ast,
+            &Settings::all(),
+            Applicability::Unsafe,
+            Some(path),
+        );
         if unsafe_fixed.applied_count > safe.applied_count {
             build_settings(path).bind(|| {
                 assert_snapshot!(format!("{stem}.unsafe-fixed"), unsafe_fixed.output);
@@ -81,11 +93,11 @@ fn fix_snapshot() {
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
-fn collect_diagnostics(input: &str) -> Vec<LintDiagnostic> {
+fn collect_diagnostics(input: &str, path: &Path) -> Vec<LintDiagnostic> {
     let mut parser = Parser::new(input, Language::Django, vec![]);
     let ast = parser.parse_root().expect("Failed to parse AST in test");
     let settings = Settings::all();
-    check_ast(input, &ast, &settings)
+    check_ast(input, &ast, &settings, Some(path))
 }
 
 fn render_check_output(path: &Path, input: String, diagnostics: Vec<LintDiagnostic>) -> String {

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -63,14 +63,14 @@ fn fix_snapshot() {
         let stem = path.file_stem().unwrap().to_str().unwrap();
         let settings = settings_for(path);
 
-        let safe = fix_ast(&input, &ast, &settings, Applicability::Safe);
+        let safe = fix_ast(&input, &ast, &settings, Applicability::Safe, Some(path));
         if safe.applied_count > 0 {
             build_settings(path).bind(|| {
                 assert_snapshot!(format!("{stem}.fixed"), safe.output);
             });
         }
 
-        let unsafe_fixed = fix_ast(&input, &ast, &settings, Applicability::Unsafe);
+        let unsafe_fixed = fix_ast(&input, &ast, &settings, Applicability::Unsafe, Some(path));
         if unsafe_fixed.applied_count > safe.applied_count {
             build_settings(path).bind(|| {
                 assert_snapshot!(format!("{stem}.unsafe-fixed"), unsafe_fixed.output);
@@ -115,8 +115,14 @@ fn settings_for(path: &Path) -> Settings {
 }
 
 fn collect_diagnostics(path: &Path, input: &str) -> Vec<LintDiagnostic> {
-    lint_source(input, Language::Django, &[], &settings_for(path))
-        .expect("Failed to parse AST in test")
+    lint_source(
+        input,
+        Language::Django,
+        &[],
+        &settings_for(path),
+        Some(path),
+    )
+    .expect("Failed to parse AST in test")
 }
 
 fn render_check_output(path: &Path, input: String, diagnostics: Vec<LintDiagnostic>) -> String {

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.fixed.snap
@@ -1,0 +1,32 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+<!-- The partials targeted by the includes below -->
+{% partialdef item-list %}<li>An item</li>{% endpartialdef %}
+{% partialdef card %}<span>A card</span>{% endpartialdef %}
+{% partialdef header %}<h1>A header</h1>{% endpartialdef %}
+{% partialdef menu %}<li>A menu entry</li>{% endpartialdef %}
+{% partialdef footer %}<small>A footer</small>{% endpartialdef %}
+{% partialdef attrs %}class="highlight"{% endpartialdef %}
+
+<!-- Same-file partial included by the file's own name + fragment -->
+{% partial item-list %}
+
+<!-- Matched by a multi-segment path suffix -->
+{% partial card %}
+
+<!-- Single-quoted template string -->
+{% partial header %}
+
+<!-- Whitespace-control markers are carried over to the fix -->
+{%- partial footer -%}
+
+<!-- Include in attribute position -->
+<div {% partial attrs %}>Highlighted</div>
+
+<!-- Nested inside an element and a block: the visitor must descend to reach it -->
+<nav>
+  {% if show_menu %}
+    {% partial menu %}
+  {% endif %}
+</nav>

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.fixed.snap
@@ -8,6 +8,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 {% partialdef menu %}<li>A menu entry</li>{% endpartialdef %}
 {% partialdef footer %}<small>A footer</small>{% endpartialdef %}
 {% partialdef attrs %}class="highlight"{% endpartialdef %}
+{% partialdef sidebar inline %}<aside>A sidebar</aside>{% endpartialdef %}
 
 <!-- Same-file partial included by the file's own name + fragment -->
 {% partial item-list %}
@@ -20,6 +21,9 @@ source: crates/djangofmt_lint/tests/check/main.rs
 
 <!-- Whitespace-control markers are carried over to the fix -->
 {%- partial footer -%}
+
+<!-- `inline` partialdefs are matched too -->
+{% partial sidebar %}
 
 <!-- Include in attribute position -->
 <div {% partial attrs %}>Highlighted</div>

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.html
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.html
@@ -1,0 +1,29 @@
+<!-- The partials targeted by the includes below -->
+{% partialdef item-list %}<li>An item</li>{% endpartialdef %}
+{% partialdef card %}<span>A card</span>{% endpartialdef %}
+{% partialdef header %}<h1>A header</h1>{% endpartialdef %}
+{% partialdef menu %}<li>A menu entry</li>{% endpartialdef %}
+{% partialdef footer %}<small>A footer</small>{% endpartialdef %}
+{% partialdef attrs %}class="highlight"{% endpartialdef %}
+
+<!-- Same-file partial included by the file's own name + fragment -->
+{% include "same_file_partial_include.invalid.html#item-list" %}
+
+<!-- Matched by a multi-segment path suffix -->
+{% include "same_file_partial_include/same_file_partial_include.invalid.html#card" %}
+
+<!-- Single-quoted template string -->
+{% include 'same_file_partial_include.invalid.html#header' %}
+
+<!-- Whitespace-control markers are carried over to the fix -->
+{%- include "same_file_partial_include.invalid.html#footer" -%}
+
+<!-- Include in attribute position -->
+<div {% include "same_file_partial_include.invalid.html#attrs" %}>Highlighted</div>
+
+<!-- Nested inside an element and a block: the visitor must descend to reach it -->
+<nav>
+  {% if show_menu %}
+    {% include "same_file_partial_include.invalid.html#menu" %}
+  {% endif %}
+</nav>

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.html
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.html
@@ -5,6 +5,7 @@
 {% partialdef menu %}<li>A menu entry</li>{% endpartialdef %}
 {% partialdef footer %}<small>A footer</small>{% endpartialdef %}
 {% partialdef attrs %}class="highlight"{% endpartialdef %}
+{% partialdef sidebar inline %}<aside>A sidebar</aside>{% endpartialdef %}
 
 <!-- Same-file partial included by the file's own name + fragment -->
 {% include "same_file_partial_include.invalid.html#item-list" %}
@@ -17,6 +18,9 @@
 
 <!-- Whitespace-control markers are carried over to the fix -->
 {%- include "same_file_partial_include.invalid.html#footer" -%}
+
+<!-- `inline` partialdefs are matched too -->
+{% include "same_file_partial_include.invalid.html#sidebar" %}
 
 <!-- Include in attribute position -->
 <div {% include "same_file_partial_include.invalid.html#attrs" %}>Highlighted</div>

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.snap
@@ -1,0 +1,70 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 6 lint error(s)
+
+Error: 
+  × Same-file partial `item-list` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:10:1]
+  9 │ <!-- Same-file partial included by the file's own name + fragment -->
+ 10 │ {% include "same_file_partial_include.invalid.html#item-list" %}
+    · ────────────────────────────────┬───────────────────────────────
+    ·                                 ╰── here
+ 11 │ 
+    ╰────
+  help: Render it with `{% partial item-list %}` to avoid reloading the template from disk.
+
+Error: 
+  × Same-file partial `card` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:13:1]
+ 12 │ <!-- Matched by a multi-segment path suffix -->
+ 13 │ {% include "same_file_partial_include/same_file_partial_include.invalid.html#card" %}
+    · ──────────────────────────────────────────┬──────────────────────────────────────────
+    ·                                           ╰── here
+ 14 │ 
+    ╰────
+  help: Render it with `{% partial card %}` to avoid reloading the template from disk.
+
+Error: 
+  × Same-file partial `header` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:16:1]
+ 15 │ <!-- Single-quoted template string -->
+ 16 │ {% include 'same_file_partial_include.invalid.html#header' %}
+    · ──────────────────────────────┬──────────────────────────────
+    ·                               ╰── here
+ 17 │ 
+    ╰────
+  help: Render it with `{% partial header %}` to avoid reloading the template from disk.
+
+Error: 
+  × Same-file partial `footer` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:19:1]
+ 18 │ <!-- Whitespace-control markers are carried over to the fix -->
+ 19 │ {%- include "same_file_partial_include.invalid.html#footer" -%}
+    · ───────────────────────────────┬───────────────────────────────
+    ·                                ╰── here
+ 20 │ 
+    ╰────
+  help: Render it with `{% partial footer %}` to avoid reloading the template from disk.
+
+Error: 
+  × Same-file partial `attrs` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:22:6]
+ 21 │ <!-- Include in attribute position -->
+ 22 │ <div {% include "same_file_partial_include.invalid.html#attrs" %}>Highlighted</div>
+    ·      ──────────────────────────────┬─────────────────────────────
+    ·                                    ╰── here
+ 23 │ 
+    ╰────
+  help: Render it with `{% partial attrs %}` to avoid reloading the template from disk.
+
+Error: 
+  × Same-file partial `menu` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:27:5]
+ 26 │   {% if show_menu %}
+ 27 │     {% include "same_file_partial_include.invalid.html#menu" %}
+    ·     ─────────────────────────────┬─────────────────────────────
+    ·                                  ╰── here
+ 28 │   {% endif %}
+    ╰────
+  help: Render it with `{% partial menu %}` to avoid reloading the template from disk.

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.snap
@@ -1,0 +1,62 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Same-file partial `item-list` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:10:1]
+  9 │ <!-- Same-file partial included by the file's own name + fragment -->
+ 10 │ {% include "same_file_partial_include.invalid.html#item-list" %}
+    · ────────────────────────────────┬───────────────────────────────
+    ·                                 ╰── here
+ 11 │ 
+    ╰────
+  help: Render it with `{% partial item-list %}` to avoid reloading the template from disk.
+
+  × Same-file partial `card` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:13:1]
+ 12 │ <!-- Matched by a multi-segment path suffix -->
+ 13 │ {% include "same_file_partial_include/same_file_partial_include.invalid.html#card" %}
+    · ──────────────────────────────────────────┬──────────────────────────────────────────
+    ·                                           ╰── here
+ 14 │ 
+    ╰────
+  help: Render it with `{% partial card %}` to avoid reloading the template from disk.
+
+  × Same-file partial `header` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:16:1]
+ 15 │ <!-- Single-quoted template string -->
+ 16 │ {% include 'same_file_partial_include.invalid.html#header' %}
+    · ──────────────────────────────┬──────────────────────────────
+    ·                               ╰── here
+ 17 │ 
+    ╰────
+  help: Render it with `{% partial header %}` to avoid reloading the template from disk.
+
+  × Same-file partial `footer` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:19:1]
+ 18 │ <!-- Whitespace-control markers are carried over to the fix -->
+ 19 │ {%- include "same_file_partial_include.invalid.html#footer" -%}
+    · ───────────────────────────────┬───────────────────────────────
+    ·                                ╰── here
+ 20 │ 
+    ╰────
+  help: Render it with `{% partial footer %}` to avoid reloading the template from disk.
+
+  × Same-file partial `attrs` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:22:6]
+ 21 │ <!-- Include in attribute position -->
+ 22 │ <div {% include "same_file_partial_include.invalid.html#attrs" %}>Highlighted</div>
+    ·      ──────────────────────────────┬─────────────────────────────
+    ·                                    ╰── here
+ 23 │ 
+    ╰────
+  help: Render it with `{% partial attrs %}` to avoid reloading the template from disk.
+
+  × Same-file partial `menu` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:27:5]
+ 26 │   {% if show_menu %}
+ 27 │     {% include "same_file_partial_include.invalid.html#menu" %}
+    ·     ─────────────────────────────┬─────────────────────────────
+    ·                                  ╰── here
+ 28 │   {% endif %}
+    ╰────
+  help: Render it with `{% partial menu %}` to avoid reloading the template from disk.

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.invalid.snap
@@ -2,61 +2,71 @@
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
   × Same-file partial `item-list` rendered via `{% include %}`.
-    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:10:1]
-  9 │ <!-- Same-file partial included by the file's own name + fragment -->
- 10 │ {% include "same_file_partial_include.invalid.html#item-list" %}
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:11:1]
+ 10 │ <!-- Same-file partial included by the file's own name + fragment -->
+ 11 │ {% include "same_file_partial_include.invalid.html#item-list" %}
     · ────────────────────────────────┬───────────────────────────────
     ·                                 ╰── here
- 11 │ 
+ 12 │ 
     ╰────
   help: Render it with `{% partial item-list %}` to avoid reloading the template from disk.
 
   × Same-file partial `card` rendered via `{% include %}`.
-    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:13:1]
- 12 │ <!-- Matched by a multi-segment path suffix -->
- 13 │ {% include "same_file_partial_include/same_file_partial_include.invalid.html#card" %}
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:14:1]
+ 13 │ <!-- Matched by a multi-segment path suffix -->
+ 14 │ {% include "same_file_partial_include/same_file_partial_include.invalid.html#card" %}
     · ──────────────────────────────────────────┬──────────────────────────────────────────
     ·                                           ╰── here
- 14 │ 
+ 15 │ 
     ╰────
   help: Render it with `{% partial card %}` to avoid reloading the template from disk.
 
   × Same-file partial `header` rendered via `{% include %}`.
-    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:16:1]
- 15 │ <!-- Single-quoted template string -->
- 16 │ {% include 'same_file_partial_include.invalid.html#header' %}
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:17:1]
+ 16 │ <!-- Single-quoted template string -->
+ 17 │ {% include 'same_file_partial_include.invalid.html#header' %}
     · ──────────────────────────────┬──────────────────────────────
     ·                               ╰── here
- 17 │ 
+ 18 │ 
     ╰────
   help: Render it with `{% partial header %}` to avoid reloading the template from disk.
 
   × Same-file partial `footer` rendered via `{% include %}`.
-    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:19:1]
- 18 │ <!-- Whitespace-control markers are carried over to the fix -->
- 19 │ {%- include "same_file_partial_include.invalid.html#footer" -%}
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:20:1]
+ 19 │ <!-- Whitespace-control markers are carried over to the fix -->
+ 20 │ {%- include "same_file_partial_include.invalid.html#footer" -%}
     · ───────────────────────────────┬───────────────────────────────
     ·                                ╰── here
- 20 │ 
+ 21 │ 
     ╰────
   help: Render it with `{% partial footer %}` to avoid reloading the template from disk.
 
+  × Same-file partial `sidebar` rendered via `{% include %}`.
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:23:1]
+ 22 │ <!-- `inline` partialdefs are matched too -->
+ 23 │ {% include "same_file_partial_include.invalid.html#sidebar" %}
+    · ───────────────────────────────┬──────────────────────────────
+    ·                                ╰── here
+ 24 │ 
+    ╰────
+  help: Render it with `{% partial sidebar %}` to avoid reloading the template from disk.
+
   × Same-file partial `attrs` rendered via `{% include %}`.
-    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:22:6]
- 21 │ <!-- Include in attribute position -->
- 22 │ <div {% include "same_file_partial_include.invalid.html#attrs" %}>Highlighted</div>
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:26:6]
+ 25 │ <!-- Include in attribute position -->
+ 26 │ <div {% include "same_file_partial_include.invalid.html#attrs" %}>Highlighted</div>
     ·      ──────────────────────────────┬─────────────────────────────
     ·                                    ╰── here
- 23 │ 
+ 27 │ 
     ╰────
   help: Render it with `{% partial attrs %}` to avoid reloading the template from disk.
 
   × Same-file partial `menu` rendered via `{% include %}`.
-    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:27:5]
- 26 │   {% if show_menu %}
- 27 │     {% include "same_file_partial_include.invalid.html#menu" %}
+    ╭─[tests/check/same_file_partial_include/same_file_partial_include.invalid.html:31:5]
+ 30 │   {% if show_menu %}
+ 31 │     {% include "same_file_partial_include.invalid.html#menu" %}
     ·     ─────────────────────────────┬─────────────────────────────
     ·                                  ╰── here
- 28 │   {% endif %}
+ 32 │   {% endif %}
     ╰────
   help: Render it with `{% partial menu %}` to avoid reloading the template from disk.

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.valid.html
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.valid.html
@@ -1,0 +1,27 @@
+<!-- Correct usage: render the same-file partial with `{% partial %}` -->
+{% partialdef item-list %}<li>An item</li>{% endpartialdef %}
+{% partial item-list %}
+
+<!-- Cross-file: the include targets a different file, so it is left alone -->
+{% include "other_app/items_list.html#item-list" %}
+
+<!-- Path matches but this file defines no partial named `missing`, so it is left alone -->
+{% include "same_file_partial_include.valid.html#missing" %}
+
+<!-- Whole-file include of this file (no `#fragment`) -->
+{% include "same_file_partial_include.valid.html" %}
+
+<!-- Dynamic template name (variable): the documented `try_include` exception -->
+{% include template_name %}
+
+<!-- Interpolated template string is dynamic -->
+{% include "{{ template }}#item-list" %}
+
+<!-- Filter applied to the template string makes it dynamic -->
+{% include "same_file_partial_include.valid.html#item-list"|default:fallback %}
+
+<!-- Path and fragment match, but `{% partial %}` has no `with` context, so this is left alone -->
+{% include "same_file_partial_include.valid.html#item-list" with obj=row %}
+
+<!-- ... and neither are `only` includes -->
+{% include "same_file_partial_include.valid.html#item-list" only %}

--- a/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.valid.html
+++ b/crates/djangofmt_lint/tests/check/same_file_partial_include/same_file_partial_include.valid.html
@@ -8,6 +8,9 @@
 <!-- Path matches but this file defines no partial named `missing`, so it is left alone -->
 {% include "same_file_partial_include.valid.html#missing" %}
 
+<!-- `item` is only a prefix of the defined `item-list` partial, not a definition of `item` -->
+{% include "same_file_partial_include.valid.html#item" %}
+
 <!-- Whole-file include of this file (no `#fragment`) -->
 {% include "same_file_partial_include.valid.html" %}
 

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -202,7 +202,7 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
     };
 
     let settings = Settings::all();
-    let diagnostics = check_ast(source, &ast, &settings);
+    let diagnostics = check_ast(source, &ast, &settings, None);
     let error_count = diagnostics.len();
 
     if error_count == 0 {

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -187,7 +187,7 @@ pub fn lint(source: &str, profile: &str) -> Result<JsValue, JsError> {
 
 fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
     let profile = get_profile(profile);
-    let diagnostics = match lint_source(source, profile.into(), &[], &Settings::all()) {
+    let diagnostics = match lint_source(source, profile.into(), &[], &Settings::all(), None) {
         Ok(diagnostics) => diagnostics,
         Err(e) => {
             let err = markup_fmt::FormatError::Syntax(e);


### PR DESCRIPTION
Checks for `{% include %}` tags that render a partial defined in the same template file: the include's template path (before `#`) is a suffix of the linted file's path and a matching `{% partialdef %}` exists in the file. Dynamic template names and includes passing `with` / `only` context are left alone, and the rule is skipped when the file path is unknown (e.g. the playground).