### PR TITLE
feat(playground): Add documentation link to navbar

### DIFF
--- a/playground/src/components/Navbar.astro
+++ b/playground/src/components/Navbar.astro
@@ -1,4 +1,5 @@
 ---
+import BookIcon from "./icons/BookIcon.astro";
 import BugIcon from "./icons/BugIcon.astro";
 import DarkTheme from "./icons/DarkTheme.astro";
 import IconShare from "./icons/IconShare.astro";
@@ -29,6 +30,15 @@ import PlusMinusInput from "./PlusMinusInput.astro";
     </div>
 
     <div class="flex items-center gap-2">
+        <a
+            class="btn btn-sm btn-ghost text-base-content/60 tooltip tooltip-left text-sm"
+            data-tip="Open the documentation"
+            href="https://unknownplatypus.github.io/djangofmt/docs/"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            <BookIcon />
+        </a>
         <button
             class="btn btn-sm btn-ghost text-base-content/60 tooltip tooltip-left text-sm"
             data-tip="Report an issue on GitHub"

--- a/playground/src/components/icons/BookIcon.astro
+++ b/playground/src/components/icons/BookIcon.astro
@@ -1,0 +1,18 @@
+---
+
+---
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    role="presentation"
+    width="20"
+    height="20"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+>
+    <path d="M12 7v14" />
+    <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+</svg>


### PR DESCRIPTION
Add a book icon button linking to the documentation site, placed next to the 'Report an issue on GitHub' button in the navbar.