### PR TITLE
Ecosystem check compact output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,15 +123,16 @@ jobs:
             cat placeholder-comment.txt
             echo "## \`ecosystem-check\` results"
             cat ecosystem-result
-          } >> full-comment.txt
+          } > full-comment.txt
 
-          # Determine if the comment exceeds 65536 characters
-          char_count=$(wc -c < full-comment.txt)
-          if [ "$char_count" -gt 65536 ]; then
+          # GitHub rejects comment bodies over 65536 characters
+          if [ "$(wc -c < full-comment.txt)" -gt 65536 ]; then
               {
                 cat placeholder-comment.txt
                 echo "## \`ecosystem-check\` results (partial, see full diff [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
-                cat ecosystem-result
+                # Drop the last line: it may be cut mid-way through a multi-byte character
+                head -c 64000 ecosystem-result | head -n -1
+                printf '\n\n> [!CAUTION]\n> **Truncated:** the full output is %s.\n' "$(du -h ecosystem-result | cut -f1)"
               } > full-comment.txt
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 ## Conventions
 
 - Use comments sparingly — only when they explain hidden behavior — and keep them to 1-2 lines.
+- Every new CLI flag must also be readable from `pyproject.toml`: add it to `PyprojectSettings`/`LintSettings` in `pyproject.rs` and resolve it with CLI args taking precedence.
 - Keep tests lean: cover the highest-value cases and refactor them to a high standard.
 - Commit titles use a conventional-commit `type(scope):` prefix, e.g. `feat(lint):`, `fix(format):`, `chore(deps):`.
 - Keep commit descriptions minimal or empty — write a body only when explicitly asked, or when a skill documents otherwise (e.g. `add-lint-rule`).

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -167,6 +167,17 @@ pub enum Commands {
     },
 }
 
+/// How `check` renders diagnostics.
+#[derive(Copy, Clone, Debug, clap::ValueEnum, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OutputFormat {
+    /// Rich diagnostics with source snippets and help text.
+    #[default]
+    Full,
+    /// One line per diagnostic: `path:line:col: rule [*] message`.
+    Concise,
+}
+
 /// CLI arguments for selecting which lint rules run.
 #[derive(Clone, Debug, Default, clap::Args)]
 #[command(next_help_heading = "Rule selection")]
@@ -216,6 +227,9 @@ pub struct CheckCommand {
     pub unsafe_fixes: bool,
     #[arg(long, overrides_with("unsafe_fixes"), hide = true)]
     pub no_unsafe_fixes: bool,
+    /// Output format for diagnostics [default: full]
+    #[arg(long, value_enum)]
+    pub output_format: Option<OutputFormat>,
     /// List per-rule fix counts after applying. Use `--no-show-fixes` to disable.
     #[arg(long, overrides_with("no_show_fixes"))]
     pub show_fixes: bool,

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -3,7 +3,7 @@ use djangofmt_lint::{
 };
 use markup_fmt::FormatError;
 use markup_fmt::parser::Parser;
-use miette::NamedSource;
+use miette::{NamedSource, SourceCode};
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
@@ -13,7 +13,7 @@ use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
 use crate::ExitStatus;
-use crate::args::{CheckCommand, Profile};
+use crate::args::{CheckCommand, OutputFormat, Profile};
 use crate::error::{CommandError, ParseError, Result};
 use crate::fs::relativize_path;
 use crate::pyproject::LintSettings;
@@ -25,6 +25,7 @@ pub struct CheckConfig {
     pub fix: bool,
     pub unsafe_fixes: bool,
     pub show_fixes: bool,
+    pub output_format: OutputFormat,
 }
 
 impl CheckConfig {
@@ -44,6 +45,10 @@ impl CheckConfig {
                 .unwrap_or_default(),
             show_fixes: resolve_bool_arg(args.show_fixes, args.no_show_fixes)
                 .or(lint.show_fixes)
+                .unwrap_or_default(),
+            output_format: args
+                .output_format
+                .or(lint.output_format)
                 .unwrap_or_default(),
         }
     }
@@ -115,10 +120,15 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         total_unsafe_fixable = 0;
     }
 
-    for result in &results {
-        if !result.file_diagnostics.is_empty() {
-            error!("{:?}", miette::Report::new(result.file_diagnostics.clone()));
+    match config.output_format {
+        OutputFormat::Full => {
+            for result in &results {
+                if !result.file_diagnostics.is_empty() {
+                    error!("{:?}", miette::Report::new(result.file_diagnostics.clone()));
+                }
+            }
         }
+        OutputFormat::Concise => print_concise(&results, threshold),
     }
 
     print_summary(
@@ -139,6 +149,30 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         return Ok(ExitStatus::Success);
     }
     Ok(ExitStatus::Failure)
+}
+
+/// Render one `path:line:col: rule [*] message` line per diagnostic.
+fn print_concise(results: &[CheckResult], threshold: Applicability) {
+    for result in results {
+        let source = &result.file_diagnostics.source_code;
+        let path = relativize_path(&result.path);
+        for diag in &result.file_diagnostics.related {
+            let (line, column) = source
+                .read_span(&diag.span, 0, 0)
+                .map_or((0, 0), |contents| {
+                    (contents.line() + 1, contents.column() + 1)
+                });
+            let fixable = if diag.fix.as_ref().is_some_and(|fix| fix.applies(threshold)) {
+                " [*]"
+            } else {
+                ""
+            };
+            error!(
+                "{path}:{line}:{column}: {}{fixable} {}",
+                diag.code, diag.message
+            );
+        }
+    }
 }
 
 fn print_summary(
@@ -306,7 +340,7 @@ fn check_path(
 #[cfg(test)]
 mod tests {
     use super::{CheckConfig, print_summary};
-    use crate::args::CheckCommand;
+    use crate::args::{CheckCommand, OutputFormat};
     use crate::pyproject::LintSettings;
     use tracing_test::traced_test;
 
@@ -319,6 +353,7 @@ mod tests {
                 fix: false,
                 unsafe_fixes: false,
                 show_fixes: false,
+                output_format: OutputFormat::Full,
             }
         );
     }
@@ -329,6 +364,7 @@ mod tests {
             fix: Some(true),
             unsafe_fixes: Some(true),
             show_fixes: Some(true),
+            output_format: Some(OutputFormat::Concise),
             ..Default::default()
         };
         let config = CheckConfig::from_args(&CheckCommand::default(), Some(&lint));
@@ -338,6 +374,7 @@ mod tests {
                 fix: true,
                 unsafe_fixes: true,
                 show_fixes: true,
+                output_format: OutputFormat::Concise,
             }
         );
     }
@@ -348,15 +385,18 @@ mod tests {
             fix: Some(false),
             unsafe_fixes: Some(false),
             show_fixes: Some(false),
+            output_format: Some(OutputFormat::Concise),
             ..Default::default()
         };
         let args = CheckCommand {
             fix: true,
             unsafe_fixes: true,
             show_fixes: true,
+            output_format: Some(OutputFormat::Full),
             ..Default::default()
         };
         let config = CheckConfig::from_args(&args, Some(&lint));
+        assert_eq!(config.output_format, OutputFormat::Full);
         assert!(config.fix);
         assert!(config.unsafe_fixes);
         assert!(config.show_fixes);

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::{fs, path::Path};
 use tracing::debug;
 
-use crate::args::Profile;
+use crate::args::{OutputFormat, Profile};
 use crate::error::{Error, Result};
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 
@@ -35,6 +35,7 @@ pub struct LintSettings {
     pub fix: Option<bool>,
     pub unsafe_fixes: Option<bool>,
     pub show_fixes: Option<bool>,
+    pub output_format: Option<OutputFormat>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -381,6 +381,26 @@ fn check_file_with_lint_error() {
 }
 
 #[test]
+fn check_concise_output_format() {
+    let project = Project::new().file(
+        "test.html",
+        "<form method=\"put\"></form>\n{% blocktranslate %}Hello{% endblocktranslate %}\n",
+    );
+    assert_cmd_snapshot_tmpdir!(
+        cli().args(["check", "--output-format", "concise"]).arg(project.join("test.html")),
+        @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    [TMP]/test.html:1:15: invalid-attr-value Invalid value 'put' for attribute 'method'.
+    [TMP]/test.html:2:3: untrimmed-blocktranslate [*] `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
+    Found 2 errors. [*] 1 fixable with the --fix option.
+    "#);
+}
+
+#[test]
 fn check_nonexistent_file() {
     assert_cmd_snapshot!(cli().args(["check", "/nonexistent/path.html"]), @r#"
     success: false

--- a/python/ecosystem-check/ecosystem_check/check.py
+++ b/python/ecosystem-check/ecosystem_check/check.py
@@ -18,6 +18,7 @@ from ecosystem_check.projects import Command
 from ecosystem_check.types import (
     CheckDiff,
     Comparison,
+    Diff,
     Result,
     ToolError,
 )
@@ -34,34 +35,28 @@ def markdown_check_result(result: Result) -> str:
     Render a `djangofmt check` ecosystem check result as markdown.
     """
     error_count = len(result.errored)
-    projects_with_changes = sum(
-        1
-        for _, comp in result.completed
-        if isinstance(comp.diff, CheckDiff) and comp.diff
-    )
-    total_added = sum(
-        comp.diff.diagnostics_added
-        for _, comp in result.completed
-        if isinstance(comp.diff, CheckDiff)
-    )
-    total_removed = sum(
-        comp.diff.diagnostics_removed
-        for _, comp in result.completed
-        if isinstance(comp.diff, CheckDiff)
-    )
+    diffs = [
+        comp.diff for _, comp in result.completed if isinstance(comp.diff, CheckDiff)
+    ]
+    projects_with_changes = sum(bool(d) for d in diffs)
+    total_added = sum(d.diagnostics_added for d in diffs)
+    total_removed = sum(d.diagnostics_removed for d in diffs)
+    total_fixed_added = sum(d.fix_diff.lines_added for d in diffs)
+    total_fixed_removed = sum(d.fix_diff.lines_removed for d in diffs)
 
-    if total_added == 0 and total_removed == 0 and error_count == 0:
+    if projects_with_changes == 0 and error_count == 0:
         return "\u2705 ecosystem check detected no check changes."
 
     lines: list[str] = []
-    if total_added == 0 and total_removed == 0:
+    if projects_with_changes == 0:
         lines.append(
             f"\u2139\ufe0f ecosystem check **encountered check errors**. "
             f"(no diagnostic changes; {error_count} project error{add_s(error_count)})"
         )
     else:
         changes = (
-            f"+{total_added} -{total_removed} diagnostic lines "
+            f"+{total_added} -{total_removed} diagnostic lines, "
+            f"+{total_fixed_added} -{total_fixed_removed} fixed lines "
             f"in {projects_with_changes} project{add_s(projects_with_changes)}"
         )
 
@@ -81,16 +76,24 @@ def markdown_check_result(result: Result) -> str:
     lines.append("")
 
     for project, comparison in result.completed:
-        if not comparison.diff:
+        diff = comparison.diff
+        if not diff or not isinstance(diff, CheckDiff):
             continue
 
-        assert isinstance(comparison.diff, CheckDiff)
-        title = f"+{comparison.diff.diagnostics_added} -{comparison.diff.diagnostics_removed} diagnostic lines"
+        title = (
+            f"+{diff.diagnostics_added} -{diff.diagnostics_removed} diagnostic lines"
+        )
+        if diff.fix_diff:
+            files = diff.fix_diff.modified_files
+            title += (
+                f", +{diff.fix_diff.lines_added} -{diff.fix_diff.lines_removed} "
+                f"fixed lines across {files} file{add_s(files)}"
+            )
 
         lines.extend(
             markdown_project_section(
                 title=title,
-                content=comparison.diff.format_markdown(),
+                content=diff.format_markdown(repo=comparison.repo),
                 options=project.cli_options,
                 project=project,
             )
@@ -115,12 +118,18 @@ async def compare_check(
     options: CliOptions,
     cloned_repo: ClonedRepository,
 ) -> Comparison:
+    # Both runs apply their fixes, so fixable rules are compared as a source diff and only the unfixable diagnostics are compared as text.
     baseline_output = await check(
         executable=baseline_executable.resolve(),
         path=cloned_repo.path,
         repo_fullname=cloned_repo.fullname,
         options=options,
     )
+    commit = await cloned_repo.commit(
+        message=f"Fixed with baseline {baseline_executable}"
+    )
+    await cloned_repo.reset(cloned_repo.path)
+
     comparison_output = await check(
         executable=comparison_executable.resolve(),
         path=cloned_repo.path,
@@ -129,7 +138,11 @@ async def compare_check(
     )
 
     return Comparison(
-        diff=CheckDiff(baseline_output, comparison_output),
+        diff=CheckDiff(
+            baseline_output,
+            comparison_output,
+            Diff(await cloned_repo.diff(commit)),
+        ),
         repo=cloned_repo,
     )
 
@@ -141,7 +154,7 @@ async def check(
     repo_fullname: str,
     options: CliOptions,
 ) -> str:
-    """Run `djangofmt check` against the specified path and return diagnostic output."""
+    """Run `djangofmt check --fix` against the path, returning unfixed diagnostics."""
     # The check CLI does not support --custom-blocks
     args = ["check", *options.to_args(executable.name, command=Command.CHECK)]
     files = set(
@@ -177,5 +190,9 @@ async def check(
     if proc.returncode not in [0, 1]:
         raise ToolError(err.decode("utf8"))
 
-    # Diagnostics are reported to stderr
-    return err.decode("utf8")
+    # Diagnostics are reported to stderr, minus the per-run summary line we want to drop here
+    return "".join(
+        line
+        for line in err.decode("utf8").splitlines(keepends=True)
+        if not line.startswith(("Found ", "All checks passed!"))
+    )

--- a/python/ecosystem-check/ecosystem_check/projects.py
+++ b/python/ecosystem-check/ecosystem_check/projects.py
@@ -74,7 +74,18 @@ class CliOptions(Serializable):
                 args.extend(("--custom-blocks", self.custom_blocks))
             if command is Command.CHECK:
                 # Select every rule, including preview, for maximum ecosystem coverage.
-                args.extend(("--select", "category:all", "--preview"))
+                # Fixes are applied so they can be reviewed as a source diff.
+                args.extend(
+                    (
+                        "--select",
+                        "category:all",
+                        "--preview",
+                        "--fix",
+                        "--unsafe-fixes",
+                        "--output-format",
+                        "concise",
+                    )
+                )
             return args
         elif executable_name == Formatter.DJADE:
             return []
@@ -204,7 +215,7 @@ class Repository(Serializable):
         Reset the cloned repository to the ref it started at.
         """
         process = await create_subprocess_exec(
-            *["git", "reset", "--hard", "origin/" + self.ref] if self.ref else [],
+            *["git", "reset", "--hard", *(["origin/" + self.ref] if self.ref else [])],
             cwd=checkout_dir,
             env={"GIT_TERMINAL_PROMPT": "0"},
             stdout=PIPE,

--- a/python/ecosystem-check/ecosystem_check/types.py
+++ b/python/ecosystem-check/ecosystem_check/types.py
@@ -116,27 +116,25 @@ class HistoriesForHunks(list[Diff]):
 
 
 class CheckDiff(Serializable):
-    """Difference in check (lint) diagnostics between baseline and comparison."""
+    """Difference in check (lint) behavior between baseline and comparison."""
 
-    def __init__(self, baseline_output: str, comparison_output: str) -> None:
-        self.baseline_output = baseline_output
-        self.comparison_output = comparison_output
+    def __init__(
+        self, baseline_output: str, comparison_output: str, fix_diff: Diff
+    ) -> None:
+        self.fix_diff = fix_diff
 
-        # Split into sorted lines for comparison (diagnostic output order is not guaranteed)
-        baseline_lines = sorted(baseline_output.splitlines(keepends=True))
-        comparison_lines = sorted(comparison_output.splitlines(keepends=True))
-
+        # Sort lines before diffing, diagnostic output order is not guaranteed
         self._diff_lines = list(
             difflib.unified_diff(
-                baseline_lines,
-                comparison_lines,
+                sorted(baseline_output.splitlines(keepends=True)),
+                sorted(comparison_output.splitlines(keepends=True)),
                 fromfile="baseline",
                 tofile="comparison",
             )
         )
 
     def __bool__(self) -> bool:
-        return bool(self._diff_lines)
+        return bool(self._diff_lines or self.fix_diff)
 
     @property
     def diagnostics_added(self) -> int:
@@ -156,30 +154,18 @@ class CheckDiff(Serializable):
 
     def jsonable(self) -> Any:
         return {
-            "baseline": self.baseline_output,
-            "comparison": self.comparison_output,
+            "diagnostics": self._diff_lines,
+            "fixes": self.fix_diff.jsonable(),
         }
 
-    def format_markdown(self) -> str:
-        # Use raw (unsorted) output for display — sorted lines are only for
-        # __bool__ and diagnostics_added/removed counting.
+    def format_markdown(self, repo: ClonedRepository) -> str:
         lines: list[str] = []
-        if self.comparison_output and not self.baseline_output:
-            lines.append("**New diagnostics:**")
-            lines.append(f"```\n{self.comparison_output.strip()}\n```")
-        elif self.baseline_output and not self.comparison_output:
-            lines.append("**Removed diagnostics:**")
-            lines.append(f"```\n{self.baseline_output.strip()}\n```")
-        else:
-            # For two-sided diffs, diff the raw lines for readability.
-            raw_diff = difflib.unified_diff(
-                self.baseline_output.splitlines(keepends=True),
-                self.comparison_output.splitlines(keepends=True),
-                fromfile="baseline",
-                tofile="comparison",
-            )
+        if self.fix_diff:
+            lines.append(self.fix_diff.format_markdown(repo=repo))
+        if self._diff_lines:
+            lines.append("**Diagnostics:**")
             lines.append("```diff")
-            lines.extend(line.rstrip("\n") for line in raw_diff)
+            lines.extend(line.rstrip("\n") for line in self._diff_lines)
             lines.append("```")
         return "\n".join(lines)
 


### PR DESCRIPTION
- fix ecosytem check comment not posted when too big
- improve ecosystem check diff for the linter diffs. Compare source for fixable rules, and use a compact output