### PR TITLE
restore build for `form-action-whitespace` fix content

### DIFF
--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -95,7 +95,7 @@ pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
     let edit = if trimmed.is_empty() {
         Edit::deletion(span)
     } else {
-        Edit::replacement(trimmed, span)
+        Edit::replacement(trimmed.to_string(), span)
     };
     guard.set_fix(Fix::safe_edit(edit));
 }


### PR DESCRIPTION
Did not rebased one of the merge which causes this merge regression to slip in