### PR TITLE
test(ecosystem-check): Select all rules + preview in check ecosystem run

### DIFF
--- a/python/ecosystem-check/ecosystem_check/projects.py
+++ b/python/ecosystem-check/ecosystem_check/projects.py
@@ -72,6 +72,9 @@ class CliOptions(Serializable):
             args = ["--profile", self.profile]
             if command is Command.FORMAT and self.custom_blocks:
                 args.extend(("--custom-blocks", self.custom_blocks))
+            if command is Command.CHECK:
+                # Select every rule, including preview, for maximum ecosystem coverage.
+                args.extend(("--select", "category:all", "--preview"))
             return args
         elif executable_name == Formatter.DJADE:
             return []


### PR DESCRIPTION
Now that rule selection has landed on `main`, the baseline binary accepts `--select`/`--preview`, so we can enable every rule (including preview) for maximum ecosystem coverage without crashing the baseline.
