### PR TITLE
feat(lint): Add `per-file-ignores` configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "djangofmt_lint",
  "dprint-plugin-json",
  "editorconfig-parser",
+ "globset",
  "ignore",
  "insta",
  "insta-cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ divan = { package = "codspeed-divan-compat", version = "*" }
 djangofmt_macros = { path = "crates/djangofmt_macros" }
 dprint-plugin-json = { version = "0.21.3" }
 editorconfig-parser = { version = "0.0.4" }
+globset = { version = "0.4.18" }
 ignore = { version = "0.4.25" }
 insta = { version = "1.47.2", features = ["filters", "glob", "yaml"] }
 insta-cmd = { version = "0.6.0" }

--- a/crates/djangofmt/Cargo.toml
+++ b/crates/djangofmt/Cargo.toml
@@ -19,6 +19,7 @@ clap_complete_command = { workspace = true }
 djangofmt_lint = { path = "../djangofmt_lint" }
 dprint-plugin-json = { workspace = true }
 editorconfig-parser = { workspace = true }
+globset = { workspace = true }
 ignore = { workspace = true }
 malva = { workspace = true }
 markup_fmt = { workspace = true }

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -16,6 +16,7 @@ use crate::ExitStatus;
 use crate::args::{CheckCommand, OutputFormat, Profile};
 use crate::error::{CommandError, ParseError, Result};
 use crate::fs::relativize_path;
+use crate::per_file_ignores::PerFileIgnores;
 use crate::pyproject::LintSettings;
 use crate::resolver::{resolve_bool_arg, resolve_rule_selection};
 
@@ -80,6 +81,11 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         warn!("{warning}");
     }
 
+    let per_file_ignores = lint
+        .and_then(|l| l.per_file_ignores.as_ref())
+        .map(|patterns| PerFileIgnores::new(patterns, &resolved.project_root))
+        .transpose()?;
+
     let threshold = if config.unsafe_fixes {
         Applicability::Unsafe
     } else {
@@ -98,10 +104,15 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         .files
         .par_iter()
         .map(|path| {
+            // Reuse the global settings unless per-file-ignores narrow them for this path.
+            let file_settings = per_file_ignores.as_ref().map(|pfi| Settings {
+                rules: pfi.rules_for(path, &settings.rules),
+            });
+            let settings = file_settings.as_ref().unwrap_or(&settings);
             check_path(
                 path,
                 resolved.profile,
-                &settings,
+                settings,
                 &custom_blocks,
                 config.fix,
                 threshold,

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -14,7 +14,7 @@ use crate::resolver::{ResolvedDiscoveryConfig, is_force_excluded};
 /// Run the formatter over a single file, read from `stdin`.
 pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
     let stdin_filename = cli.stdin_filename.as_deref();
-    let pyproject = load_pyproject_from_cwd()?;
+    let (pyproject, _) = load_pyproject_from_cwd()?;
     let discovery_config = ResolvedDiscoveryConfig::new(&cli.file_selection, &pyproject);
 
     // If force-exclude matches the (virtual) stdin filename, parrot stdin to

--- a/crates/djangofmt/src/commands/mod.rs
+++ b/crates/djangofmt/src/commands/mod.rs
@@ -16,6 +16,8 @@ pub(crate) struct ResolvedCommand {
     pub pyproject: PyprojectSettings,
     pub profile: Option<Profile>,
     pub files: Vec<PathBuf>,
+    /// Directory of the nearest `pyproject.toml` (or the cwd), anchoring path-relative config.
+    pub project_root: PathBuf,
 }
 
 pub(crate) fn resolve_command(
@@ -23,7 +25,7 @@ pub(crate) fn resolve_command(
     profile: Option<Profile>,
     file_selection: &FileSelectionArgs,
 ) -> Result<ResolvedCommand> {
-    let pyproject = load_pyproject_from_cwd()?;
+    let (pyproject, project_root) = load_pyproject_from_cwd()?;
     let profile = profile.or(pyproject.profile);
     let discovery_config = ResolvedDiscoveryConfig::new(file_selection, &pyproject);
     let resolved_files = resolve_files(files, &discovery_config)?;
@@ -31,6 +33,7 @@ pub(crate) fn resolve_command(
         pyproject,
         profile,
         files: resolved_files,
+        project_root,
     })
 }
 

--- a/crates/djangofmt/src/lib.rs
+++ b/crates/djangofmt/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod fs;
 pub mod line_width;
 mod logging;
+pub mod per_file_ignores;
 pub mod pyproject;
 pub mod resolver;
 #[cfg(test)]

--- a/crates/djangofmt/src/per_file_ignores.rs
+++ b/crates/djangofmt/src/per_file_ignores.rs
@@ -1,0 +1,176 @@
+//! Per-file rule ignores: drop selected lint rules for files matching a glob.
+//!
+//! Ruff equivalent: `ruff_linter`'s `per-file-ignores` / `CompiledPerFileIgnoreList`.
+//!
+//! Configured under `[tool.djangofmt.lint.per-file-ignores]` as a map from a glob
+//! to the rule selectors to ignore for matching files. A file's effective rule set
+//! is the global selection minus the union of every matching glob's ignored rules.
+//!
+//! Glob semantics follow ruff exactly, so config ports over unchanged: every pattern
+//! is matched both against the file's basename and against the pattern normalized to
+//! the project root, and `*` crosses `/` (`templates/*.html` also covers nested files).
+//! Ruff tests its patterns one matcher at a time; we compile each of the two families
+//! into a `GlobSet`, so match cost does not grow with the number of patterns.
+
+use std::path::Path;
+
+use globset::{Candidate, Glob, GlobSet, GlobSetBuilder, escape};
+use std::collections::BTreeMap;
+
+use djangofmt_lint::{RuleSelector, RuleSet};
+
+use crate::error::{Error, Result};
+
+/// Per-file-ignore globs compiled into two matchers, each paired index-for-index
+/// with the rule set its glob removes.
+#[derive(Debug)]
+pub struct PerFileIgnores {
+    /// Patterns matched against a file's basename.
+    basenames: GlobSet,
+    /// The same patterns anchored at the project root, matched against the full path.
+    absolutes: GlobSet,
+    /// Rules to ignore, parallel to the globs registered in both sets.
+    ignored: Vec<RuleSet>,
+}
+
+impl PerFileIgnores {
+    /// Compile `patterns` (glob -> selectors to ignore) anchored at `root`.
+    pub fn new(patterns: &BTreeMap<String, Vec<RuleSelector>>, root: &Path) -> Result<Self> {
+        // Files are discovered as canonical paths, so anchor the globs at the canonical
+        // root. Fall back to the raw root if it can't be canonicalized.
+        let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        let escaped_root = escape(&root.to_string_lossy());
+
+        let mut basenames = GlobSetBuilder::new();
+        let mut absolutes = GlobSetBuilder::new();
+        let mut ignored = Vec::with_capacity(patterns.len());
+        for (pattern, selectors) in patterns {
+            let anchored = if Path::new(pattern).is_absolute() {
+                pattern.clone()
+            } else {
+                format!("{escaped_root}/{pattern}")
+            };
+            basenames.add(compile(pattern, pattern)?);
+            absolutes.add(compile(&anchored, pattern)?);
+            ignored.push(selectors.iter().flat_map(|s| s.all_rules()).collect());
+        }
+        Ok(Self {
+            basenames: build(&basenames)?,
+            absolutes: build(&absolutes)?,
+            ignored,
+        })
+    }
+
+    /// Effective rule set for `path`: `base` minus every matching glob's ignored rules.
+    #[must_use]
+    pub fn rules_for(&self, path: &Path, base: &RuleSet) -> RuleSet {
+        let full = Candidate::new(path);
+        let name = path.file_name().map(Candidate::new);
+
+        // `matches_candidate` allocates; most files match nothing, so ask first.
+        let by_name = name.filter(|name| self.basenames.is_match_candidate(name));
+        let by_path = self.absolutes.is_match_candidate(&full);
+        if by_name.is_none() && !by_path {
+            return *base;
+        }
+
+        let mut rules = *base;
+        let matches = by_name
+            .map(|name| self.basenames.matches_candidate(&name))
+            .unwrap_or_default()
+            .into_iter()
+            .chain(if by_path {
+                self.absolutes.matches_candidate(&full)
+            } else {
+                vec![]
+            });
+        for idx in matches {
+            for rule in &self.ignored[idx] {
+                rules.remove(rule);
+            }
+        }
+        rules
+    }
+}
+
+/// Compile one glob, reporting `pattern` (the user's spelling) on failure.
+fn compile(glob: &str, pattern: &str) -> Result<Glob> {
+    Glob::new(glob)
+        .map_err(|e| Error::Resolve(format!("Invalid per-file-ignores pattern '{pattern}': {e}")))
+}
+
+fn build(builder: &GlobSetBuilder) -> Result<GlobSet> {
+    builder
+        .build()
+        .map_err(|e| Error::Resolve(format!("Failed to build per-file-ignores: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djangofmt_lint::Rule;
+
+    fn all_rules() -> RuleSet {
+        RuleSelector::All.all_rules().collect()
+    }
+
+    fn ignores(patterns: &[(&str, Rule)]) -> PerFileIgnores {
+        let mut map = BTreeMap::new();
+        for (pattern, rule) in patterns {
+            map.insert((*pattern).to_string(), vec![RuleSelector::Rule(*rule)]);
+        }
+        PerFileIgnores::new(&map, Path::new("/proj")).unwrap()
+    }
+
+    /// Worked example: a bare glob ignores by basename at any depth, a path glob is
+    /// anchored at the root, ignores union across matches, and a rule listed for one
+    /// glob is untouched on files that don't match it.
+    #[test]
+    fn per_file_ignores_worked_example() {
+        let pfi = ignores(&[
+            ("*.jinja", Rule::UseHttps),
+            ("templates/admin/**", Rule::InvalidAttrValue),
+        ]);
+        let base = all_rules();
+
+        // Bare glob: a `.jinja` nested anywhere drops `use-https` only.
+        let nested = pfi.rules_for(Path::new("/proj/app/templates/x.jinja"), &base);
+        assert!(!nested.contains(Rule::UseHttps));
+        assert!(nested.contains(Rule::InvalidAttrValue));
+
+        // A root-level admin `.jinja` matches both globs: the ignore sets union.
+        let admin = pfi.rules_for(Path::new("/proj/templates/admin/page.jinja"), &base);
+        assert!(!admin.contains(Rule::UseHttps)); // from `*.jinja`
+        assert!(!admin.contains(Rule::InvalidAttrValue)); // from `templates/admin/**`
+
+        // `templates/admin/**` is anchored: the same dir nested under `app/` doesn't match.
+        let not_admin = pfi.rules_for(Path::new("/proj/app/templates/admin/page.html"), &base);
+        assert!(not_admin.contains(Rule::InvalidAttrValue));
+
+        // A file matching nothing keeps the full set.
+        assert_eq!(pfi.rules_for(Path::new("/proj/index.html"), &base), base);
+    }
+
+    /// `*` crosses `/`, as in ruff: `templates/*.html` covers nested files too.
+    #[test]
+    fn star_crosses_separators_like_ruff() {
+        let pfi = ignores(&[("templates/*.html", Rule::UseHttps)]);
+        let base = all_rules();
+        for path in [
+            "/proj/templates/page.html",
+            "/proj/templates/admin/deep/page.html",
+        ] {
+            assert!(
+                !pfi.rules_for(Path::new(path), &base).contains(Rule::UseHttps),
+                "{path} should match `templates/*.html`"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_pattern_errors() {
+        let mut patterns = BTreeMap::new();
+        patterns.insert("[unclosed".to_string(), vec![]);
+        assert!(PerFileIgnores::new(&patterns, Path::new("/proj")).is_err());
+    }
+}

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -1,6 +1,10 @@
 use djangofmt_lint::RuleSelector;
 use serde::Deserialize;
-use std::{fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 use tracing::debug;
 
 use crate::args::{OutputFormat, Profile};
@@ -36,6 +40,7 @@ pub struct LintSettings {
     pub unsafe_fixes: Option<bool>,
     pub show_fixes: Option<bool>,
     pub output_format: Option<OutputFormat>,
+    pub per_file_ignores: Option<BTreeMap<String, Vec<RuleSelector>>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -58,12 +63,15 @@ fn load_options_from_pyproject_toml(content: &str) -> Result<PyprojectSettings> 
 
 /// Load `pyproject.toml` settings rooted at the current working directory,
 /// falling back to defaults if the cwd can't be determined.
-pub fn load_pyproject_from_cwd() -> Result<PyprojectSettings> {
+pub fn load_pyproject_from_cwd() -> Result<(PyprojectSettings, PathBuf)> {
     load_options(crate::fs::get_cwd())
 }
 
-/// Loads user configured options from the nearest `pyproject.toml` file from the given path
-pub fn load_options<P: AsRef<Path>>(start_path: P) -> Result<PyprojectSettings> {
+/// Loads user configured options from the nearest `pyproject.toml` file from the given path.
+///
+/// Also returns the directory that file was found in (the search start when there is none),
+/// which anchors path-relative config such as `per-file-ignores`.
+pub fn load_options<P: AsRef<Path>>(start_path: P) -> Result<(PyprojectSettings, PathBuf)> {
     let Some(pyproject_path) =
         crate::fs::find_nearest_ancestor_file(start_path.as_ref(), "pyproject.toml")
     else {
@@ -71,7 +79,10 @@ pub fn load_options<P: AsRef<Path>>(start_path: P) -> Result<PyprojectSettings> 
             "No pyproject.toml found starting search from: {}",
             start_path.as_ref().display()
         );
-        return Ok(PyprojectSettings::default());
+        return Ok((
+            PyprojectSettings::default(),
+            start_path.as_ref().to_path_buf(),
+        ));
     };
     debug!(
         "Loading options from pyproject.toml at: {}",
@@ -84,7 +95,10 @@ pub fn load_options<P: AsRef<Path>>(start_path: P) -> Result<PyprojectSettings> 
             pyproject_path.display()
         ))
     })?;
-    load_options_from_pyproject_toml(&content)
+    let root = pyproject_path
+        .parent()
+        .map_or_else(|| start_path.as_ref().to_path_buf(), Path::to_path_buf);
+    Ok((load_options_from_pyproject_toml(&content)?, root))
 }
 
 #[cfg(test)]
@@ -106,7 +120,7 @@ mod tests {
             html-void-self-closing='always'
             ",
         );
-        let result = load_options(project.join("pyproject.toml")).unwrap();
+        let (result, _) = load_options(project.join("pyproject.toml")).unwrap();
         assert_eq!(
             result,
             PyprojectSettings {
@@ -129,7 +143,7 @@ mod tests {
             line-length=200
             ",
         );
-        let result = load_options(project.join("pyproject.toml")).unwrap();
+        let (result, _) = load_options(project.join("pyproject.toml")).unwrap();
         assert_eq!(
             result,
             PyprojectSettings {
@@ -142,14 +156,14 @@ mod tests {
     #[test]
     fn test_load_options_returns_default_when_no_pyproject_toml() {
         let project = Project::new();
-        let result = load_options(project.path()).unwrap();
+        let (result, _) = load_options(project.path()).unwrap();
         assert_eq!(result, PyprojectSettings::default());
     }
 
     #[test]
     fn test_load_options_returns_default_when_empty_pyproject_toml() {
         let project = Project::new().file("pyproject.toml", "");
-        let result = load_options(project.join("pyproject.toml")).unwrap();
+        let (result, _) = load_options(project.join("pyproject.toml")).unwrap();
         assert_eq!(result, PyprojectSettings::default());
     }
 
@@ -272,6 +286,22 @@ preview = true
                 }),
                 ..Default::default()
             }
+        );
+    }
+
+    #[test]
+    fn test_load_lint_per_file_ignores() {
+        use djangofmt_lint::Rule;
+
+        let content = r#"
+[tool.djangofmt.lint.per-file-ignores]
+"templates/admin/*.html" = ["missing-img-alt"]
+"#;
+        let result = load_options_from_pyproject_toml(content).unwrap();
+        let per_file = result.lint.unwrap().per_file_ignores.unwrap();
+        assert_eq!(
+            per_file.get("templates/admin/*.html"),
+            Some(&vec![RuleSelector::Rule(Rule::MissingImgAlt)])
         );
     }
 

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -539,3 +539,51 @@ fn check_respects_pyproject_custom_blocks() {
     Couldn't check 1 files!
     "###);
 }
+
+#[test]
+fn check_respects_pyproject_per_file_ignores() {
+    // Same violation in both files: the glob must silence it in `legacy/` only.
+    let violation = "<form method=\"put\"></form>\n";
+    let project = Project::new()
+        .file(
+            "pyproject.toml",
+            "[tool.djangofmt.lint.per-file-ignores]\n\"legacy/*\" = [\"invalid-attr-value\"]\n",
+        )
+        .file("legacy/old.html", violation)
+        .file("new.html", violation);
+    assert_cmd_snapshot!(cli().current_dir(project.path()).args(["check", "."]), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Invalid value 'put' for attribute 'method'.
+       ╭─[new.html:1:15]
+     1 │ <form method="put"></form>
+       ·               ─┬─
+       ·                ╰── here
+       ╰────
+      help: Use one of: get, post, dialog
+
+    Found 1 errors.
+    "###);
+
+    // Globs anchor at the `pyproject.toml` directory, not the cwd: `legacy/*` keeps
+    // matching when djangofmt runs from inside `legacy/`.
+    assert_cmd_snapshot_tmpdir!(cli().current_dir(project.join("legacy")).args(["check", ".."]), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Invalid value 'put' for attribute 'method'.
+       ╭─[[TMP]/new.html:1:15]
+     1 │ <form method="put"></form>
+       ·               ─┬─
+       ·                ╰── here
+       ╰────
+      help: Use one of: get, post, dialog
+
+    Found 1 errors.
+    "###);
+}

--- a/crates/djangofmt_dev/src/generate_rules_table.rs
+++ b/crates/djangofmt_dev/src/generate_rules_table.rs
@@ -36,6 +36,16 @@ A selector is either:
 
 
 Preview rules are off by default. Enable them with `--preview` or `preview = true`.
+
+To turn rules off for some files only, map a glob to the selectors to ignore there:
+
+```toml
+[tool.djangofmt.lint.per-file-ignores]
+"legacy/*" = ["category:accessibility"]
+"emails/*.html" = ["missing-img-dimensions", "use-https"]
+```
+
+Every pattern is matched both against the file name and against the path relative to the directory holding `pyproject.toml`: `"*.jinja"` covers that extension at any depth, while `"emails/*.html"` is anchored at the project root (and, since `*` crosses `/`, covers nested files under `emails/` too). These are ruff's `per-file-ignores` semantics, so a block can be copied over unchanged.
 "#;
 
 fn render() -> String {


### PR DESCRIPTION
Mirror ruff's `per-file-ignores`: a map of glob -> rule selectors to ignore.

Can be configured under `[tool.djangofmt.lint.per-file-ignores]` in project `pyproject.toml`. 

Globs are anchored at the project root, except bare patterns (no `/`) which match a file's basename at any depth. 

Fixes #354