### PR TITLE
fix(format): Bump `markup_fmt` to fix script indent with mixed `tabs` and `spaces`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=6345c548496168903cd4a06ed6321556436992d0#6345c548496168903cd4a06ed6321556436992d0"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=d2cc494eedf783940aa2307aa4cf7d3e12f3ac34#d2cc494eedf783940aa2307aa4cf7d3e12f3ac34"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=65d0ef7c38db6ec1b81a366681cded7e1252fe17#65d0ef7c38db6ec1b81a366681cded7e1252fe17"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=30d2aab99d736fae8985c65d7261fbd9a2a6878e#30d2aab99d736fae8985c65d7261fbd9a2a6878e"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ insta-cmd = { version = "0.7.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "6345c548496168903cd4a06ed6321556436992d0"
+  rev = "d2cc494eedf783940aa2307aa4cf7d3e12f3ac34"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ insta-cmd = { version = "0.6.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "65d0ef7c38db6ec1b81a366681cded7e1252fe17"
+  rev = "30d2aab99d736fae8985c65d7261fbd9a2a6878e"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }


### PR DESCRIPTION
Fixes #153