### PR TITLE
chore(deps): Bump cargo dist to latest to fix toml 1.1 parsing error

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,9 +56,10 @@
       enabled: false,
     },
     {
-      // This file is managed by cargo-dist, don't try to update it.
-      "matchFileNames": [".github/workflows/release.yml"],
-      "enabled": false
+      // This file is managed by cargo-dist, don't try to update actions inside it.
+      matchManagers: ["github-actions"],
+      matchFileNames: [".github/workflows/release.yml"],
+      enabled: false,
     },
     {
       // Disable automatic updates for markup_fmt (cargo dep and dprint plugin), updates are handled manually.
@@ -94,6 +95,11 @@
       matchManagers: ["custom.regex"],
       matchDepNames: ["maturin"],
       commitMessageTopic: "maturin",
+    },
+    {
+      matchManagers: ["custom.regex"],
+      matchDepNames: ["cargo-dist"],
+      commitMessageTopic: "cargo-dist",
     },
   ],
   customManagers: [
@@ -164,6 +170,20 @@
       matchStrings: ['"https://plugins\\.dprint\\.dev/g-plane/(?<depName>[a-z0-9_]+)-(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\.wasm"'],
       packageNameTemplate: "g-plane/{{depName}}",
       datasourceTemplate: "github-releases",
+    },
+    // cargo-dist version, kept in sync between dist-workspace.toml and the generated release.yml installer.
+    {
+      customType: "regex",
+      managerFilePatterns: [
+        "/(^|/)dist-workspace\\.toml$/",
+        "/.github/workflows/release\\.yml$/",
+      ],
+      matchStrings: [
+        '(?<packageName>[\\w-]+?)-version = "(?<currentValue>\\d+\\.\\d+\\.\\d+)"',
+        'https://github\\.com/axodotdev/(?<packageName>[\\w-]+?)/releases/download/v(?<currentValue>\\d+\\.\\d+\\.\\d+)/',
+      ],
+      datasourceTemplate: "crate",
+      versioningTemplate: "semver",
     },
   ],
   vulnerabilityAlerts: {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ aarch64-unknown-linux-gnu = "2.28"
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.3"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
Fixes this toml parsing error https://github.com/UnknownPlatypus/djangofmt/actions/runs/27467833566/job/81193215470

Also adds a new renovate rule to bump cargo-dist