### PR TITLE
fix(lint): don't disable missing-doctype on root-level Jinja blocks

### DIFF
--- a/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
+++ b/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use markup_fmt::ast::{NodeKind, Root};
+use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
 
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
@@ -61,8 +61,8 @@ pub fn check(root: &Root<'_>, checker: &Checker<'_>) {
 
     for node in &root.children {
         match &node.kind {
-            NodeKind::JinjaBlock(_) => return,
-            NodeKind::JinjaTag(tag) if is_extends_tag(tag.content) => return,
+            NodeKind::JinjaBlock(block) if is_block_partial(block) => return,
+            NodeKind::JinjaTag(tag) if is_tag_keyword(tag.content, "extends") => return,
             NodeKind::Doctype(_) => has_doctype = true,
             NodeKind::Element(el)
                 if html_element.is_none() && el.tag_name.eq_ignore_ascii_case("html") =>
@@ -85,20 +85,29 @@ pub fn check(root: &Root<'_>, checker: &Checker<'_>) {
     checker.report_diagnostic(&MissingDoctype, span(offset, html.tag_name.len()));
 }
 
-/// Returns `true` if `content` is the body of a Jinja `{% extends %}` tag.
+/// Returns `true` if the block opens with `{% block %}`, marking the file as a partial.
+/// Other root-level blocks (`{% if %}`, `{% for %}`, ...) are legitimate in full documents.
+fn is_block_partial(block: &JinjaBlock<'_, Node<'_>>) -> bool {
+    matches!(
+        block.body.first(),
+        Some(JinjaTagOrChildren::Tag(tag)) if is_tag_keyword(tag.content, "block")
+    )
+}
+
+/// Returns `true` if `content` is the body of a Jinja tag starting with `keyword`.
 ///
 /// Handles Jinja's whitespace-stripping markers (`{%-` / `-%}`), which the parser preserves as
-/// leading/trailing `-` inside `content`. The check after `extends` requires a word boundary so
-/// e.g. `{% extendsfoo %}` is not matched.
-fn is_extends_tag(content: &str) -> bool {
+/// leading/trailing `-` inside `content`. The check after the keyword requires a word boundary
+/// so e.g. `{% extendsfoo %}` is not matched.
+fn is_tag_keyword(content: &str, keyword: &str) -> bool {
     let trimmed = content
         .trim_start()
         .strip_prefix('-')
         .map_or_else(|| content.trim_start(), str::trim_start);
-    let Some(after_extends) = trimmed.strip_prefix("extends") else {
+    let Some(after_keyword) = trimmed.strip_prefix(keyword) else {
         return false;
     };
-    after_extends
+    after_keyword
         .chars()
         .next()
         .is_none_or(|c| c.is_ascii_whitespace())

--- a/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
+++ b/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
+use markup_fmt::parser::parse_jinja_tag_name;
 
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
@@ -62,7 +63,7 @@ pub fn check(root: &Root<'_>, checker: &Checker<'_>) {
     for node in &root.children {
         match &node.kind {
             NodeKind::JinjaBlock(block) if is_block_partial(block) => return,
-            NodeKind::JinjaTag(tag) if is_tag_keyword(tag.content, "extends") => return,
+            NodeKind::JinjaTag(tag) if parse_jinja_tag_name(tag) == "extends" => return,
             NodeKind::Doctype(_) => has_doctype = true,
             NodeKind::Element(el)
                 if html_element.is_none() && el.tag_name.eq_ignore_ascii_case("html") =>
@@ -90,25 +91,6 @@ pub fn check(root: &Root<'_>, checker: &Checker<'_>) {
 fn is_block_partial(block: &JinjaBlock<'_, Node<'_>>) -> bool {
     matches!(
         block.body.first(),
-        Some(JinjaTagOrChildren::Tag(tag)) if is_tag_keyword(tag.content, "block")
+        Some(JinjaTagOrChildren::Tag(tag)) if parse_jinja_tag_name(tag) == "block"
     )
-}
-
-/// Returns `true` if `content` is the body of a Jinja tag starting with `keyword`.
-///
-/// Handles Jinja's whitespace-stripping markers (`{%-` / `-%}`), which the parser preserves as
-/// leading/trailing `-` inside `content`. The check after the keyword requires a word boundary
-/// so e.g. `{% extendsfoo %}` is not matched.
-fn is_tag_keyword(content: &str, keyword: &str) -> bool {
-    let trimmed = content
-        .trim_start()
-        .strip_prefix('-')
-        .map_or_else(|| content.trim_start(), str::trim_start);
-    let Some(after_keyword) = trimmed.strip_prefix(keyword) else {
-        return false;
-    };
-    after_keyword
-        .chars()
-        .next()
-        .is_none_or(|c| c.is_ascii_whitespace())
 }

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_block_plus_marker.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_block_plus_marker.valid.html
@@ -1,0 +1,5 @@
+<!-- Jinja whitespace-preserving form `{%+ block %}` still marks the file as a partial. -->
+{%+ block head %}{% endblock %}
+<html lang="en">
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_plus_marker.valid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_extends_plus_marker.valid.html
@@ -1,0 +1,5 @@
+<!-- Jinja whitespace-preserving form `{%+ extends %}` is a legitimate extends. -->
+{%+ extends "base.html" %}
+<html lang="en">
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_if_block.invalid.html
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_if_block.invalid.html
@@ -1,0 +1,7 @@
+<!-- A root-level `{% if %}` block does not make the file a partial; the full document below
+     still needs a DOCTYPE. -->
+{% if debug %}<meta name="x">{% endif %}
+<html lang="en">
+    <head><title>Page</title></head>
+    <body>Content</body>
+</html>

--- a/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_if_block.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/missing_doctype/missing_doctype_if_block.invalid.snap
@@ -1,0 +1,12 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Missing `<!DOCTYPE html>` declaration.
+   ╭─[tests/check/missing_doctype/missing_doctype_if_block.invalid.html:4:2]
+ 3 │ {% if debug %}<meta name="x">{% endif %}
+ 4 │ <html lang="en">
+   ·  ──┬─
+   ·    ╰── here
+ 5 │     <head><title>Page</title></head>
+   ╰────
+  help: Add `<!DOCTYPE html>` before the `<html>` tag.


### PR DESCRIPTION
`missing-doctype` bailed out on *any* root-level Jinja block (`{% if %}`, `{% for %}`, `{% comment %}`, ...), so a full `<html>` document preceded by e.g. `{% if debug %}...{% endif %}` was never flagged. Only `{% extends %}` / `{% block %}` partials are meant to be exempt.

The check now returns early only when the root block actually opens with `{% block %}`; other blocks no longer stop the scan.