### PR TITLE
fix(cli): anchor exclude patterns at the project root and match excluded parent directories

### DIFF
--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -15,8 +15,9 @@ use crate::resolver::{ResolvedDiscoveryConfig, is_force_excluded};
 /// Run the formatter over a single file, read from `stdin`.
 pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
     let stdin_filename = cli.stdin_filename.as_deref();
-    let (pyproject, _) = load_pyproject_from_cwd()?;
-    let discovery_config = ResolvedDiscoveryConfig::new(&cli.file_selection, &pyproject);
+    let (pyproject, project_root) = load_pyproject_from_cwd()?;
+    let discovery_config =
+        ResolvedDiscoveryConfig::new(&cli.file_selection, &pyproject, &project_root);
 
     // If force-exclude matches the (virtual) stdin filename, parrot stdin to
     // stdout unchanged so editors don't trip on excluded files.

--- a/crates/djangofmt/src/commands/mod.rs
+++ b/crates/djangofmt/src/commands/mod.rs
@@ -24,7 +24,7 @@ pub(crate) fn resolve_command(
     file_selection: &FileSelectionArgs,
 ) -> Result<ResolvedCommand> {
     let (pyproject, project_root) = load_pyproject_from_cwd()?;
-    let discovery_config = ResolvedDiscoveryConfig::new(file_selection, &pyproject);
+    let discovery_config = ResolvedDiscoveryConfig::new(file_selection, &pyproject, &project_root);
     let resolved_files = resolve_files(files, &discovery_config)?;
     Ok(ResolvedCommand {
         pyproject,

--- a/crates/djangofmt/src/resolver.rs
+++ b/crates/djangofmt/src/resolver.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use ignore::WalkBuilder;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::overrides::OverrideBuilder;
 use ignore::types::TypesBuilder;
 use tracing::{debug, warn};
@@ -45,6 +46,8 @@ pub struct ResolvedDiscoveryConfig {
     pub include: Vec<String>,
     pub respect_gitignore: bool,
     pub force_exclude: bool,
+    /// Directory anchoring path-relative exclude patterns (the `pyproject.toml` directory).
+    pub project_root: PathBuf,
 }
 
 impl ResolvedDiscoveryConfig {
@@ -52,7 +55,11 @@ impl ResolvedDiscoveryConfig {
     ///
     /// Precedence (highest to lowest): CLI > pyproject > defaults.
     #[must_use]
-    pub fn new(cli: &FileSelectionArgs, pyproject: &PyprojectSettings) -> Self {
+    pub fn new(
+        cli: &FileSelectionArgs,
+        pyproject: &PyprojectSettings,
+        project_root: &Path,
+    ) -> Self {
         let mut exclude = cli
             .exclude
             .clone()
@@ -82,6 +89,10 @@ impl ResolvedDiscoveryConfig {
             force_exclude: resolve_bool_arg(cli.force_exclude, cli.no_force_exclude)
                 .or(pyproject.force_exclude)
                 .unwrap_or(false),
+            // Discovered files are canonicalized, so anchor patterns at the canonical root.
+            project_root: project_root
+                .canonicalize()
+                .unwrap_or_else(|_| project_root.to_path_buf()),
         }
     }
 }
@@ -100,12 +111,9 @@ fn build_types(config: &ResolvedDiscoveryConfig) -> Result<ignore::types::Types,
         .map_err(|e| Error::Resolve(format!("Failed to build file types: {e}")))
 }
 
-/// Build the exclude `Override` matcher from the resolved config.
-fn build_overrides(
-    root: &Path,
-    config: &ResolvedDiscoveryConfig,
-) -> Result<ignore::overrides::Override, Error> {
-    let mut override_builder = OverrideBuilder::new(root);
+/// Build the exclude `Override` matcher used to prune the directory walk.
+fn build_overrides(config: &ResolvedDiscoveryConfig) -> Result<ignore::overrides::Override, Error> {
+    let mut override_builder = OverrideBuilder::new(&config.project_root);
     for pattern in &config.exclude {
         override_builder
             .add(&format!("!{pattern}"))
@@ -116,15 +124,40 @@ fn build_overrides(
         .map_err(|e| Error::Resolve(format!("Failed to build exclude overrides: {e}")))
 }
 
+/// Build the exclude matcher for explicitly-passed paths, which (unlike the walk,
+/// where excluded directories are pruned) must also match via parent directories.
+fn build_exclude_matcher(config: &ResolvedDiscoveryConfig) -> Result<Gitignore, Error> {
+    let mut builder = GitignoreBuilder::new(&config.project_root);
+    for pattern in &config.exclude {
+        builder
+            .add_line(None, pattern)
+            .map_err(|e| Error::Resolve(format!("Invalid exclude pattern '{pattern}': {e}")))?;
+    }
+    builder
+        .build()
+        .map_err(|e| Error::Resolve(format!("Failed to build exclude matcher: {e}")))
+}
+
+/// Return whether `path` or any of its parent directories up to the project root
+/// matches an exclude pattern. Paths outside the root are never excluded.
+fn is_excluded(matcher: &Gitignore, path: &Path) -> bool {
+    path.strip_prefix(matcher.path()).is_ok_and(|relative| {
+        matcher
+            .matched_path_or_any_parents(relative, false)
+            .is_ignore()
+    })
+}
+
 /// Return `true` if the given filename should be force-excluded based on the resolved
 /// configuration. Returns `false` if `force_exclude` is disabled.
 pub fn is_force_excluded(filename: &Path, config: &ResolvedDiscoveryConfig) -> Result<bool, Error> {
     if !config.force_exclude {
         return Ok(false);
     }
-    let cwd = crate::fs::get_cwd();
-    let overrides = build_overrides(cwd, config)?;
-    Ok(overrides.matched(filename, false).is_ignore())
+    let matcher = build_exclude_matcher(config)?;
+    // Stdin filenames may be relative to the cwd and may not exist on disk.
+    let path = crate::fs::get_cwd().join(filename);
+    Ok(is_excluded(&matcher, &path.canonicalize().unwrap_or(path)))
 }
 
 /// Resolve a list of CLI paths (files and/or directories) into a flat,
@@ -134,10 +167,10 @@ pub fn resolve_files(
     config: &ResolvedDiscoveryConfig,
 ) -> Result<Vec<PathBuf>, Error> {
     let mut files: Vec<PathBuf> = Vec::with_capacity(paths.len());
-    let mut dirs: Vec<&Path> = vec![];
+    let mut dirs: Vec<PathBuf> = vec![];
 
     // Process the provided paths, collecting directories for later recursive processing.
-    // Explicit files paths are canonicalized.
+    // Paths are canonicalized so they match patterns anchored at the canonical project root.
     for path in paths {
         if !path.exists() {
             return Err(Error::Resolve(format!(
@@ -145,29 +178,22 @@ pub fn resolve_files(
                 path.display()
             )));
         }
-        if path.is_file() {
-            let canonical = std::fs::canonicalize(path).map_err(|e| {
-                Error::Resolve(format!("Failed to canonicalize {}: {e}", path.display()))
-            })?;
+        let canonical = std::fs::canonicalize(path).map_err(|e| {
+            Error::Resolve(format!("Failed to canonicalize {}: {e}", path.display()))
+        })?;
+        if canonical.is_file() {
             files.push(canonical);
-        } else if path.is_dir() {
-            dirs.push(path);
+        } else if canonical.is_dir() {
+            dirs.push(canonical);
         }
     }
 
     // When force_exclude is enabled, apply exclude patterns to explicitly-passed files too.
-    if config.force_exclude
-        && !files.is_empty()
-        && let Some(root) = dirs
-            .first()
-            .copied()
-            .or_else(|| files.first().and_then(|f| f.parent()))
-    {
-        let overrides = build_overrides(root, config)?;
+    if config.force_exclude && !files.is_empty() {
+        let matcher = build_exclude_matcher(config)?;
         let len_before = files.len();
         files.retain(|file| {
-            let dominated = overrides.matched(file, false);
-            if dominated.is_ignore() {
+            if is_excluded(&matcher, file) {
                 debug!("Force-excluded: {}", file.display());
                 false
             } else {
@@ -185,7 +211,7 @@ pub fn resolve_files(
     // Walk all directories with a single parallel WalkBuilder.
     if let Some((first, rest)) = dirs.split_first() {
         let types = build_types(config)?;
-        let overrides = build_overrides(first, config)?;
+        let overrides = build_overrides(config)?;
 
         let mut builder = WalkBuilder::new(first);
         for dir in rest {
@@ -342,7 +368,8 @@ mod tests {
 
     #[test]
     fn test_defaults() {
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config =
+            ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), Path::new("."));
         assert_eq!(
             config.include,
             vec!["*.html", "*.jinja", "*.jinja2", "*.j2"]
@@ -359,7 +386,7 @@ mod tests {
             exclude: Some(vec!["custom_dir".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, Path::new("."));
         assert_eq!(config.exclude, vec!["custom_dir"]);
     }
 
@@ -369,7 +396,7 @@ mod tests {
             extend_exclude: Some(vec!["vendor".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, Path::new("."));
         assert!(config.exclude.contains(&".git".to_string()));
         assert!(config.exclude.contains(&"vendor".to_string()));
     }
@@ -384,7 +411,7 @@ mod tests {
             exclude: Some(vec!["should_be_replaced".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject, Path::new("."));
         assert_eq!(config.exclude, vec!["migrations"]);
     }
 
@@ -398,7 +425,7 @@ mod tests {
             extend_exclude: Some(vec!["pyproject_extra".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject, Path::new("."));
         assert!(config.exclude.contains(&"pyproject_extra".to_string()));
         assert!(config.exclude.contains(&"cli_extra".to_string()));
     }
@@ -414,7 +441,7 @@ mod tests {
             extend_exclude: Some(vec!["build".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject, Path::new("."));
         assert!(config.exclude.contains(&"migrations".to_string()));
         assert!(config.exclude.contains(&"build".to_string()));
         assert!(config.exclude.contains(&"vendor".to_string()));
@@ -427,7 +454,7 @@ mod tests {
             include: Some(vec!["*.txt".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, Path::new("."));
         assert_eq!(config.include, vec!["*.txt"]);
     }
 
@@ -437,7 +464,7 @@ mod tests {
             extend_include: Some(vec!["*.djhtml".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, Path::new("."));
         assert_eq!(
             config.include,
             vec!["*.html", "*.jinja", "*.jinja2", "*.j2", "*.djhtml"]
@@ -450,7 +477,7 @@ mod tests {
             respect_gitignore: Some(false),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, Path::new("."));
         assert!(!config.respect_gitignore);
     }
 
@@ -464,7 +491,7 @@ mod tests {
             respect_gitignore: Some(true),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&cli, &pyproject, Path::new("."));
         assert!(!config.respect_gitignore);
     }
 
@@ -477,7 +504,7 @@ mod tests {
         create_file(dir.path(), "d.py");
         create_file(dir.path(), "e.css");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         let names = file_names(&files);
@@ -495,7 +522,7 @@ mod tests {
         fs::create_dir_all(&excluded_dir).unwrap();
         create_file(dir.path(), ".venv/template.html");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let explicit_file = excluded_dir.join("template.html");
         let files = resolve_files(&[explicit_file], &config).unwrap();
 
@@ -508,7 +535,7 @@ mod tests {
         create_file(dir.path(), "good.html");
         create_file(dir.path(), ".venv/bad.html");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         let names = file_names(&files);
@@ -528,7 +555,7 @@ mod tests {
         create_file(dir.path(), "included.html");
         create_file(dir.path(), "ignored/excluded.html");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         let names = file_names(&files);
@@ -552,7 +579,7 @@ mod tests {
             respect_gitignore: Some(false),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         let names = file_names(&files);
@@ -563,14 +590,15 @@ mod tests {
     #[test]
     fn test_resolve_files_empty_directory() {
         let dir = tempdir().unwrap();
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
         assert!(files.is_empty());
     }
 
     #[test]
     fn test_resolve_files_nonexistent_path_errors() {
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config =
+            ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), Path::new("."));
         let result = resolve_files(&[PathBuf::from("/nonexistent/path")], &config);
         assert!(result.is_err());
     }
@@ -582,7 +610,7 @@ mod tests {
         create_file(dir.path(), "sub/nested.html");
         create_file(dir.path(), "sub/deep/deeper.jinja2");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
         assert_eq!(files.len(), 3);
     }
@@ -597,7 +625,7 @@ mod tests {
             include: Some(vec!["*.txt".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         let names = file_names(&files);
@@ -610,7 +638,7 @@ mod tests {
         let dir = tempdir().unwrap();
         create_file(dir.path(), "a.html");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let explicit = dir.path().join("a.html");
         let files = resolve_files(&[dir.path().to_path_buf(), explicit], &config).unwrap();
         assert_eq!(files.len(), 1);
@@ -623,7 +651,7 @@ mod tests {
         create_file(dir.path(), "a.html");
         create_file(dir.path(), "b.html");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         let names = file_names(&files);
@@ -639,7 +667,7 @@ mod tests {
             include: Some(vec!["[invalid".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject);
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &pyproject, dir.path());
         let result = resolve_files(&[dir.path().to_path_buf()], &config);
         assert!(result.is_err());
     }
@@ -658,7 +686,7 @@ mod tests {
         create_file(dir.path(), "sub/included.html");
         create_file(dir.path(), "sub/ignored_nested/excluded.html");
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         let names = file_names(&files);
@@ -677,7 +705,7 @@ mod tests {
             exclude: Some(vec!["b.html".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&cli, &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&cli, &default_pyproject(), dir.path());
         let files = resolve_files(
             &[dir.path().join("a.html"), dir.path().join("b.html")],
             &config,
@@ -690,6 +718,23 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_files_force_exclude_keeps_files_outside_project_root() {
+        // Root-anchored patterns can't apply outside the project root: keep the file.
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        create_file(outside.path(), ".venv/a.html");
+
+        let cli = FileSelectionArgs {
+            force_exclude: true,
+            ..Default::default()
+        };
+        let config = ResolvedDiscoveryConfig::new(&cli, &default_pyproject(), root.path());
+        let files = resolve_files(&[outside.path().join(".venv/a.html")], &config).unwrap();
+
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
     fn test_resolve_files_no_force_exclude_keeps_explicit_files() {
         let dir = tempdir().unwrap();
         create_file(dir.path(), "a.html");
@@ -699,7 +744,7 @@ mod tests {
             exclude: Some(vec!["b.html".to_string()]),
             ..Default::default()
         };
-        let config = ResolvedDiscoveryConfig::new(&cli, &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&cli, &default_pyproject(), dir.path());
         let files = resolve_files(
             &[dir.path().join("a.html"), dir.path().join("b.html")],
             &config,
@@ -717,7 +762,7 @@ mod tests {
         std::os::unix::fs::symlink(dir.path().join("real_dir"), dir.path().join("link_dir"))
             .unwrap();
 
-        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject());
+        let config = ResolvedDiscoveryConfig::new(&default_cli(), &default_pyproject(), dir.path());
         let files = resolve_files(&[dir.path().to_path_buf()], &config).unwrap();
 
         assert!(

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -108,6 +108,49 @@ fn format_directory() {
 }
 
 #[test]
+fn format_force_exclude_skips_file_in_excluded_dir() {
+    // Pre-commit passes explicit paths: force-exclude must also match files
+    // through an excluded parent directory (here the default `.venv`).
+    let original = "<div   ></div>\n";
+    let project = Project::new()
+        .file("pyproject.toml", "[tool.djangofmt]\nforce-exclude = true\n")
+        .file(".venv/lib/tpl.html", original);
+    assert_cmd_snapshot!(
+        cli().current_dir(project.path()).arg(".venv/lib/tpl.html"),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "#);
+    assert_eq!(project.read(".venv/lib/tpl.html"), original);
+}
+
+#[test]
+fn format_exclude_anchors_at_project_root() {
+    // `templates/vendor` anchors at the pyproject.toml directory, not at the
+    // first CLI path: it must still apply when the walk starts in `templates`.
+    let original = "<div   ></div>\n";
+    let project = Project::new()
+        .file(
+            "pyproject.toml",
+            "[tool.djangofmt]\nextend-exclude = [\"templates/vendor\"]\n",
+        )
+        .file("templates/page.html", original)
+        .file("templates/vendor/lib.html", original);
+    assert_cmd_snapshot!(cli().current_dir(project.path()).arg("templates"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    1 file reformatted !
+    "#);
+    assert_eq!(project.read("templates/vendor/lib.html"), original);
+}
+
+#[test]
 fn format_quiet() {
     let project = Project::new().file("test.html", "<div   ></div>\n");
     assert_cmd_snapshot!(cli().arg("-q").arg(project.join("test.html")), @r#"


### PR DESCRIPTION
`force-exclude` never excluded explicitly-passed files inside excluded directories: `Override::matched` doesn't match a file through a parent-directory pattern, and every `DEFAULT_EXCLUDE` entry is a directory name — so under pre-commit, `djangofmt .venv/lib/tpl.html` happily reformatted the file. Exclude matchers were also anchored at the first CLI path instead of the project root, so `extend-exclude = ["templates/vendor"]` worked with `djangofmt .` but not `djangofmt templates`, and force-exclude results depended on argument order.

All exclude matchers are now anchored at the project root (the `pyproject.toml` directory), and explicit files / `--stdin-filename` are matched with `Gitignore::matched_path_or_any_parents` so parent-directory patterns apply. Files outside the project root are simply kept.
