### PR TITLE
fix(check): render parse errors concisely with `--output-format concise`

### DIFF
--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -97,7 +97,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
     let duration = start.elapsed();
     debug!("Checked {} files in {:.2?}", resolved.files.len(), duration);
 
-    let error_count = super::report_parse_errors(parse_errors, "check");
+    let error_count = super::report_parse_errors(parse_errors, "check", config.output_format);
 
     let mut total_diagnostics = 0usize;
     let mut total_applied = 0usize;

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use tracing::{debug, info};
 
 use crate::ExitStatus;
-use crate::args::{FormatCommand, Profile};
+use crate::args::{FormatCommand, OutputFormat, Profile};
 use crate::editorconfig::{self, EditorconfigSettings};
 use crate::error::{CommandError, ParseError, Result};
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
@@ -300,7 +300,7 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
         start.elapsed()
     );
 
-    let nb_errors = super::report_parse_errors(parse_errors, "format");
+    let nb_errors = super::report_parse_errors(parse_errors, "format", OutputFormat::Full);
 
     // Report on the formatting changes.
     let summary = build_summary(results.as_ref());

--- a/crates/djangofmt/src/commands/mod.rs
+++ b/crates/djangofmt/src/commands/mod.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tracing::error;
 
-use crate::args::{FileSelectionArgs, Profile};
+use crate::args::{FileSelectionArgs, OutputFormat, Profile};
 use crate::error::{CommandError, Result};
 use crate::pyproject::{PyprojectSettings, load_pyproject_from_cwd};
 use crate::resolver::{ResolvedDiscoveryConfig, resolve_files};
@@ -36,11 +36,18 @@ pub(crate) fn resolve_command(
 
 /// Sort parse errors by path, log each as a report, and return the count.
 /// `verb` fills the summary line, e.g. "Couldn't format N files!".
-pub(crate) fn report_parse_errors(mut parse_errors: Vec<CommandError>, verb: &str) -> usize {
+pub(crate) fn report_parse_errors(
+    mut parse_errors: Vec<CommandError>,
+    verb: &str,
+    output_format: OutputFormat,
+) -> usize {
     parse_errors.sort_unstable_by(|a, b| a.path().cmp(&b.path()));
     let count = parse_errors.len();
     for err in parse_errors {
-        error!("{:?}", miette::Report::new(err));
+        match output_format {
+            OutputFormat::Full => error!("{:?}", miette::Report::new(err)),
+            OutputFormat::Concise => error!("{}", err.concise()),
+        }
     }
     if count > 0 {
         error!("Couldn't {verb} {count} files!");

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -1,4 +1,4 @@
-use miette::{Diagnostic, NamedSource, SourceOffset, SourceSpan};
+use miette::{Diagnostic, NamedSource, SourceCode, SourceOffset, SourceSpan, SpanContents};
 use std::io;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -70,6 +70,19 @@ impl CommandError {
             Self::Read(path, _) | Self::Write(path, _) => path.as_deref(),
         }
     }
+
+    /// Render as a single `path:line:column: message` line.
+    #[must_use]
+    pub fn concise(&self) -> String {
+        match self {
+            Self::Parse(err) => {
+                let (line, column) = err.location();
+                let path = path_display(err.path.as_ref());
+                format!("{path}:{line}:{column}: {}", err.message)
+            }
+            Self::Read(..) | Self::Write(..) => self.to_string(),
+        }
+    }
 }
 
 impl ParseError {
@@ -121,5 +134,14 @@ impl ParseError {
             span,
             hint,
         }
+    }
+
+    /// 1-based line and column the error points at.
+    fn location(&self) -> (usize, usize) {
+        self.src
+            .read_span(&self.span, 0, 0)
+            .map_or((0, 0), |contents| {
+                (contents.line() + 1, contents.column() + 1)
+            })
     }
 }

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -9,12 +9,12 @@ fn cli() -> Command {
     Command::new(get_cargo_bin("djangofmt"))
 }
 
-/// Like [`assert_cmd_snapshot!`] but redacts the leading directory of `test.html`
-/// occurrences (i.e. the per-run `TempDir` prefix in miette diagnostics).
+/// Like [`assert_cmd_snapshot!`] but redacts the leading directory of `.html` paths
+/// (i.e. the per-run `TempDir` prefix in miette diagnostics).
 macro_rules! assert_cmd_snapshot_tmpdir {
     ($cmd:expr, @$snapshot:literal $(,)?) => {
         insta::with_settings!(
-            { filters => vec![(r"[^\s\[]+/test\.html", "[TMP]/test.html")] },
+            { filters => vec![(r"[^\s\[]+/(\w+\.html)", "[TMP]/$1")] },
             { assert_cmd_snapshot!($cmd, @$snapshot) }
         )
     };
@@ -382,22 +382,26 @@ fn check_file_with_lint_error() {
 
 #[test]
 fn check_concise_output_format() {
-    let project = Project::new().file(
-        "test.html",
-        "<form method=\"put\"></form>\n{% blocktranslate %}Hello{% endblocktranslate %}\n",
-    );
+    let project = Project::new()
+        .file(
+            "test.html",
+            "<form method=\"put\"></form>\n{% blocktranslate %}Hello{% endblocktranslate %}\n",
+        )
+        .file("unparsable.html", "<div>\n");
     assert_cmd_snapshot_tmpdir!(
-        cli().args(["check", "--output-format", "concise"]).arg(project.join("test.html")),
-        @r#"
+        cli().args(["check", "--output-format", "concise"]).arg(project.path()),
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
+    [TMP]/unparsable.html:1:1: expected close tag for opening tag <div>
+    Couldn't check 1 files!
     [TMP]/test.html:1:15: invalid-attr-value Invalid value 'put' for attribute 'method'.
     [TMP]/test.html:2:3: untrimmed-blocktranslate [*] `{% blocktranslate %}` should declare `trimmed` to avoid leaking indentation into translation strings.
     Found 2 errors. [*] 1 fixable with the --fix option.
-    "#);
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
Missed it when adding the concise format, this was inconsistant and made the final output a bit weird when you have both parse errors and lint errors in your set of files 