### PR TITLE
fix(format): don't panic on `{% comment %}` among tag attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=084d68e60da1f13545a97c19b4171ec9ea7c3a5b#084d68e60da1f13545a97c19b4171ec9ea7c3a5b"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=76ccd171f6eee458ed9b8b0f23119e84c3df6907#76ccd171f6eee458ed9b8b0f23119e84c3df6907"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta-cmd = { version = "0.6.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "084d68e60da1f13545a97c19b4171ec9ea7c3a5b"
+  rev = "76ccd171f6eee458ed9b8b0f23119e84c3df6907"
 }
 miette = { version = "7.6.0", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -168,8 +168,8 @@ pub fn build_markup_options(
             // Ignore formatting with comment directive:
             // <!-- djangofmt:ignore -->
             // <div>unformatted</div>
-            ignore_comment_directive: DJANGOFMT_IGNORE_COMMENT_DIRECTIVE.into(),
-            ignore_file_comment_directive: DJANGOFMT_IGNORE_COMMENT_DIRECTIVE.into(),
+            ignore_comment_directive: vec![DJANGOFMT_IGNORE_COMMENT_DIRECTIVE.into()],
+            ignore_file_comment_directive: vec![DJANGOFMT_IGNORE_COMMENT_DIRECTIVE.into()],
             // Indent style tags content:
             // <style>
             //     body { color: red }

--- a/crates/djangofmt/tests/fmt/comment_in_attributes.html
+++ b/crates/djangofmt/tests/fmt/comment_in_attributes.html
@@ -1,0 +1,17 @@
+<a {% comment %}c{% endcomment %} href="x">y</a>
+<button
+    class="x"
+    {% comment %}
+      a note about the attribute below
+    {% endcomment %}
+    type="button"
+>y</button>
+<div>
+        <button
+  class="x"
+          {% comment %}
+    a badly indented note
+              {% endcomment %}
+      type="button"
+        >y</button>
+</div>

--- a/crates/djangofmt/tests/fmt/comment_in_attributes.snap
+++ b/crates/djangofmt/tests/fmt/comment_in_attributes.snap
@@ -1,0 +1,24 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<a {% comment %}c{% endcomment %} href="x">y</a>
+<button
+    class="x"
+    {% comment %}
+      a note about the attribute below
+    {% endcomment %}
+    type="button"
+>
+    y
+</button>
+<div>
+    <button
+        class="x"
+        {% comment %}
+    a badly indented note
+              {% endcomment %}
+        type="button"
+    >
+        y
+    </button>
+</div>


### PR DESCRIPTION
Fix #391