### PR TITLE
fix(format): only treat Django's built-in tags as block tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=a977ae6a8bbb6550dfd2433c935f95eac57eb505#a977ae6a8bbb6550dfd2433c935f95eac57eb505"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=af4bebd56395c7c595760fadb848af62605c45a7#af4bebd56395c7c595760fadb848af62605c45a7"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta-cmd = { version = "0.6.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "a977ae6a8bbb6550dfd2433c935f95eac57eb505"
+  rev = "af4bebd56395c7c595760fadb848af62605c45a7"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }


### PR DESCRIPTION
Update the django list of builtin tag that was not correct and mixing with some of jinja