### PR TITLE
feat(lint): Add `table-header-missing-scope` lint rule

### DIFF
--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -142,6 +142,10 @@ impl<'a> Checker<'a> {
             && self.is_rule_enabled(Rule::MissingTitle)
         {
             rules::accessibility::missing_title::check(element, self);
+        } else if element.tag_name.eq_ignore_ascii_case("th")
+            && self.is_rule_enabled(Rule::TableHeaderMissingScope)
+        {
+            rules::accessibility::table_header_missing_scope::check(element, self);
         }
 
         for attr in &element.attrs {

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -260,4 +260,5 @@ define_rules! {
     (MissingTitle, rules::accessibility::missing_title::MissingTitle),
     (MissingImgAlt, rules::accessibility::missing_img_alt::MissingImgAlt),
     (MissingImgDimensions, rules::accessibility::missing_img_dimensions::MissingImgDimensions),
+    (TableHeaderMissingScope, rules::accessibility::table_header_missing_scope::TableHeaderMissingScope),
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/mod.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/mod.rs
@@ -2,3 +2,4 @@ pub mod missing_html_lang;
 pub mod missing_img_alt;
 pub mod missing_img_dimensions;
 pub mod missing_title;
+pub mod table_header_missing_scope;

--- a/crates/djangofmt_lint/src/rules/accessibility/table_header_missing_scope.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/table_header_missing_scope.rs
@@ -1,0 +1,138 @@
+use markup_fmt::ast::{Attribute, Element};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::rules::helpers::{contains_interpolation, declares_native_attr};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// The keywords a `scope` attribute may take (HTML spec / WCAG H63).
+const VALID_SCOPE_VALUES: [&str; 4] = ["row", "col", "rowgroup", "colgroup"];
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScopeViolation {
+    /// No `scope` attribute, or one with an empty/valueless value.
+    MissingOrEmpty,
+    /// A `scope` attribute whose value is not one of `VALID_SCOPE_VALUES`.
+    InvalidValue { value: String },
+}
+
+/// ## What it does
+/// Checks that every `<th>` header cell has a `scope` attribute set to one of the valid keywords
+/// `row`, `col`, `rowgroup`, or `colgroup`.
+///
+/// ## Why is this bad?
+/// The `scope` attribute tells assistive technology whether a header cell labels a column or a row.
+/// Without it, screen readers must guess the header-to-data association in anything but the simplest
+/// table, so cells may be announced with the wrong header or none at all.
+///
+///
+/// ## Example
+/// ```html
+/// <table>
+///     <tr><th>Name</th><th scope="column">Email</th></tr>
+///     <tr><td>Ada</td><td>ada@example.com</td></tr>
+/// </table>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// <table>
+///     <tr><th scope="col">Name</th><th scope="col">Email</th></tr>
+///     <tr><td>Ada</td><td>ada@example.com</td></tr>
+/// </table>
+/// ```
+///
+/// ## References
+/// - [WCAG H63: Using the `scope` attribute](https://www.w3.org/WAI/WCAG21/Techniques/html/H63)
+/// - [MDN: `<th>` `scope`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct TableHeaderMissingScope {
+    pub kind: ScopeViolation,
+}
+
+impl Violation for TableHeaderMissingScope {
+    const RULE: Rule = Rule::TableHeaderMissingScope;
+    const CATEGORY: RuleCategory = RuleCategory::Accessibility;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        match &self.kind {
+            ScopeViolation::MissingOrEmpty => {
+                "Missing or empty `scope` attribute on `<th>`.".to_string()
+            }
+            ScopeViolation::InvalidValue { value } => {
+                format!("Invalid `scope` value `{value}` on `<th>`.")
+            }
+        }
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(match &self.kind {
+            ScopeViolation::MissingOrEmpty => {
+                "Add `scope=\"col\"` or `scope=\"row\"` to associate the header with its data."
+                    .to_string()
+            }
+            ScopeViolation::InvalidValue { .. } => {
+                "Change `scope` to one of `row`, `col`, `rowgroup`, or `colgroup`.".to_string()
+            }
+        })
+    }
+}
+
+/// The caller guarantees `element` is a `<th>`.
+pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
+    let native_scope = element.attrs.iter().find_map(|attr| match attr {
+        Attribute::Native(native) if native.name.eq_ignore_ascii_case("scope") => Some(native),
+        _ => None,
+    });
+
+    let Some(scope) = native_scope else {
+        // A `scope` wrapped in a Jinja block counts as present but stays unvalidated.
+        if element
+            .attrs
+            .iter()
+            .any(|attr| declares_native_attr(attr, "scope"))
+        {
+            return;
+        }
+        let offset = checker.source_offset(element.tag_name);
+        checker.report_diagnostic(
+            &TableHeaderMissingScope {
+                kind: ScopeViolation::MissingOrEmpty,
+            },
+            (offset, element.tag_name.len()).into(),
+        );
+        return;
+    };
+
+    match scope.value {
+        Some((value, offset)) if !value.is_empty() => {
+            if contains_interpolation(value)
+                || VALID_SCOPE_VALUES
+                    .iter()
+                    .any(|valid| valid.eq_ignore_ascii_case(value))
+            {
+                return;
+            }
+            checker.report_diagnostic(
+                &TableHeaderMissingScope {
+                    kind: ScopeViolation::InvalidValue {
+                        value: value.to_string(),
+                    },
+                },
+                (offset, value.len()).into(),
+            );
+        }
+        // `scope=""` or a valueless `scope`: present but with no usable value.
+        _ => {
+            let offset = checker.source_offset(scope.name);
+            checker.report_diagnostic(
+                &TableHeaderMissingScope {
+                    kind: ScopeViolation::MissingOrEmpty,
+                },
+                (offset, scope.name.len()).into(),
+            );
+        }
+    }
+}

--- a/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.valid.html
+++ b/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.valid.html
@@ -27,7 +27,7 @@
 <div x-id=""></div>
 
 <!-- `id`/`class` appearing inside a value or text content -->
-<th data-field="id" style="display: none">ID</th>
+<th scope="col" data-field="id" style="display: none">ID</th>
 <input type="number" name="account_id" placeholder="enter account ID here" />
 <meta name="description" content="Simple app to rate a class, a session, etc." />
 <a href="{% url 'foo:bar' id %}">link</a>

--- a/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.valid.html
+++ b/crates/djangofmt_lint/tests/check/empty_tag_pair/empty_tag_pair.valid.html
@@ -39,7 +39,7 @@
 <table>
     <tr>
         <td></td>
-        <th></th>
+        <th scope="col"></th>
     </tr>
 </table>
 <ul>
@@ -54,7 +54,7 @@
 <table>
     <tr>
         <TD></TD>
-        <TH></TH>
+        <TH scope="col"></TH>
     </tr>
 </table>
 

--- a/crates/djangofmt_lint/tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html
+++ b/crates/djangofmt_lint/tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html
@@ -1,0 +1,55 @@
+<!-- Bare <th> with no attributes -->
+<table>
+    <tr><th>Name</th><th>Email</th></tr>
+    <tr><td>Ada</td><td>ada@example.com</td></tr>
+</table>
+
+<!-- <th> with other attributes but no scope -->
+<table>
+    <tr><th class="font-bold" id="col-name">Name</th></tr>
+</table>
+
+<!-- Case-insensitive tag name -->
+<table>
+    <tr><TH>Name</TH></tr>
+</table>
+
+<!-- A look-alike attribute that is not scope -->
+<table>
+    <tr><th data-scope="col">Name</th></tr>
+</table>
+
+<!-- <th> inside <thead>/<tbody> structure -->
+<table>
+    <thead>
+        <tr><th>Name</th><th>Email</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>Ada</td><td>ada@example.com</td></tr>
+    </tbody>
+</table>
+
+<!-- <th> with a Jinja interpolation in an unrelated attribute -->
+<table>
+    <tr><th class="{{ header_class }}">Name</th></tr>
+</table>
+
+<!-- Unrecognized scope value -->
+<table>
+    <tr><th scope="column">Name</th></tr>
+</table>
+
+<!-- `auto` is the browser fallback, not a writable scope value -->
+<table>
+    <tr><th scope="auto">Name</th></tr>
+</table>
+
+<!-- Empty scope value provides no association -->
+<table>
+    <tr><th scope="">Name</th></tr>
+</table>
+
+<!-- Valueless (boolean) scope attribute -->
+<table>
+    <tr><th scope>Name</th></tr>
+</table>

--- a/crates/djangofmt_lint/tests/check/table_header_missing_scope/table_header_missing_scope.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/table_header_missing_scope/table_header_missing_scope.invalid.snap
@@ -1,0 +1,136 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 12 lint error(s)
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+   ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:3:10]
+ 2 │ <table>
+ 3 │     <tr><th>Name</th><th>Email</th></tr>
+   ·          ─┬
+   ·           ╰── here
+ 4 │     <tr><td>Ada</td><td>ada@example.com</td></tr>
+   ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+   ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:3:23]
+ 2 │ <table>
+ 3 │     <tr><th>Name</th><th>Email</th></tr>
+   ·                       ─┬
+   ·                        ╰── here
+ 4 │     <tr><td>Ada</td><td>ada@example.com</td></tr>
+   ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:9:10]
+  8 │ <table>
+  9 │     <tr><th class="font-bold" id="col-name">Name</th></tr>
+    ·          ─┬
+    ·           ╰── here
+ 10 │ </table>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:14:10]
+ 13 │ <table>
+ 14 │     <tr><TH>Name</TH></tr>
+    ·          ─┬
+    ·           ╰── here
+ 15 │ </table>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:19:10]
+ 18 │ <table>
+ 19 │     <tr><th data-scope="col">Name</th></tr>
+    ·          ─┬
+    ·           ╰── here
+ 20 │ </table>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:25:14]
+ 24 │     <thead>
+ 25 │         <tr><th>Name</th><th>Email</th></tr>
+    ·              ─┬
+    ·               ╰── here
+ 26 │     </thead>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:25:27]
+ 24 │     <thead>
+ 25 │         <tr><th>Name</th><th>Email</th></tr>
+    ·                           ─┬
+    ·                            ╰── here
+ 26 │     </thead>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:34:10]
+ 33 │ <table>
+ 34 │     <tr><th class="{{ header_class }}">Name</th></tr>
+    ·          ─┬
+    ·           ╰── here
+ 35 │ </table>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Invalid `scope` value `column` on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:39:20]
+ 38 │ <table>
+ 39 │     <tr><th scope="column">Name</th></tr>
+    ·                    ───┬──
+    ·                       ╰── here
+ 40 │ </table>
+    ╰────
+  help: Change `scope` to one of `row`, `col`, `rowgroup`, or `colgroup`.
+
+Error: 
+  × Invalid `scope` value `auto` on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:44:20]
+ 43 │ <table>
+ 44 │     <tr><th scope="auto">Name</th></tr>
+    ·                    ──┬─
+    ·                      ╰── here
+ 45 │ </table>
+    ╰────
+  help: Change `scope` to one of `row`, `col`, `rowgroup`, or `colgroup`.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:49:13]
+ 48 │ <table>
+ 49 │     <tr><th scope="">Name</th></tr>
+    ·             ──┬──
+    ·               ╰── here
+ 50 │ </table>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.
+
+Error: 
+  × Missing or empty `scope` attribute on `<th>`.
+    ╭─[tests/check/table_header_missing_scope/table_header_missing_scope.invalid.html:54:13]
+ 53 │ <table>
+ 54 │     <tr><th scope>Name</th></tr>
+    ·             ──┬──
+    ·               ╰── here
+ 55 │ </table>
+    ╰────
+  help: Add `scope="col"` or `scope="row"` to associate the header with its data.

--- a/crates/djangofmt_lint/tests/check/table_header_missing_scope/table_header_missing_scope.valid.html
+++ b/crates/djangofmt_lint/tests/check/table_header_missing_scope/table_header_missing_scope.valid.html
@@ -1,0 +1,48 @@
+<!-- All four valid scope keywords -->
+<table>
+    <tr><th scope="col">Name</th><th scope="colgroup">Contact</th></tr>
+    <tr><th scope="row">Total</th><td>42</td></tr>
+    <tr><th scope="rowgroup">Group</th><td>x</td></tr>
+</table>
+
+<!-- Keyword matching is case-insensitive -->
+<table>
+    <tr><th scope="COL">Name</th></tr>
+</table>
+
+<!-- Case-insensitive scope attribute name -->
+<table>
+    <tr><th SCOPE="col">Name</th></tr>
+</table>
+
+<!-- scope value supplied via a Jinja interpolation is not validated -->
+<table>
+    <tr><th scope="{{ orientation }}">Name</th></tr>
+</table>
+
+<!-- scope alongside other attributes -->
+<table>
+    <tr><th class="font-bold" scope="col" id="col-name">Name</th></tr>
+</table>
+
+<!-- scope declared in each branch of a wrapping Jinja block -->
+<table>
+    <tr><th {% if vertical %}scope="row"{% else %}scope="col"{% endif %}>Name</th></tr>
+</table>
+
+<!-- scope declared inside a Jinja block alongside other attributes -->
+<table>
+    <tr><th {% if sortable %}scope="col" aria-sort="ascending"{% endif %}>Name</th></tr>
+</table>
+
+<!-- <td> data cells are never flagged -->
+<table>
+    <tr><td>Ada</td><td>ada@example.com</td></tr>
+</table>
+
+<!-- Tag names that merely start with "th" are not <th> -->
+<table>
+    <thead>
+        <tr><td>Header</td></tr>
+    </thead>
+</table>


### PR DESCRIPTION
Checks for `<th>` elements that have no `scope` attribute.

The `scope` attribute tells assistive technology whether a header cell labels a column (`scope="col"`) or a row (`scope="row"`). Without it, screen readers must guess the header-to-data association in anything but the simplest table, so cells may be announced with the wrong — or no — header. Explicit `scope` makes the data relationships unambiguous (WCAG 1.3.1, Info and Relationships).

Elements that carry a dynamic or templated attribute that could resolve to `scope` (for example a Jinja block or tag wrapping attributes) are skipped to avoid false positives.

```html
<table>
    <tr><th>Name</th><th>Email</th></tr>
    <tr><td>Ada</td><td>ada@example.com</td></tr>
</table>
```

Use instead:
```html
<table>
    <tr><th scope="col">Name</th><th scope="col">Email</th></tr>
    <tr><td>Ada</td><td>ada@example.com</td></tr>
</table>
```

- [WCAG 1.3.1: Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
- [MDN: `<th>` `scope`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope)