### PR TITLE
feat(lint): Add `duplicate-block-name` lint rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "miette",
  "rustc-hash",
  "serde",
+ "smallvec",
  "strum",
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rustc-hash = { version = "2.1.2" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6.5" }
 similar-asserts = { version = "2.0.0" }
+smallvec = { version = "1.15.1", features = ["const_new"] }
 strum = { version = "0.28.0", features = ["derive"] }
 syn = { version = "2.0" }
 tempfile = { version = "3.27.0" }

--- a/crates/djangofmt_lint/Cargo.toml
+++ b/crates/djangofmt_lint/Cargo.toml
@@ -13,6 +13,7 @@ markup_fmt = { workspace = true }
 miette = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+smallvec = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -2,6 +2,7 @@ use markup_fmt::ast::{
     Attribute, Element, JinjaBlock, JinjaTagOrChildren, NativeAttribute, Node, NodeKind, Root,
 };
 use miette::SourceSpan;
+use smallvec::SmallVec;
 
 use crate::LintDiagnostic;
 use crate::Settings;
@@ -13,6 +14,10 @@ use crate::violation::Violation;
 /// AST visitor that collects lint diagnostics.
 pub struct Checker<'a> {
     context: LintContext<'a>,
+    /// Block names collected during the traversal.
+    /// Blocks in attribute position (`<div {% block x %}…>`) are not visited here, so are not recorded.
+    /// Inline-backed: templates rarely exceed a handful of blocks, so the common case never allocates.
+    block_names: SmallVec<[&'a str; 8]>,
 }
 
 impl<'a> Checker<'a> {
@@ -20,6 +25,7 @@ impl<'a> Checker<'a> {
     pub const fn new(source: &'a str, settings: &'a Settings) -> Self {
         Self {
             context: LintContext::new(source, settings),
+            block_names: SmallVec::new_const(),
         }
     }
 
@@ -27,6 +33,12 @@ impl<'a> Checker<'a> {
     #[must_use]
     pub const fn context(&self) -> &LintContext<'a> {
         &self.context
+    }
+
+    /// Block names recorded during the traversal, borrowed from the source.
+    #[must_use]
+    pub fn block_names(&self) -> &[&'a str] {
+        &self.block_names
     }
 
     /// Compute the byte offset of a string slice within the source.
@@ -83,7 +95,7 @@ impl<'a> Checker<'a> {
     }
 
     /// Visit the root of the AST and run all lint rules.
-    pub fn visit_root(&mut self, root: &Root<'_>) {
+    pub fn visit_root(&mut self, root: &Root<'a>) {
         if self.is_rule_enabled(Rule::MissingDoctype) {
             rules::style::missing_doctype::check(root, self);
         }
@@ -91,9 +103,14 @@ impl<'a> Checker<'a> {
         for node in &root.children {
             self.visit_node(node);
         }
+
+        // Cross-node finalize: now that every `{% block %}` has been recorded, flag duplicates.
+        if self.is_rule_enabled(Rule::DuplicateBlockName) {
+            rules::correctness::duplicate_block_name::check(self);
+        }
     }
 
-    fn visit_node(&mut self, node: &Node<'_>) {
+    fn visit_node(&mut self, node: &Node<'a>) {
         match &node.kind {
             NodeKind::Element(element) => self.visit_element(element),
             NodeKind::JinjaBlock(block) => self.visit_jinja_block(block),
@@ -101,7 +118,7 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn visit_element(&mut self, element: &Element<'_>) {
+    fn visit_element(&mut self, element: &Element<'a>) {
         if self.is_rule_enabled(Rule::DuplicateAttr) {
             rules::suspicious::duplicate_attr::check(element, self);
         }
@@ -136,7 +153,7 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn visit_attribute(&mut self, attr: &Attribute<'_>, element: &Element<'_>) {
+    fn visit_attribute(&mut self, attr: &Attribute<'a>, element: &Element<'a>) {
         match attr {
             Attribute::Native(native) => self.visit_native_attribute(native, element),
             Attribute::JinjaBlock(block) => self.visit_jinja_attr_block(block, element),
@@ -144,7 +161,7 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn visit_native_attribute(&self, attr: &NativeAttribute<'_>, element: &Element<'_>) {
+    fn visit_native_attribute(&self, attr: &NativeAttribute<'a>, element: &Element<'a>) {
         if self.is_rule_enabled(Rule::InvalidAttrValue) {
             rules::correctness::invalid_attr_value::check(attr, element, self);
         }
@@ -183,9 +200,13 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn visit_jinja_block(&mut self, block: &JinjaBlock<'_, Node<'_>>) {
+    fn visit_jinja_block(&mut self, block: &JinjaBlock<'a, Node<'a>>) {
         if self.is_rule_enabled(Rule::UntrimmedBlocktranslate) {
             rules::correctness::untrimmed_blocktranslate::check(block, self);
+        }
+
+        if self.is_rule_enabled(Rule::DuplicateBlockName) {
+            self.record_block_name(block);
         }
 
         for item in &block.body {
@@ -197,10 +218,16 @@ impl<'a> Checker<'a> {
         }
     }
 
+    fn record_block_name(&mut self, block: &JinjaBlock<'a, Node<'a>>) {
+        if let Some(name) = rules::correctness::duplicate_block_name::block_name(block) {
+            self.block_names.push(name);
+        }
+    }
+
     fn visit_jinja_attr_block(
         &mut self,
-        block: &JinjaBlock<'_, Attribute<'_>>,
-        element: &Element<'_>,
+        block: &JinjaBlock<'a, Attribute<'a>>,
+        element: &Element<'a>,
     ) {
         for item in &block.body {
             if let JinjaTagOrChildren::Children(children) = item {

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -123,7 +123,11 @@ impl FileDiagnostics {
 ///
 /// Traverses the AST and runs all enabled lint rules, returning any diagnostics found.
 #[must_use]
-pub fn check_ast(source: &str, ast: &Root<'_>, settings: &Settings) -> Vec<LintDiagnostic> {
+pub fn check_ast<'a>(
+    source: &'a str,
+    ast: &Root<'a>,
+    settings: &'a Settings,
+) -> Vec<LintDiagnostic> {
     let mut checker = Checker::new(source, settings);
     checker.visit_root(ast);
     checker.into_diagnostics()

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -244,6 +244,7 @@ define_rules {
 define_rules! {
     (InvalidAttrValue, rules::correctness::invalid_attr_value::InvalidAttrValue),
     (UntrimmedBlocktranslate, rules::correctness::untrimmed_blocktranslate::UntrimmedBlocktranslate),
+    (DuplicateBlockName, rules::correctness::duplicate_block_name::DuplicateBlockName),
     (EmptyAttrValue, rules::style::empty_attr_value::EmptyAttrValue<'static>),
     (RedundantTypeAttr, rules::style::redundant_type_attr::RedundantTypeAttr),
     (DjangoStaticUrl, rules::suspicious::django_static_url::DjangoStaticUrl),

--- a/crates/djangofmt_lint/src/rules/correctness/duplicate_block_name.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/duplicate_block_name.rs
@@ -1,0 +1,79 @@
+use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node};
+
+use crate::Checker;
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+
+/// ## What it does
+/// Checks for multiple `{% block %}` tags that share the same name within a single template.
+///
+/// ## Why is this bad?
+/// Django requires `{% block %}` names to be unique within a template. A block both provides a hole
+/// for a child template to fill and defines the default content for that hole, so two blocks with
+/// the same name are ambiguous. Django raises a `TemplateSyntaxError` when the template is parsed,
+/// so a duplicate name breaks the template at runtime.
+///
+/// ## Example
+/// ```html
+/// {% block title %}Title 1{% endblock %}
+/// {% block title %}Title 2{% endblock %}
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {% block title %}Title 1{% endblock %}
+/// {% block subtitle %}Title 2{% endblock %}
+/// ```
+///
+/// ## References
+/// - [Django documentation: template inheritance](https://docs.djangoproject.com/en/stable/ref/templates/language/#template-inheritance)
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "0.2.11")]
+pub struct DuplicateBlockName<'a> {
+    pub name: &'a str,
+}
+
+impl Violation for DuplicateBlockName<'_> {
+    const RULE: Rule = Rule::DuplicateBlockName;
+    const CATEGORY: RuleCategory = RuleCategory::Correctness;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Duplicate `{{% block %}}` name `{}`.", self.name)
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(format!(
+            "Rename or remove one of the `{{% block {} %}}` tags; Django requires block names to be \
+             unique within a template.",
+            self.name
+        ))
+    }
+}
+
+pub fn block_name<'s>(block: &JinjaBlock<'s, Node<'s>>) -> Option<&'s str> {
+    let Some(JinjaTagOrChildren::Tag(open_tag)) = block.body.first() else {
+        return None;
+    };
+    // `{% block NAME %}`: one whitespace pass yields the tag (token 0) then the name (token 1).
+    // Strip `{%-`/`{%+` markers first; otherwise they become a leading token and shift the name.
+    let mut tokens = open_tag
+        .content
+        .trim_start_matches(['+', '-'])
+        .split_ascii_whitespace();
+    if tokens.next() != Some("block") {
+        return None;
+    }
+    tokens.next()
+}
+
+/// Flag every block name that occurs more than once, reporting each occurrence after the first.
+pub fn check(checker: &Checker<'_>) {
+    let names = checker.block_names();
+    for (i, &name) in names.iter().enumerate() {
+        if names[..i].contains(&name) {
+            let offset = checker.source_offset(name);
+            checker.report_diagnostic(&DuplicateBlockName { name }, (offset, name.len()).into());
+        }
+    }
+}

--- a/crates/djangofmt_lint/src/rules/correctness/mod.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/mod.rs
@@ -1,2 +1,3 @@
+pub mod duplicate_block_name;
 pub mod invalid_attr_value;
 pub mod untrimmed_blocktranslate;

--- a/crates/djangofmt_lint/tests/check/duplicate_block_name/duplicate_block_name.invalid.html
+++ b/crates/djangofmt_lint/tests/check/duplicate_block_name/duplicate_block_name.invalid.html
@@ -1,0 +1,20 @@
+<!-- Two top-level blocks with the same name (the issue's example) -->
+{% block title %}Title 1{% endblock %}
+{% block title %}Title 2{% endblock %}
+
+<!-- Three occurrences of one name report two diagnostics -->
+{% block header %}a{% endblock %}
+{% block header %}b{% endblock %}
+{% block header %}c{% endblock %}
+
+<!-- A block nested inside another block of the same name -->
+{% block content %}
+    {% block content %}inner{% endblock %}
+{% endblock %}
+
+<!-- The same name in different {% if %} branches still counts (Django registers both) -->
+{% if cond %}
+    {% block sidebar %}on{% endblock %}
+{% else %}
+    {% block sidebar %}off{% endblock %}
+{% endif %}

--- a/crates/djangofmt_lint/tests/check/duplicate_block_name/duplicate_block_name.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/duplicate_block_name/duplicate_block_name.invalid.snap
@@ -1,0 +1,59 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Found 5 lint error(s)
+
+Error: 
+  × Duplicate `{% block %}` name `title`.
+   ╭─[tests/check/duplicate_block_name/duplicate_block_name.invalid.html:3:10]
+ 2 │ {% block title %}Title 1{% endblock %}
+ 3 │ {% block title %}Title 2{% endblock %}
+   ·          ──┬──
+   ·            ╰── here
+ 4 │ 
+   ╰────
+  help: Rename or remove one of the `{% block title %}` tags; Django requires block names to be unique within a template.
+
+Error: 
+  × Duplicate `{% block %}` name `header`.
+   ╭─[tests/check/duplicate_block_name/duplicate_block_name.invalid.html:7:10]
+ 6 │ {% block header %}a{% endblock %}
+ 7 │ {% block header %}b{% endblock %}
+   ·          ───┬──
+   ·             ╰── here
+ 8 │ {% block header %}c{% endblock %}
+   ╰────
+  help: Rename or remove one of the `{% block header %}` tags; Django requires block names to be unique within a template.
+
+Error: 
+  × Duplicate `{% block %}` name `header`.
+   ╭─[tests/check/duplicate_block_name/duplicate_block_name.invalid.html:8:10]
+ 7 │ {% block header %}b{% endblock %}
+ 8 │ {% block header %}c{% endblock %}
+   ·          ───┬──
+   ·             ╰── here
+ 9 │ 
+   ╰────
+  help: Rename or remove one of the `{% block header %}` tags; Django requires block names to be unique within a template.
+
+Error: 
+  × Duplicate `{% block %}` name `content`.
+    ╭─[tests/check/duplicate_block_name/duplicate_block_name.invalid.html:12:14]
+ 11 │ {% block content %}
+ 12 │     {% block content %}inner{% endblock %}
+    ·              ───┬───
+    ·                 ╰── here
+ 13 │ {% endblock %}
+    ╰────
+  help: Rename or remove one of the `{% block content %}` tags; Django requires block names to be unique within a template.
+
+Error: 
+  × Duplicate `{% block %}` name `sidebar`.
+    ╭─[tests/check/duplicate_block_name/duplicate_block_name.invalid.html:19:14]
+ 18 │ {% else %}
+ 19 │     {% block sidebar %}off{% endblock %}
+    ·              ───┬───
+    ·                 ╰── here
+ 20 │ {% endif %}
+    ╰────
+  help: Rename or remove one of the `{% block sidebar %}` tags; Django requires block names to be unique within a template.

--- a/crates/djangofmt_lint/tests/check/duplicate_block_name/duplicate_block_name.valid.html
+++ b/crates/djangofmt_lint/tests/check/duplicate_block_name/duplicate_block_name.valid.html
@@ -1,0 +1,19 @@
+<!-- Distinct block names -->
+{% block title %}Title{% endblock %}
+{% block content %}Content{% endblock %}
+{% block footer %}Footer{% endblock %}
+
+<!-- Distinct nested names: nesting alone must not trigger -->
+{% block outer %}
+    {% block inner %}nested{% endblock %}
+{% endblock %}
+
+<!-- A single block used once -->
+{% block sidebar %}Sidebar{% endblock %}
+
+<!-- blocktranslate / blocktrans are not `block` tags, even when repeated verbatim.
+     `trimmed` keeps the untrimmed-blocktranslate rule quiet (all rules run here). -->
+{% blocktranslate trimmed %}Hello{% endblocktranslate %}
+{% blocktranslate trimmed %}Hello{% endblocktranslate %}
+{% blocktrans trimmed %}Hi{% endblocktrans %}
+{% blocktrans trimmed %}Hi{% endblocktrans %}


### PR DESCRIPTION
## What it does
Checks for multiple `{% block %}` tags that share the same name within a single template.

## Why is this bad?
Django requires `{% block %}` names to be unique within a template. A block both provides a hole for a child template to fill and defines the default content for that hole, so two blocks with the same name are ambiguous. Django raises a `TemplateSyntaxError` when the template is parsed, so a duplicate name breaks the template at runtime.

## Example
```jinja
{% block title %}Title 1{% endblock %}
{% block title %}Title 2{% endblock %}
```

Use instead:
```jinja
{% block title %}Title 1{% endblock %}
{% block subtitle %}Title 2{% endblock %}
```

## References
- [Django documentation: template inheritance](https://docs.djangoproject.com/en/stable/ref/templates/language/#template-inheritance)

Closes #361