### PR TITLE
feat(format): support `.editorconfig` configuration files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "clap_complete_command",
  "djangofmt_lint",
  "dprint-plugin-json",
+ "editorconfig-parser",
  "ignore",
  "insta",
  "insta-cmd",
@@ -509,6 +510,15 @@ dependencies = [
  "jsonc-parser",
  "serde",
  "text_lines",
+]
+
+[[package]]
+name = "editorconfig-parser"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e587c7336689e4dbb79157eb50ca5de9b3f75a48b85f17c1297d9c31e9d3bbc3"
+dependencies = [
+ "globset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ clap_complete_command = { version = "0.6.1" }
 divan = { package = "codspeed-divan-compat", version = "*" }
 djangofmt_macros = { path = "crates/djangofmt_macros" }
 dprint-plugin-json = { version = "0.21.3" }
+editorconfig-parser = { version = "0.0.4" }
 ignore = { version = "0.4.25" }
 insta = { version = "1.47.2", features = ["filters", "glob", "yaml"] }
 insta-cmd = { version = "0.6.0" }

--- a/README.md
+++ b/README.md
@@ -125,7 +125,17 @@ preserve-unquoted-attrs = false
 Djangofmt looks for a `pyproject.toml` file by traversing directories upward from the current working directory.
 The first `pyproject.toml` found is used. If no file is found or the file doesn't contain a `[tool.djangofmt]` section, defaults are used.
 
-Command-line arguments always take precedence over `pyproject.toml` settings.
+Djangofmt also picks up [EditorConfig](https://editorconfig.org/) settings from the nearest `.editorconfig` file:
+
+```ini
+root = true
+
+[*]
+indent_size = 4
+max_line_length = 120
+```
+
+Command-line arguments always take precedence over `pyproject.toml` settings, which take precedence over `.editorconfig` settings.
 
 See [Controlling the formatting](https://unknownplatypus.github.io/djangofmt/docs/formatting/) for the behaviour of each option and how to opt into per-node overrides.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ preserve-unquoted-attrs = false
 Djangofmt looks for a `pyproject.toml` file by traversing directories upward from the current working directory.
 The first `pyproject.toml` found is used. If no file is found or the file doesn't contain a `[tool.djangofmt]` section, defaults are used.
 
-Djangofmt also picks up [EditorConfig](https://editorconfig.org/) settings from the nearest `.editorconfig` file:
+Djangofmt also reads [EditorConfig](https://editorconfig.org/) settings from the nearest `.editorconfig` file:
 
 ```ini
 root = true

--- a/crates/djangofmt/Cargo.toml
+++ b/crates/djangofmt/Cargo.toml
@@ -18,6 +18,7 @@ clap = { workspace = true }
 clap_complete_command = { workspace = true }
 djangofmt_lint = { path = "../djangofmt_lint" }
 dprint-plugin-json = { workspace = true }
+editorconfig-parser = { workspace = true }
 ignore = { workspace = true }
 malva = { workspace = true }
 markup_fmt = { workspace = true }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -9,12 +9,15 @@ use tracing::{debug, error, info};
 
 use crate::ExitStatus;
 use crate::args::{FormatCommand, Profile};
+use crate::editorconfig::{self, EditorconfigSettings};
 use crate::error::{CommandError, ParseError, Result};
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 use crate::pyproject::PyprojectSettings;
 use crate::resolver::resolve_bool_arg;
+use editorconfig_parser::EditorConfig;
 
 /// Pre-built configuration for all formatters.
+#[derive(Clone)]
 pub struct FormatterConfig {
     /// Config for main HTML/Jinja formatter
     pub markup: markup_fmt::config::FormatOptions,
@@ -46,18 +49,24 @@ impl FormatterConfig {
         }
     }
 
-    /// Build a [`FormatterConfig`] by merging CLI arguments with pyproject.toml settings.
+    /// Build a [`FormatterConfig`] by merging CLI arguments with `pyproject.toml` and `.editorconfig` settings.
     ///
-    /// CLI arguments take precedence over pyproject settings, which take precedence over defaults.
+    /// Precedence is `cli` > `pyproject` > `editorconfig` > `default`
     #[must_use]
-    pub fn from_args(args: &FormatCommand, pyproject: &PyprojectSettings) -> Self {
+    pub fn from_args(
+        args: &FormatCommand,
+        pyproject: &PyprojectSettings,
+        editorconfig: &EditorconfigSettings,
+    ) -> Self {
         let line_length = args
             .line_length
             .or(pyproject.line_length)
+            .or(editorconfig.line_length)
             .unwrap_or_default();
         let indent_width = args
             .indent_width
             .or(pyproject.indent_width)
+            .or(editorconfig.indent_width)
             .unwrap_or_default();
         let custom_blocks =
             merge_custom_blocks(args.custom_blocks.clone(), pyproject.custom_blocks.clone());
@@ -214,16 +223,72 @@ fn build_json_config(
         .build()
 }
 
+/// Per-run inputs used to derive a per-file [`FormatterConfig`] and [`Profile`].
+struct FormatContext<'a> {
+    args: &'a FormatCommand,
+    pyproject: &'a PyprojectSettings,
+    editorconfig: Option<&'a EditorConfig>,
+    profile: Option<Profile>,
+    /// Built once when `.editorconfig` can't vary per file (no config, or only `[*]`).
+    shared_config: Option<FormatterConfig>,
+}
+
+impl<'a> FormatContext<'a> {
+    fn new(
+        args: &'a FormatCommand,
+        pyproject: &'a PyprojectSettings,
+        editorconfig: Option<&'a EditorConfig>,
+        profile: Option<Profile>,
+    ) -> Self {
+        let mut context = Self {
+            args,
+            pyproject,
+            editorconfig,
+            profile,
+            shared_config: None,
+        };
+        if !editorconfig::has_per_file_sections(editorconfig) {
+            // Any filename resolves the same settings here, so build the config once.
+            context.shared_config = Some(context.build_config(Path::new("any")));
+        }
+        context
+    }
+
+    fn profile_for(&self, path: &Path) -> Profile {
+        self.profile
+            .or_else(|| Profile::from_path(path))
+            .unwrap_or_default()
+    }
+
+    /// The config for `path`: the shared one when set, otherwise built for this file.
+    fn config_for(&self, path: &Path) -> Cow<'_, FormatterConfig> {
+        self.shared_config
+            .as_ref()
+            .map_or_else(|| Cow::Owned(self.build_config(path)), Cow::Borrowed)
+    }
+
+    fn build_config(&self, path: &Path) -> FormatterConfig {
+        let settings = editorconfig::settings_for(self.editorconfig, path);
+        FormatterConfig::from_args(self.args, self.pyproject, &settings)
+    }
+}
+
 pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
     let resolved = super::resolve_command(&args.files, args.profile, &args.file_selection)?;
-    let config = FormatterConfig::from_args(args, &resolved.pyproject);
+    let editorconfig = editorconfig::load_editorconfig_from_cwd();
+    let context = FormatContext::new(
+        args,
+        &resolved.pyproject,
+        editorconfig.as_ref(),
+        resolved.profile,
+    );
 
     // Format files in parallel
     let start = Instant::now();
     let (results, mut parse_errors): (Vec<_>, Vec<_>) = resolved
         .files
         .par_iter()
-        .map(|entry| format_path(entry, &config, resolved.profile))
+        .map(|entry| format_path(entry, &context))
         .partition_map(|result| match result {
             Ok(fmt_res) => Left(fmt_res),
             Err(err) => Right(err),
@@ -332,16 +397,14 @@ pub fn format_text(
 #[tracing::instrument(level="debug", skip_all, fields(path = %path.display()))]
 fn format_path(
     path: &Path,
-    config: &FormatterConfig,
-    profile: Option<Profile>,
+    context: &FormatContext,
 ) -> std::result::Result<FormatResult, Box<CommandError>> {
-    let profile = profile
-        .or_else(|| Profile::from_path(path))
-        .unwrap_or_default();
+    let profile = context.profile_for(path);
+    let config = context.config_for(path);
     let unformatted = std::fs::read_to_string(path)
         .map_err(|err| CommandError::Read(Some(path.to_path_buf()), err))?;
 
-    let formatted = match format_text(&unformatted, config, profile) {
+    let formatted = match format_text(&unformatted, &config, profile) {
         Ok(f) => f,
         Err(err) => {
             return Err(Box::new(CommandError::Parse(ParseError::new(
@@ -505,7 +568,8 @@ mod tests {
             file_selection: crate::args::FileSelectionArgs::default(),
         };
         let pyproject = PyprojectSettings::default();
-        let config = FormatterConfig::from_args(&args, &pyproject);
+        let config =
+            FormatterConfig::from_args(&args, &pyproject, &EditorconfigSettings::default());
         assert_eq!(config.markup.layout.print_width, 120);
         assert_eq!(config.markup.layout.indent_width, 4);
     }
@@ -530,7 +594,8 @@ mod tests {
             html_void_self_closing: Some(SelfClosing::Never),
             ..Default::default()
         };
-        let config = FormatterConfig::from_args(&args, &pyproject);
+        let config =
+            FormatterConfig::from_args(&args, &pyproject, &EditorconfigSettings::default());
         assert_eq!(config.markup.layout.print_width, 80);
         assert_eq!(config.markup.layout.indent_width, 2);
         assert_eq!(config.markup.language.html_void_self_closing, Some(true));
@@ -554,8 +619,33 @@ mod tests {
             line_length: Some(LineLength::try_from(200u16).unwrap()),
             ..Default::default()
         };
-        let config = FormatterConfig::from_args(&args, &pyproject);
+        let config =
+            FormatterConfig::from_args(&args, &pyproject, &EditorconfigSettings::default());
         assert_eq!(config.markup.layout.print_width, 200);
+    }
+
+    #[test]
+    fn formatter_config_from_args_falls_back_to_editorconfig() {
+        let args = FormatCommand {
+            files: vec![],
+            stdin_filename: None,
+            line_length: None,
+            indent_width: None,
+            profile: None,
+            custom_blocks: None,
+            html_void_self_closing: None,
+            preserve_unquoted_attrs: false,
+            no_preserve_unquoted_attrs: false,
+            file_selection: crate::args::FileSelectionArgs::default(),
+        };
+        let editorconfig = EditorconfigSettings {
+            line_length: Some(LineLength::try_from(100u16).unwrap()),
+            indent_width: Some(IndentWidth::try_from(2u8).unwrap()),
+        };
+        let config =
+            FormatterConfig::from_args(&args, &PyprojectSettings::default(), &editorconfig);
+        assert_eq!(config.markup.layout.print_width, 100);
+        assert_eq!(config.markup.layout.indent_width, 2);
     }
 
     #[test]
@@ -573,7 +663,8 @@ mod tests {
             file_selection: crate::args::FileSelectionArgs::default(),
         };
         let pyproject = PyprojectSettings::default();
-        let config = FormatterConfig::from_args(&args, &pyproject);
+        let config =
+            FormatterConfig::from_args(&args, &pyproject, &EditorconfigSettings::default());
         assert!(config.markup.language.preserve_unquoted_attrs);
     }
 
@@ -595,7 +686,8 @@ mod tests {
             preserve_unquoted_attrs: Some(true),
             ..Default::default()
         };
-        let config = FormatterConfig::from_args(&args, &pyproject);
+        let config =
+            FormatterConfig::from_args(&args, &pyproject, &EditorconfigSettings::default());
         assert!(config.markup.language.preserve_unquoted_attrs);
     }
 
@@ -617,7 +709,8 @@ mod tests {
             preserve_unquoted_attrs: Some(true),
             ..Default::default()
         };
-        let config = FormatterConfig::from_args(&args, &pyproject);
+        let config =
+            FormatterConfig::from_args(&args, &pyproject, &EditorconfigSettings::default());
         assert!(!config.markup.language.preserve_unquoted_attrs);
     }
 

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -230,7 +230,7 @@ struct FormatContext<'a> {
     editorconfig: Option<&'a EditorConfig>,
     profile: Option<Profile>,
     /// Built once when `.editorconfig` can't vary per file (no config, or only `[*]`).
-    shared_config: Option<FormatterConfig>,
+    config: Option<FormatterConfig>,
 }
 
 impl<'a> FormatContext<'a> {
@@ -245,11 +245,11 @@ impl<'a> FormatContext<'a> {
             pyproject,
             editorconfig,
             profile,
-            shared_config: None,
+            config: None,
         };
         if !editorconfig::has_per_file_sections(editorconfig) {
             // Any filename resolves the same settings here, so build the config once.
-            context.shared_config = Some(context.build_config(Path::new("any")));
+            context.config = Some(context.build_config(Path::new("any")));
         }
         context
     }
@@ -262,14 +262,14 @@ impl<'a> FormatContext<'a> {
 
     /// The config for `path`: the shared one when set, otherwise built for this file.
     fn config_for(&self, path: &Path) -> Cow<'_, FormatterConfig> {
-        self.shared_config
+        self.config
             .as_ref()
             .map_or_else(|| Cow::Owned(self.build_config(path)), Cow::Borrowed)
     }
 
     fn build_config(&self, path: &Path) -> FormatterConfig {
-        let settings = editorconfig::settings_for(self.editorconfig, path);
-        FormatterConfig::from_args(self.args, self.pyproject, &settings)
+        let editorconfig = editorconfig::resolve_editorconfig(self.editorconfig, path);
+        FormatterConfig::from_args(self.args, self.pyproject, &editorconfig)
     }
 }
 

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -32,7 +32,7 @@ pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
         .or(pyproject.profile)
         .unwrap_or_default();
     let editorconfig = editorconfig::load_editorconfig_from_cwd();
-    let settings = editorconfig::settings_for(
+    let settings = editorconfig::resolve_editorconfig(
         editorconfig.as_ref(),
         stdin_filename.unwrap_or_else(|| Path::new("")),
     );

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -6,6 +6,7 @@ use tracing::error;
 use crate::ExitStatus;
 use crate::args::{FormatCommand, Profile};
 use crate::commands::format::{FormatterConfig, format_text};
+use crate::editorconfig;
 use crate::error::{CommandError, ParseError, Result};
 use crate::pyproject::load_pyproject_from_cwd;
 use crate::resolver::{ResolvedDiscoveryConfig, is_force_excluded};
@@ -25,12 +26,17 @@ pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
         return Ok(ExitStatus::Success);
     }
 
-    let config = FormatterConfig::from_args(cli, &pyproject);
     let profile = cli
         .profile
         .or_else(|| stdin_filename.and_then(Profile::from_path))
         .or(pyproject.profile)
         .unwrap_or_default();
+    let editorconfig = editorconfig::load_editorconfig_from_cwd();
+    let settings = editorconfig::settings_for(
+        editorconfig.as_ref(),
+        stdin_filename.unwrap_or_else(|| Path::new("")),
+    );
+    let config = FormatterConfig::from_args(cli, &pyproject, &settings);
 
     match format_source_code(stdin_filename, &config, profile) {
         Ok(()) => Ok(ExitStatus::Success),

--- a/crates/djangofmt/src/editorconfig.rs
+++ b/crates/djangofmt/src/editorconfig.rs
@@ -20,7 +20,7 @@ pub fn load_editorconfig_from_cwd() -> Option<EditorConfig> {
 /// Parse the nearest `.editorconfig` searching upward from `start_path`.
 ///
 /// Section globs are anchored at the file's own directory, so the parsed config
-/// is resolved against each formatted file's real path via [`settings_for`].
+/// is resolved against each formatted file's real path via [`resolve_editorconfig`].
 pub fn load_editorconfig<P: AsRef<Path>>(start_path: P) -> Option<EditorConfig> {
     let Some(path) = crate::fs::find_nearest_ancestor_file(start_path.as_ref(), ".editorconfig")
     else {
@@ -44,7 +44,10 @@ pub fn load_editorconfig<P: AsRef<Path>>(start_path: P) -> Option<EditorConfig> 
 
 /// Resolve `.editorconfig` indent/line settings for `path`.
 #[must_use]
-pub fn settings_for(editorconfig: Option<&EditorConfig>, path: &Path) -> EditorconfigSettings {
+pub fn resolve_editorconfig(
+    editorconfig: Option<&EditorConfig>,
+    path: &Path,
+) -> EditorconfigSettings {
     let Some(editorconfig) = editorconfig else {
         return EditorconfigSettings::default();
     };
@@ -87,7 +90,7 @@ mod tests {
     /// Resolve settings for `file` against an `.editorconfig` written at the project root.
     fn settings(editorconfig: &str, file: &str) -> EditorconfigSettings {
         let project = Project::new().file(".editorconfig", editorconfig);
-        settings_for(
+        resolve_editorconfig(
             load_editorconfig(project.path()).as_ref(),
             &project.join(file),
         )
@@ -97,7 +100,7 @@ mod tests {
     fn returns_default_when_no_editorconfig() {
         let project = Project::new();
         assert_eq!(
-            settings_for(
+            resolve_editorconfig(
                 load_editorconfig(project.path()).as_ref(),
                 &project.join("x.html")
             ),
@@ -185,7 +188,7 @@ indent_size = 3
         // Only the nearest file is used, the parent one is not merged in.
         let editorconfig = load_editorconfig(project.join("child"));
         assert_eq!(
-            settings_for(editorconfig.as_ref(), &project.join("child/x.html")),
+            resolve_editorconfig(editorconfig.as_ref(), &project.join("child/x.html")),
             EditorconfigSettings {
                 line_length: None,
                 indent_width: Some(IndentWidth::try_from(8u8).unwrap()),

--- a/crates/djangofmt/src/editorconfig.rs
+++ b/crates/djangofmt/src/editorconfig.rs
@@ -1,0 +1,211 @@
+use editorconfig_parser::{EditorConfig, EditorConfigProperty, MaxLineLength};
+use std::{fs, path::Path};
+use tracing::{debug, warn};
+
+use crate::line_width::{IndentWidth, LineLength};
+
+/// Indent/line settings resolved from an `.editorconfig` for a specific file.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct EditorconfigSettings {
+    pub line_length: Option<LineLength>,
+    pub indent_width: Option<IndentWidth>,
+}
+
+/// Parse the nearest `.editorconfig` searching upward from the current working directory.
+#[must_use]
+pub fn load_editorconfig_from_cwd() -> Option<EditorConfig> {
+    load_editorconfig(crate::fs::get_cwd())
+}
+
+/// Parse the nearest `.editorconfig` searching upward from `start_path`.
+///
+/// Section globs are anchored at the file's own directory, so the parsed config
+/// is resolved against each formatted file's real path via [`settings_for`].
+pub fn load_editorconfig<P: AsRef<Path>>(start_path: P) -> Option<EditorConfig> {
+    let Some(path) = crate::fs::find_nearest_ancestor_file(start_path.as_ref(), ".editorconfig")
+    else {
+        debug!(
+            "No .editorconfig found starting search from: {}",
+            start_path.as_ref().display()
+        );
+        return None;
+    };
+    let content = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) => {
+            warn!("Failed to read {}: {}", path.display(), err);
+            return None;
+        }
+    };
+    debug!("Loading options from .editorconfig at: {}", path.display());
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    Some(EditorConfig::parse(&content).with_cwd(dir))
+}
+
+/// Resolve `.editorconfig` indent/line settings for `path`.
+#[must_use]
+pub fn settings_for(editorconfig: Option<&EditorConfig>, path: &Path) -> EditorconfigSettings {
+    let Some(editorconfig) = editorconfig else {
+        return EditorconfigSettings::default();
+    };
+    let properties = editorconfig.resolve(path);
+
+    let mut settings = EditorconfigSettings::default();
+    if let EditorConfigProperty::Value(size) = properties.indent_size {
+        match IndentWidth::try_from(size) {
+            Ok(width) => settings.indent_width = Some(width),
+            Err(err) => warn!("Ignoring editorconfig indent_size: {err}"),
+        }
+    }
+    if let EditorConfigProperty::Value(MaxLineLength::Number(length)) = properties.max_line_length {
+        match LineLength::try_from(length) {
+            Ok(line_length) => settings.line_length = Some(line_length),
+            Err(err) => warn!("Ignoring editorconfig max_line_length: {err}"),
+        }
+    }
+    settings
+}
+
+/// Whether `.editorconfig` settings can differ between files.
+///
+/// `false` when there is no config or only a root `[*]` section, letting callers
+/// resolve settings once instead of per file.
+#[must_use]
+pub fn has_per_file_sections(editorconfig: Option<&EditorConfig>) -> bool {
+    editorconfig.is_some_and(|editorconfig| {
+        let sections = editorconfig.sections();
+        !(sections.is_empty() || matches!(sections, [section] if section.name == "*"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::Project;
+    use rstest::rstest;
+
+    /// Resolve settings for `file` against an `.editorconfig` written at the project root.
+    fn settings(editorconfig: &str, file: &str) -> EditorconfigSettings {
+        let project = Project::new().file(".editorconfig", editorconfig);
+        settings_for(
+            load_editorconfig(project.path()).as_ref(),
+            &project.join(file),
+        )
+    }
+
+    #[test]
+    fn returns_default_when_no_editorconfig() {
+        let project = Project::new();
+        assert_eq!(
+            settings_for(
+                load_editorconfig(project.path()).as_ref(),
+                &project.join("x.html")
+            ),
+            EditorconfigSettings::default()
+        );
+    }
+
+    #[test]
+    fn reads_indent_and_line_length() {
+        assert_eq!(
+            settings(
+                "
+root = true
+
+[*]
+indent_size = 2
+max_line_length = 100
+",
+                "x.html"
+            ),
+            EditorconfigSettings {
+                line_length: Some(LineLength::try_from(100u16).unwrap()),
+                indent_width: Some(IndentWidth::try_from(2u8).unwrap()),
+            }
+        );
+    }
+
+    #[rstest]
+    #[case("x.html", 2)]
+    #[case("x.jinja", 3)]
+    #[case("x.jinja2", 3)]
+    #[case("x.j2", 3)]
+    fn section_matches_by_file_extension(#[case] file: &str, #[case] expected_indent: u8) {
+        let editorconfig = "
+[*.html]
+indent_size = 2
+
+[*.{jinja,jinja2,j2}]
+indent_size = 3
+";
+        assert_eq!(
+            settings(editorconfig, file),
+            EditorconfigSettings {
+                line_length: None,
+                indent_width: Some(IndentWidth::try_from(expected_indent).unwrap()),
+            }
+        );
+    }
+
+    #[test]
+    fn detects_whether_sections_vary_per_file() {
+        let none = Project::new();
+        assert!(!has_per_file_sections(
+            load_editorconfig(none.path()).as_ref()
+        ));
+
+        let root_only = Project::new().file(".editorconfig", "[*]\nindent_size = 2");
+        assert!(!has_per_file_sections(
+            load_editorconfig(root_only.path()).as_ref()
+        ));
+
+        let per_extension = Project::new().file(".editorconfig", "[*.html]\nindent_size = 2");
+        assert!(has_per_file_sections(
+            load_editorconfig(per_extension.path()).as_ref()
+        ));
+    }
+
+    #[test]
+    fn matches_jinja_variant_specific_section() {
+        // A section written for `.j2` alone is honored for a `.j2` file.
+        assert_eq!(
+            settings("[*.j2]\nindent_size = 3", "x.j2"),
+            EditorconfigSettings {
+                line_length: None,
+                indent_width: Some(IndentWidth::try_from(3u8).unwrap()),
+            }
+        );
+    }
+
+    #[test]
+    fn nearest_editorconfig_wins() {
+        let project = Project::new()
+            .file(".editorconfig", "[*]\nindent_size = 2")
+            .file("child/.editorconfig", "[*]\nindent_size = 8");
+        // Only the nearest file is used, the parent one is not merged in.
+        let editorconfig = load_editorconfig(project.join("child"));
+        assert_eq!(
+            settings_for(editorconfig.as_ref(), &project.join("child/x.html")),
+            EditorconfigSettings {
+                line_length: None,
+                indent_width: Some(IndentWidth::try_from(8u8).unwrap()),
+            }
+        );
+    }
+
+    #[rstest]
+    #[case("[*]\nindent_size = 0")]
+    #[case("[*]\nindent_size = 17")]
+    #[case("[*]\nindent_size = 99999")]
+    #[case("[*]\nindent_size = tab")]
+    #[case("[*]\nindent_size = unset")]
+    #[case("[*]\nmax_line_length = 0")]
+    #[case("[*]\nmax_line_length = 321")]
+    #[case("[*]\nmax_line_length = off")]
+    fn ignores_invalid_values(#[case] editorconfig: &str) {
+        assert_eq!(
+            settings(editorconfig, "x.html"),
+            EditorconfigSettings::default()
+        );
+    }
+}

--- a/crates/djangofmt/src/fs.rs
+++ b/crates/djangofmt/src/fs.rs
@@ -20,3 +20,48 @@ pub fn relativize_path<P: AsRef<Path>>(path: P) -> String {
     }
     path.display().to_string()
 }
+
+/// Finds the nearest `file_name` by traversing directories upward from `start_path`.
+pub fn find_nearest_ancestor_file<P: AsRef<Path>>(
+    start_path: P,
+    file_name: &str,
+) -> Option<PathBuf> {
+    start_path
+        .as_ref()
+        .ancestors()
+        .map(|directory| directory.join(file_name))
+        .find(|candidate| candidate.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::Project;
+
+    #[test]
+    fn returns_none_when_absent() {
+        let project = Project::new();
+        assert_eq!(
+            find_nearest_ancestor_file(project.path(), "marker.toml"),
+            None
+        );
+    }
+
+    #[test]
+    fn finds_file_in_start_dir() {
+        let project = Project::new().file("marker.toml", "");
+        assert_eq!(
+            find_nearest_ancestor_file(project.path(), "marker.toml"),
+            Some(project.join("marker.toml"))
+        );
+    }
+
+    #[test]
+    fn finds_file_in_ancestor_dir() {
+        let project = Project::new().file("marker.toml", "").dir("child");
+        assert_eq!(
+            find_nearest_ancestor_file(project.join("child"), "marker.toml"),
+            Some(project.join("marker.toml"))
+        );
+    }
+}

--- a/crates/djangofmt/src/lib.rs
+++ b/crates/djangofmt/src/lib.rs
@@ -8,6 +8,7 @@ use crate::args::Args;
 use crate::logging::setup_tracing;
 pub mod args;
 pub mod commands;
+pub mod editorconfig;
 pub mod error;
 pub mod fs;
 pub mod line_width;

--- a/crates/djangofmt/src/lib.rs
+++ b/crates/djangofmt/src/lib.rs
@@ -14,6 +14,8 @@ pub mod line_width;
 mod logging;
 pub mod pyproject;
 pub mod resolver;
+#[cfg(test)]
+mod test_support;
 
 #[derive(Copy, Clone)]
 pub enum ExitStatus {

--- a/crates/djangofmt/src/line_width.rs
+++ b/crates/djangofmt/src/line_width.rs
@@ -36,6 +36,21 @@ impl TryFrom<u16> for LineLength {
     }
 }
 
+impl TryFrom<usize> for LineLength {
+    type Error = String;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        u16::try_from(value)
+            .map_err(|_| {
+                format!(
+                    "line-length must be between 1 and {} (got {value})",
+                    Self::MAX
+                )
+            })
+            .and_then(Self::try_from)
+    }
+}
+
 impl From<LineLength> for usize {
     fn from(value: LineLength) -> Self {
         value.0.get() as Self
@@ -97,6 +112,21 @@ impl TryFrom<u8> for IndentWidth {
                 Self::MAX
             )),
         }
+    }
+}
+
+impl TryFrom<usize> for IndentWidth {
+    type Error = String;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        u8::try_from(value)
+            .map_err(|_| {
+                format!(
+                    "indent-width must be between 1 and {} (got {value})",
+                    Self::MAX
+                )
+            })
+            .and_then(Self::try_from)
     }
 }
 

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -1,8 +1,5 @@
 use serde::Deserialize;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::Path};
 use tracing::{debug, warn};
 
 use crate::args::Profile;
@@ -51,17 +48,6 @@ fn load_options_from_pyproject_toml(content: &str) -> PyprojectSettings {
     }
 }
 
-/// Finds the `pyproject.toml` settings file by traversing directories upward from the given path
-fn find_pyproject_toml<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
-    for directory in start_path.as_ref().ancestors() {
-        let pyproject_toml = directory.join("pyproject.toml");
-        if pyproject_toml.is_file() {
-            return Some(pyproject_toml);
-        }
-    }
-    None
-}
-
 /// Load `pyproject.toml` settings rooted at the current working directory,
 /// falling back to defaults if the cwd can't be determined.
 #[must_use]
@@ -71,7 +57,9 @@ pub fn load_pyproject_from_cwd() -> PyprojectSettings {
 
 /// Loads user configured options from the nearest `pyproject.toml` file from the given path
 pub fn load_options<P: AsRef<Path>>(start_path: P) -> PyprojectSettings {
-    let Some(pyproject_path) = find_pyproject_toml(start_path.as_ref()) else {
+    let Some(pyproject_path) =
+        crate::fs::find_nearest_ancestor_file(start_path.as_ref(), "pyproject.toml")
+    else {
         debug!(
             "No pyproject.toml found starting search from: {}",
             start_path.as_ref().display()
@@ -96,53 +84,28 @@ pub fn load_options<P: AsRef<Path>>(start_path: P) -> PyprojectSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::Project;
     use rstest::rstest;
-    use tempfile::tempdir;
-
-    #[test]
-    fn test_find_pyproject_toml_should_return_none() {
-        let temp_dir = tempdir().unwrap();
-        assert_eq!(find_pyproject_toml(temp_dir), None);
-    }
-
-    #[test]
-    fn test_find_pyproject_toml_in_current_dir() {
-        let temp_dir = tempdir().unwrap();
-        let pyproject_path = temp_dir.path().join("pyproject.toml");
-        fs::write(&pyproject_path, "").unwrap();
-        assert_eq!(find_pyproject_toml(temp_dir), Some(pyproject_path));
-    }
-
-    #[test]
-    fn test_find_pyproject_toml_in_parent_dir() {
-        let parent_dir = tempdir().unwrap();
-        let pyproject_path = parent_dir.path().join("pyproject.toml");
-        fs::write(&pyproject_path, "").unwrap();
-        fs::create_dir(parent_dir.path().join("child_dir")).unwrap();
-        let child_dir = parent_dir.path().join("child_dir");
-        assert_eq!(find_pyproject_toml(child_dir), Some(pyproject_path));
-    }
 
     #[test]
     fn test_load_options_from_pyproject_toml() {
-        let temp_dir = tempdir().unwrap();
-        let pyproject_path = temp_dir.path().join("pyproject.toml");
-        let pyproject_content = r"
+        let project = Project::new().file(
+            "pyproject.toml",
+            r"
             [tool.djangofmt]
             line-length=200
             indent-width=4
             custom-blocks=['foo', 'bar']
             profile='django'
             html-void-self-closing='always'
-            ";
-
-        fs::write(&pyproject_path, pyproject_content).unwrap();
-        let result = load_options(&pyproject_path);
+            ",
+        );
+        let result = load_options(project.join("pyproject.toml"));
         assert_eq!(
             result,
             PyprojectSettings {
-                line_length: Some(LineLength::try_from(200).unwrap()),
-                indent_width: Some(IndentWidth::try_from(4).unwrap()),
+                line_length: Some(LineLength::try_from(200u16).unwrap()),
+                indent_width: Some(IndentWidth::try_from(4u8).unwrap()),
                 custom_blocks: Some(vec!["foo".to_string(), "bar".to_string()]),
                 profile: Some(Profile::Django),
                 html_void_self_closing: Some(SelfClosing::Always),
@@ -152,18 +115,35 @@ mod tests {
     }
 
     #[test]
+    fn test_load_options_from_incomplete_pyproject_toml() {
+        let project = Project::new().file(
+            "pyproject.toml",
+            r"
+            [tool.djangofmt]
+            line-length=200
+            ",
+        );
+        let result = load_options(project.join("pyproject.toml"));
+        assert_eq!(
+            result,
+            PyprojectSettings {
+                line_length: Some(LineLength::try_from(200u16).unwrap()),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
     fn test_load_options_returns_default_when_no_pyproject_toml() {
-        let temp_dir = tempdir().unwrap();
-        let result = load_options(temp_dir.path());
+        let project = Project::new();
+        let result = load_options(project.path());
         assert_eq!(result, PyprojectSettings::default());
     }
 
     #[test]
     fn test_load_options_returns_default_when_empty_pyproject_toml() {
-        let temp_dir = tempdir().unwrap();
-        let pyproject_path = temp_dir.path().join("pyproject.toml");
-        fs::write(&pyproject_path, "").unwrap();
-        let result = load_options(&pyproject_path);
+        let project = Project::new().file("pyproject.toml", "");
+        let result = load_options(project.join("pyproject.toml"));
         assert_eq!(result, PyprojectSettings::default());
     }
 
@@ -177,26 +157,6 @@ mod tests {
         assert_eq!(
             load_options_from_pyproject_toml(content),
             PyprojectSettings::default()
-        );
-    }
-
-    #[test]
-    fn test_load_options_from_incomplete_pyproject_toml() {
-        let temp_dir = tempdir().unwrap();
-        let pyproject_path = temp_dir.path().join("pyproject.toml");
-        let pyproject_content = r"
-            [tool.djangofmt]
-            line-length=200
-            ";
-
-        fs::write(&pyproject_path, pyproject_content).unwrap();
-        let result = load_options(&pyproject_path);
-        assert_eq!(
-            result,
-            PyprojectSettings {
-                line_length: Some(LineLength::try_from(200).unwrap()),
-                ..Default::default()
-            }
         );
     }
 
@@ -215,7 +175,7 @@ mod tests {
         assert_eq!(
             result,
             PyprojectSettings {
-                line_length: Some(LineLength::try_from(120).unwrap()),
+                line_length: Some(LineLength::try_from(120u16).unwrap()),
                 exclude: Some(vec![".git".to_string(), ".venv".to_string()]),
                 extend_exclude: Some(vec!["vendor".to_string()]),
                 include: Some(vec!["*.html".to_string()]),
@@ -291,8 +251,8 @@ show-fixes = true
         assert_eq!(
             result,
             PyprojectSettings {
-                line_length: Some(LineLength::try_from(80).unwrap()),
-                indent_width: Some(IndentWidth::try_from(2).unwrap()),
+                line_length: Some(LineLength::try_from(80u16).unwrap()),
+                indent_width: Some(IndentWidth::try_from(2u8).unwrap()),
                 profile: Some(Profile::Jinja),
                 custom_blocks: Some(vec!["cache".to_string()]),
                 ..Default::default()

--- a/crates/djangofmt/src/test_support.rs
+++ b/crates/djangofmt/src/test_support.rs
@@ -1,0 +1,49 @@
+//! Shared filesystem helpers for tests.
+#![allow(dead_code)] // Each test binary uses only a subset of these helpers.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+/// A throwaway directory of files for a test; cleaned up on drop.
+///
+/// ```ignore
+/// let project = Project::new().file("pyproject.toml", "[tool.djangofmt]\n");
+/// load_options(&project.join("pyproject.toml"));
+/// ```
+pub struct Project(TempDir);
+
+impl Project {
+    pub fn new() -> Self {
+        Self(TempDir::new().expect("create temp dir"))
+    }
+
+    /// Write `content` to `name` (creating parent dirs), returning `self` to chain.
+    pub fn file(self, name: &str, content: &str) -> Self {
+        let path = self.0.path().join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent dir");
+        }
+        fs::write(path, content).expect("write project file");
+        self
+    }
+
+    /// Create an empty subdirectory `name`, returning `self` to chain.
+    pub fn dir(self, name: &str) -> Self {
+        fs::create_dir_all(self.0.path().join(name)).expect("create dir");
+        self
+    }
+
+    pub fn path(&self) -> &Path {
+        self.0.path()
+    }
+
+    pub fn join(&self, name: &str) -> PathBuf {
+        self.0.path().join(name)
+    }
+
+    pub fn read(&self, name: &str) -> String {
+        fs::read_to_string(self.join(name)).expect("read project file")
+    }
+}

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -1,6 +1,9 @@
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 use std::process::Command;
-use tempfile::TempDir;
+
+#[path = "../src/test_support.rs"]
+mod test_support;
+use test_support::Project;
 
 fn cli() -> Command {
     Command::new(get_cargo_bin("djangofmt"))
@@ -21,10 +24,8 @@ macro_rules! assert_cmd_snapshot_tmpdir {
 
 #[test]
 fn format_single_file() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "<div   class=\"foo\"  >\n</div>\n").unwrap();
-    assert_cmd_snapshot!(cli().arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", "<div   class=\"foo\"  >\n</div>\n");
+    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -32,16 +33,13 @@ fn format_single_file() {
     ----- stderr -----
     1 file reformatted !
     "#);
-    let content = std::fs::read_to_string(&file).unwrap();
-    assert_eq!(content, "<div class=\"foo\"></div>\n");
+    assert_eq!(project.read("test.html"), "<div class=\"foo\"></div>\n");
 }
 
 #[test]
 fn format_already_formatted_file() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "<div class=\"foo\"></div>\n").unwrap();
-    assert_cmd_snapshot!(cli().arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", "<div class=\"foo\"></div>\n");
+    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -53,11 +51,9 @@ fn format_already_formatted_file() {
 
 #[test]
 fn format_file_with_ignore_directive() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
     let original = "<!-- djangofmt:ignore -->\n<div   class=\"foo\"  ></div>\n";
-    std::fs::write(&file, original).unwrap();
-    assert_cmd_snapshot!(cli().arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", original);
+    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -65,17 +61,14 @@ fn format_file_with_ignore_directive() {
     ----- stderr -----
     1 file skipped !
     "#);
-    let content = std::fs::read_to_string(&file).unwrap();
-    assert_eq!(content, original);
+    assert_eq!(project.read("test.html"), original);
 }
 
 #[test]
 fn format_file_with_jinja_ignore_directive() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
     let original = "{# djangofmt:ignore #}\n<div   class=\"foo\"  ></div>\n";
-    std::fs::write(&file, original).unwrap();
-    assert_cmd_snapshot!(cli().arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", original);
+    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -83,8 +76,7 @@ fn format_file_with_jinja_ignore_directive() {
     ----- stderr -----
     1 file skipped !
     "#);
-    let content = std::fs::read_to_string(&file).unwrap();
-    assert_eq!(content, original);
+    assert_eq!(project.read("test.html"), original);
 }
 
 #[test]
@@ -102,10 +94,10 @@ fn format_nonexistent_file() {
 
 #[test]
 fn format_directory() {
-    let dir = TempDir::new().unwrap();
-    std::fs::write(dir.path().join("a.html"), "<div   ></div>\n").unwrap();
-    std::fs::write(dir.path().join("b.html"), "<span   ></span>\n").unwrap();
-    assert_cmd_snapshot!(cli().arg(dir.path().as_os_str()), @r#"
+    let project = Project::new()
+        .file("a.html", "<div   ></div>\n")
+        .file("b.html", "<span   ></span>\n");
+    assert_cmd_snapshot!(cli().arg(project.path()), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -117,10 +109,8 @@ fn format_directory() {
 
 #[test]
 fn format_quiet() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "<div   ></div>\n").unwrap();
-    assert_cmd_snapshot!(cli().arg("-q").arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", "<div   ></div>\n");
+    assert_cmd_snapshot!(cli().arg("-q").arg(project.join("test.html")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -303,14 +293,10 @@ fn format_stdin_filename_alone_without_dash() {
     "#);
 }
 
-// ── Check subcommand ─────────────────────────────────────────────────
-
 #[test]
 fn check_clean_file() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "<form method=\"post\"></form>\n").unwrap();
-    assert_cmd_snapshot!(cli().arg("check").arg(file.as_os_str()), @r###"
+    let project = Project::new().file("test.html", "<form method=\"post\"></form>\n");
+    assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -322,10 +308,8 @@ fn check_clean_file() {
 
 #[test]
 fn check_file_with_lint_error() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "<form method=\"put\"></form>\n").unwrap();
-    assert_cmd_snapshot_tmpdir!(cli().arg("check").arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", "<form method=\"put\"></form>\n");
+    assert_cmd_snapshot_tmpdir!(cli().arg("check").arg(project.join("test.html")), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -359,11 +343,9 @@ fn check_nonexistent_file() {
 
 #[test]
 fn check_fixable_file_without_fix() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
     let original = "{% blocktranslate %}Hello{% endblocktranslate %}\n";
-    std::fs::write(&file, original).unwrap();
-    assert_cmd_snapshot_tmpdir!(cli().arg("check").arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", original);
+    assert_cmd_snapshot_tmpdir!(cli().arg("check").arg(project.join("test.html")), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -383,15 +365,16 @@ fn check_fixable_file_without_fix() {
     Found 1 errors. [*] 1 fixable with the --fix option.
     "#);
     // Ensure we didn't apply anything without --fix.
-    assert_eq!(std::fs::read_to_string(&file).unwrap(), original);
+    assert_eq!(project.read("test.html"), original);
 }
 
 #[test]
 fn check_fixable_file_with_fix() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "{% blocktranslate %}Hello{% endblocktranslate %}\n").unwrap();
-    assert_cmd_snapshot!(cli().args(["check", "--fix"]).arg(file.as_os_str()), @r#"
+    let project = Project::new().file(
+        "test.html",
+        "{% blocktranslate %}Hello{% endblocktranslate %}\n",
+    );
+    assert_cmd_snapshot!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -401,18 +384,19 @@ fn check_fixable_file_with_fix() {
     "#);
     // Ensure file was mutated.
     assert_eq!(
-        std::fs::read_to_string(&file).unwrap(),
+        project.read("test.html"),
         "{% blocktranslate trimmed %}Hello{% endblocktranslate %}\n"
     );
 }
 
 #[test]
 fn check_fixable_file_with_show_fixes() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "{% blocktranslate %}Hello{% endblocktranslate %}\n").unwrap();
+    let project = Project::new().file(
+        "test.html",
+        "{% blocktranslate %}Hello{% endblocktranslate %}\n",
+    );
     assert_cmd_snapshot_tmpdir!(
-        cli().args(["check", "--fix", "--show-fixes"]).arg(file.as_os_str()),
+        cli().args(["check", "--fix", "--show-fixes"]).arg(project.join("test.html")),
         @r#"
     success: true
     exit_code: 0
@@ -428,10 +412,8 @@ fn check_fixable_file_with_show_fixes() {
 
 #[test]
 fn check_malformed_file_with_fix_surfaces_parse_error() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.html");
-    std::fs::write(&file, "{% if x %}\n  unclosed\n").unwrap();
-    assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(file.as_os_str()), @r#"
+    let project = Project::new().file("test.html", "{% if x %}\n  unclosed\n");
+    assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r#"
     success: false
     exit_code: 1
     ----- stdout -----

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -294,6 +294,58 @@ fn format_stdin_filename_alone_without_dash() {
 }
 
 #[test]
+fn format_respects_editorconfig() {
+    let project = Project::new()
+        .file(
+            ".editorconfig",
+            "root = true\n\n[*]\nindent_size = 2\nmax_line_length = 40\n",
+        )
+        .file(
+            "test.html",
+            "<div class=\"alpha beta gamma delta epsilon\"><span>hello world</span></div>\n",
+        );
+    assert_cmd_snapshot!(cli().current_dir(project.path()).arg("test.html"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    1 file reformatted !
+    "#);
+    // The line wraps because of `max_line_length` and is indented by `indent_size`.
+    assert_eq!(
+        project.read("test.html"),
+        "<div class=\"alpha beta gamma delta epsilon\">\n  <span>hello world</span>\n</div>\n"
+    );
+}
+
+#[test]
+fn format_pyproject_overrides_editorconfig() {
+    let project = Project::new()
+        .file(
+            ".editorconfig",
+            "root = true\n\n[*]\nindent_size = 2\nmax_line_length = 40\n",
+        )
+        .file("pyproject.toml", "[tool.djangofmt]\nindent-width = 8\n")
+        .file(
+            "test.html",
+            "<div class=\"alpha beta gamma delta epsilon\"><span>hello world</span></div>\n",
+        );
+    assert_cmd_snapshot!(cli().current_dir(project.path()).arg("test.html"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    1 file reformatted !
+    "#);
+    assert_eq!(
+        project.read("test.html"),
+        "<div class=\"alpha beta gamma delta epsilon\">\n        <span>hello world</span>\n</div>\n"
+    );
+}
+
+#[test]
 fn check_clean_file() {
     let project = Project::new().file("test.html", "<form method=\"post\"></form>\n");
     assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r###"


### PR DESCRIPTION
Fixes #204

This adds minimal support for `.editorconfig`. It will only read `indent_size` and `max_line_length` 

Sample config:
```ini
root = true

# Any profile
[*]
indent_size = 4
max_line_length = 120

// Jinja profile
[*.{jinja,jinja2,j2}]
indent_size = 4
max_line_length = 120

// Django profile
[**/templates/**/*.html]
indent_size = 4
max_line_length = 120
```