### PR TITLE
feat(cli): hint at the conditional open/close tag limitation on parse errors

### DIFF
--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -98,7 +98,10 @@ impl ParseError {
                         column,
                     } => (
                         format!("expected close tag for opening tag <{tag_name}>"),
-                        None,
+                        Some(format!(
+                            "If a `</{tag_name}>` does exist, it must live in the same block as the opening tag: \
+                             https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags"
+                        )),
                         SourceSpan::new(SourceOffset::from_location(&source, *line, *column), djangofmt_lint::clamp_offset(tag_name.len())),
                     ),
                     markup_fmt::SyntaxErrorKind::ExpectJinjaBlockEnd {

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -252,6 +252,9 @@ fn format_stdin_parse_error_exits_2() {
        · ─┬─
        ·  ╰── here
        ╰────
+      help: If a `</div>` does exist, it must live in the same block as the
+            opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
+            limitations/#conditional-openclose-tags
     "###);
 }
 

--- a/crates/djangofmt/tests/parse_error/invalid_closing_tag_syntax.snap
+++ b/crates/djangofmt/tests/parse_error/invalid_closing_tag_syntax.snap
@@ -9,3 +9,4 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·    ╰── here
  3 │ </html>
    ╰────
+  help: If a `</p>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt/tests/parse_error/nested_unclosed_tags.snap
+++ b/crates/djangofmt/tests/parse_error/nested_unclosed_tags.snap
@@ -9,3 +9,4 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·              ╰── here
  5 │         </article>
    ╰────
+  help: If a `</p>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt/tests/parse_error/unclosed_body_tag.snap
+++ b/crates/djangofmt/tests/parse_error/unclosed_body_tag.snap
@@ -9,3 +9,4 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·    ╰── here
  6 │ <head>
    ╰────
+  help: If a `</html>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt/tests/parse_error/unclosed_div_tag.snap
+++ b/crates/djangofmt/tests/parse_error/unclosed_div_tag.snap
@@ -9,3 +9,4 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·       ╰── here
  8 │         <h1>Unclosed div tag</h1>
    ╰────
+  help: If a `</div>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags


### PR DESCRIPTION
Link to https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags when having a parse error