### PR TITLE
perf(bench): add a reporter benchmark covering diagnostic rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "djangofmt",
  "djangofmt_lint",
  "markup_fmt",
+ "miette",
 ]
 
 [[package]]

--- a/crates/djangofmt_benchmark/Cargo.toml
+++ b/crates/djangofmt_benchmark/Cargo.toml
@@ -28,6 +28,10 @@ name = "parser"
 
 [[bench]]
 harness = false
+name = "reporter"
+
+[[bench]]
+harness = false
 name = "summary"
 
 [dependencies]
@@ -37,6 +41,7 @@ djangofmt = { path = "../djangofmt" }
 divan = { workspace = true }
 djangofmt_lint = { path = "../djangofmt_lint" }
 markup_fmt = { workspace = true }
+miette = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/djangofmt_benchmark/benches/reporter.rs
+++ b/crates/djangofmt_benchmark/benches/reporter.rs
@@ -1,0 +1,45 @@
+//! Diagnostic rendering: the `miette` path the linter benches stop before, and
+//! the dominant cost of `djangofmt check` on a dirty codebase.
+
+use djangofmt_benchmark::{
+    DJANGO_TEMPLATE_DEEPLY_NESTED, DJANGO_TEMPLATE_LARGE, JINJA_TEMPLATE_LARGE, TestFile,
+};
+use djangofmt_lint::{FileDiagnostics, Settings, check_ast};
+use markup_fmt::parser::Parser;
+use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
+
+fn main() {
+    divan::main();
+}
+
+/// Templates that trip enough rules to measure rendering on.
+static DIAGNOSTIC_HEAVY: [&TestFile; 3] = [
+    &DJANGO_TEMPLATE_DEEPLY_NESTED,
+    &DJANGO_TEMPLATE_LARGE,
+    &JINJA_TEMPLATE_LARGE,
+];
+
+/// Every diagnostic of a file, rendered to the terminal output the user sees.
+#[divan::bench(args = DIAGNOSTIC_HEAVY)]
+fn render(bencher: divan::Bencher, template: &'static TestFile) {
+    let mut parser = Parser::new(template.code, template.profile.into(), vec![]);
+    let ast = parser.parse_root().expect("Parsing to succeed");
+    let diagnostics = check_ast(template.code, &ast, &Settings::all());
+    assert!(!diagnostics.is_empty(), "{} tripped no rule", template.name);
+    let file_diagnostics = FileDiagnostics::new(
+        NamedSource::new(template.name, template.code.to_string()),
+        diagnostics,
+    );
+
+    // Pinned to what an interactive `check` renders, so the terminal the
+    // benchmark happens to run in can't change the result.
+    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode()).with_width(120);
+
+    bencher.counter(file_diagnostics.len()).bench(|| {
+        let mut out = String::new();
+        handler
+            .render_report(&mut out, divan::black_box(&file_diagnostics))
+            .expect("rendering to a String cannot fail");
+        out
+    });
+}


### PR DESCRIPTION
Add a benchmark for the rendering of diagnostic before trying the oxc/miette fork that is supposed to contain perf improvements