### PR TITLE
fix(format): re-indent `{% endcomment %}` with its block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=76ccd171f6eee458ed9b8b0f23119e84c3df6907#76ccd171f6eee458ed9b8b0f23119e84c3df6907"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=a977ae6a8bbb6550dfd2433c935f95eac57eb505#a977ae6a8bbb6550dfd2433c935f95eac57eb505"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta-cmd = { version = "0.6.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "76ccd171f6eee458ed9b8b0f23119e84c3df6907"
+  rev = "a977ae6a8bbb6550dfd2433c935f95eac57eb505"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/crates/djangofmt/tests/fmt/comment_in_attributes.html
+++ b/crates/djangofmt/tests/fmt/comment_in_attributes.html
@@ -1,4 +1,5 @@
 <a {% comment %}c{% endcomment %} href="x">y</a>
+<a {% comment %} keep my spaces {% endcomment %} href="x">y</a>
 <button
     class="x"
     {% comment %}

--- a/crates/djangofmt/tests/fmt/comment_in_attributes.snap
+++ b/crates/djangofmt/tests/fmt/comment_in_attributes.snap
@@ -2,6 +2,7 @@
 source: crates/djangofmt/tests/fmt/main.rs
 ---
 <a {% comment %}c{% endcomment %} href="x">y</a>
+<a {% comment %} keep my spaces {% endcomment %} href="x">y</a>
 <button
     class="x"
     {% comment %}
@@ -16,7 +17,7 @@ source: crates/djangofmt/tests/fmt/main.rs
         class="x"
         {% comment %}
     a badly indented note
-              {% endcomment %}
+        {% endcomment %}
         type="button"
     >
         y


### PR DESCRIPTION
Noticed this while fixing the comment handling in attribute, we can at least fix the endblock indentation