### PR TITLE
refactor(format): Delete dead display only fix api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,6 @@ dependencies = [
 name = "djangofmt_lint"
 version = "0.2.12"
 dependencies = [
- "anyhow",
  "djangofmt_macros",
  "insta",
  "markup_fmt",

--- a/crates/djangofmt/src/per_file_ignores.rs
+++ b/crates/djangofmt/src/per_file_ignores.rs
@@ -161,7 +161,8 @@ mod tests {
             "/proj/templates/admin/deep/page.html",
         ] {
             assert!(
-                !pfi.rules_for(Path::new(path), &base).contains(Rule::UseHttps),
+                !pfi.rules_for(Path::new(path), &base)
+                    .contains(Rule::UseHttps),
                 "{path} should match `templates/*.html`"
             );
         }

--- a/crates/djangofmt_lint/Cargo.toml
+++ b/crates/djangofmt_lint/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
 djangofmt_macros = { workspace = true }
 markup_fmt = { workspace = true }
 miette = { workspace = true }

--- a/crates/djangofmt_lint/src/fix/apply.rs
+++ b/crates/djangofmt_lint/src/fix/apply.rs
@@ -34,30 +34,10 @@ pub struct ApplyResult {
     pub applied_count: usize,
     /// Number of fixes that were filtered out (overlap, isolation, applicability).
     pub skipped_count: usize,
-    /// Source map mapping byte offsets in the original source to offsets in
-    /// the output.
-    pub source_map: SourceMap,
     /// Metadata for each applied fix, in application order.
     ///
     /// Used by the CLI's `--show-fixes` to render per-rule counts.
     pub applied_fixes: Vec<AppliedFix>,
-}
-
-/// Sequence of [`SourceMarker`]s describing the offset transformation from
-/// the original source to the fixed output.
-#[derive(Debug, Default)]
-pub struct SourceMap {
-    pub markers: Vec<SourceMarker>,
-}
-
-/// A start/end pair of byte offsets pinning a region in the original source
-/// to its image in the output.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SourceMarker {
-    /// Byte offset in the original source.
-    pub source: usize,
-    /// Byte offset in the output.
-    pub dest: usize,
 }
 
 /// Maximum number of fix iterations before giving up.
@@ -88,7 +68,6 @@ pub fn apply_fixes(
     });
 
     let mut output = String::with_capacity(source.len());
-    let mut markers: Vec<SourceMarker> = Vec::new();
     let mut last_pos: usize = 0;
     let mut applied_count = 0usize;
     let mut skipped_count = 0usize;
@@ -119,17 +98,9 @@ pub fn apply_fixes(
 
         for edit in edits {
             output.push_str(&source[last_pos..edit.start()]);
-            markers.push(SourceMarker {
-                source: edit.start(),
-                dest: output.len(),
-            });
             if let Some(content) = edit.content() {
                 output.push_str(content);
             }
-            markers.push(SourceMarker {
-                source: edit.end(),
-                dest: output.len(),
-            });
             last_pos = edit.end();
         }
 
@@ -149,7 +120,6 @@ pub fn apply_fixes(
         output,
         applied_count,
         skipped_count,
-        source_map: SourceMap { markers },
         applied_fixes,
     }
 }
@@ -383,7 +353,6 @@ mod tests {
         let diags = vec![
             diag_with_fix(Fix::safe_edit(Edit::replacement("S", span(0, 1)))),
             diag_with_fix(Fix::unsafe_edit(Edit::replacement("U", span(2, 1)))),
-            diag_with_fix(Fix::display_only_edit(Edit::replacement("D", span(4, 1)))),
         ];
 
         // Safe threshold: only the safe fix applies.
@@ -395,11 +364,6 @@ mod tests {
         let result = apply_fixes(source, &diags, Applicability::Unsafe);
         assert_eq!(result.output, "SbUdefghij");
         assert_eq!(result.applied_count, 2);
-
-        // DisplayOnly threshold: all apply.
-        let result = apply_fixes(source, &diags, Applicability::DisplayOnly);
-        assert_eq!(result.output, "SbUdDfghij");
-        assert_eq!(result.applied_count, 3);
     }
 
     #[test]
@@ -444,28 +408,6 @@ mod tests {
         assert_eq!(result.output, "abc");
         assert_eq!(result.applied_count, 0);
         assert_eq!(result.skipped_count, 0);
-    }
-
-    #[test]
-    fn source_map_markers() {
-        let source = "hello world";
-        let diags = vec![diag_with_fix(Fix::safe_edit(Edit::replacement(
-            "Rust",
-            span(6, 5),
-        )))];
-        let result = apply_fixes(source, &diags, Applicability::Safe);
-        assert_eq!(result.source_map.markers.len(), 2);
-        assert_eq!(
-            result.source_map.markers[0],
-            SourceMarker { source: 6, dest: 6 }
-        );
-        assert_eq!(
-            result.source_map.markers[1],
-            SourceMarker {
-                source: 11,
-                dest: 10
-            }
-        );
     }
 
     #[test]

--- a/crates/djangofmt_lint/src/fix/mod.rs
+++ b/crates/djangofmt_lint/src/fix/mod.rs
@@ -50,12 +50,10 @@ impl std::fmt::Display for FixAvailability {
     }
 }
 
-/// Three-tier safety classification for fixes, ordered ascending so `>=`
-/// reads as a "minimum required" applicability check.
+/// Safety classification for fixes, ordered ascending so `>=` reads as a
+/// "minimum required" applicability check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Applicability {
-    /// Likely incorrect; surfaced in diagnostics but never applied automatically.
-    DisplayOnly,
     /// May change runtime behavior; applied only with `--unsafe-fixes`.
     Unsafe,
     /// Preserves exact semantics; applied with `--fix`.
@@ -231,12 +229,6 @@ impl Fix {
         Self::single(edit, Applicability::Unsafe)
     }
 
-    /// Single-edit display-only fix.
-    #[must_use]
-    pub fn display_only_edit(edit: Edit) -> Self {
-        Self::single(edit, Applicability::DisplayOnly)
-    }
-
     /// Multi-edit safe fix.
     #[must_use]
     pub fn safe_edits<I>(first: Edit, rest: I) -> Self
@@ -255,26 +247,10 @@ impl Fix {
         Self::multi(first, rest, Applicability::Unsafe)
     }
 
-    /// Multi-edit display-only fix.
-    #[must_use]
-    pub fn display_only_edits<I>(first: Edit, rest: I) -> Self
-    where
-        I: IntoIterator<Item = Edit>,
-    {
-        Self::multi(first, rest, Applicability::DisplayOnly)
-    }
-
     /// Set the isolation level (builder).
     #[must_use]
     pub const fn isolate(mut self, level: IsolationLevel) -> Self {
         self.isolation_level = level;
-        self
-    }
-
-    /// Override the applicability (builder).
-    #[must_use]
-    pub const fn with_applicability(mut self, applicability: Applicability) -> Self {
-        self.applicability = applicability;
         self
     }
 
@@ -389,12 +365,6 @@ mod tests {
     }
 
     #[test]
-    fn fix_display_only_edit() {
-        let fix = Fix::display_only_edit(Edit::insertion("x", 5));
-        assert_eq!(fix.applicability(), Applicability::DisplayOnly);
-    }
-
-    #[test]
     fn fix_safe_edits_sorts() {
         let fix = Fix::safe_edits(
             Edit::insertion("late", 10),
@@ -422,43 +392,23 @@ mod tests {
     }
 
     #[test]
-    fn fix_display_only_edits() {
-        let fix = Fix::display_only_edits(Edit::insertion("a", 0), [Edit::insertion("b", 5)]);
-        assert_eq!(fix.applicability(), Applicability::DisplayOnly);
-    }
-
-    #[test]
     fn fix_isolate_builder() {
         let fix = Fix::safe_edit(Edit::insertion("x", 0)).isolate(IsolationLevel::Group(7));
         assert!(matches!(fix.isolation(), IsolationLevel::Group(7)));
     }
 
     #[test]
-    fn fix_with_applicability_builder() {
-        let fix = Fix::safe_edit(Edit::insertion("x", 0)).with_applicability(Applicability::Unsafe);
-        assert_eq!(fix.applicability(), Applicability::Unsafe);
-    }
-
-    #[test]
     fn fix_applies_threshold_semantics() {
         let safe = Fix::safe_edit(Edit::insertion("x", 0));
         let unsafe_ = Fix::unsafe_edit(Edit::insertion("x", 0));
-        let display = Fix::display_only_edit(Edit::insertion("x", 0));
 
         // threshold = Safe admits only Safe
         assert!(safe.applies(Applicability::Safe));
         assert!(!unsafe_.applies(Applicability::Safe));
-        assert!(!display.applies(Applicability::Safe));
 
         // threshold = Unsafe admits Safe + Unsafe
         assert!(safe.applies(Applicability::Unsafe));
         assert!(unsafe_.applies(Applicability::Unsafe));
-        assert!(!display.applies(Applicability::Unsafe));
-
-        // threshold = DisplayOnly admits everything
-        assert!(safe.applies(Applicability::DisplayOnly));
-        assert!(unsafe_.applies(Applicability::DisplayOnly));
-        assert!(display.applies(Applicability::DisplayOnly));
     }
 
     #[test]

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -27,7 +27,7 @@ mod violation;
 pub use checker::Checker;
 pub use fix::apply::{
     AppliedFix, ApplyResult, FixerError, FixerResult, MAX_FIX_ITERATIONS, RuleFixSummary,
-    SourceMap, SourceMarker, apply_fixes, fix_ast, lint_fix,
+    apply_fixes, fix_ast, lint_fix,
 };
 pub use fix::{Applicability, Edit, Fix, FixAvailability, IsolationLevel};
 pub use lint_context::{DiagnosticGuard, LintContext};

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -5,7 +5,6 @@
 //! pushes it into the context's buffer.
 
 use std::cell::RefCell;
-use std::ops::{Deref, DerefMut};
 
 use miette::SourceSpan;
 
@@ -110,7 +109,6 @@ impl<'a> LintContext<'a> {
                 fix: None,
                 fix_title: violation.fix_title(),
             }),
-            rule: V::RULE,
         }
     }
 
@@ -122,14 +120,9 @@ impl<'a> LintContext<'a> {
 }
 
 /// Guard that holds a partially-built diagnostic and pushes it on Drop.
-///
-/// Implements [`Deref`] / [`DerefMut`] to the underlying [`LintDiagnostic`]
-/// so callers can override fields like `help` or `fix_title` if needed.
 pub struct DiagnosticGuard<'ctx, 'a> {
     context: &'ctx LintContext<'a>,
     diagnostic: Option<LintDiagnostic>,
-    /// Rule the diagnostic was reported for. Used for tracing on fallible fixes.
-    rule: Rule,
 }
 
 impl DiagnosticGuard<'_, '_> {
@@ -139,46 +132,6 @@ impl DiagnosticGuard<'_, '_> {
         if let Some(diag) = self.diagnostic.as_mut() {
             diag.fix = Some(fix);
         }
-    }
-
-    /// Compute a fix fallibly; on `Err`, log at debug and skip attachment.
-    pub fn try_set_fix(&mut self, f: impl FnOnce() -> anyhow::Result<Fix>) {
-        match f() {
-            Ok(fix) => self.set_fix(fix),
-            Err(err) => {
-                tracing::debug!(rule = %self.rule, "failed to compute fix: {err}");
-            }
-        }
-    }
-
-    /// Compute an optional fix fallibly; on `Ok(None)`, skip; on `Err`, log
-    /// and skip.
-    pub fn try_set_optional_fix(&mut self, f: impl FnOnce() -> anyhow::Result<Option<Fix>>) {
-        match f() {
-            Ok(Some(fix)) => self.set_fix(fix),
-            Ok(None) => {}
-            Err(err) => {
-                tracing::debug!(rule = %self.rule, "failed to compute optional fix: {err}");
-            }
-        }
-    }
-}
-
-impl Deref for DiagnosticGuard<'_, '_> {
-    type Target = LintDiagnostic;
-
-    fn deref(&self) -> &Self::Target {
-        self.diagnostic
-            .as_ref()
-            .expect("diagnostic accessed during Drop")
-    }
-}
-
-impl DerefMut for DiagnosticGuard<'_, '_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.diagnostic
-            .as_mut()
-            .expect("diagnostic accessed during Drop")
     }
 }
 


### PR DESCRIPTION
I don't want to display "most likely incorrect" fixes, let's drop this idea altogether