### PR TITLE
fix(error): Remove the tracing-subscriber pin and use the added workaround

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,13 +67,6 @@
       description: "Disable updates for markup_fmt due to known issue"
     },
     {
-      // Pin tracing-subscriber to avoid https://github.com/tokio-rs/tracing/issues/3369
-      matchManagers: ["cargo"],
-      matchDepNames: ["tracing-subscriber"],
-      enabled: false,
-      description: "Disable updates for tracing-subscriber due to known issue",
-    },
-    {
       // @tailwindcss/vite 4.2.3+ broke build with vite 8 / rolldown
       // (`Missing field tsconfigPaths on BindingViteResolvePluginConfig.resolveOptions`).
       // The aliasOnly:false change from tailwindlabs/tailwindcss#19803 triggers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ thiserror = { version = "2.0.18" }
 tikv-jemallocator = { version = "0.7.0" }
 toml = { version = "1.1.2" }
 tracing = { version = "0.1.44" }
-# Pin to avoid https://github.com/tokio-rs/tracing/issues/3369
-tracing-subscriber = { version = "=0.3.23" }
+tracing-subscriber = { version = "0.3.23" }
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 tracing-tree = { version = "0.4.1" }
 tsify = { version = "0.5.6" }

--- a/crates/djangofmt/src/logging.rs
+++ b/crates/djangofmt/src/logging.rs
@@ -48,6 +48,7 @@ pub fn setup_tracing(level: LogLevel) {
             .with(
                 tracing_subscriber::fmt::layer()
                     .with_writer(std::io::stderr)
+                    .with_ansi_sanitization(false)
                     .event_format(
                         format()
                             .compact()


### PR DESCRIPTION
renovate regressed this, the explicit pins was not configured correctly I suppose