### PR TITLE
fix(lint): detect whitespace-padded URLs in django-static-url and django-url-pattern

### DIFF
--- a/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
@@ -110,7 +110,11 @@ fn report_static_path(url: &str, offset: usize, attribute: &'static str, checker
     if contains_interpolation(url) {
         return;
     }
-    if starts_with_static_path(url) {
-        checker.report_diagnostic(&DjangoStaticUrl { attribute }, span(offset, url.len()));
+    // Browsers strip surrounding ASCII whitespace when resolving URL attributes.
+    let trimmed = url.trim_ascii_start();
+    let offset = offset + url.len() - trimmed.len();
+    let trimmed = trimmed.trim_ascii_end();
+    if starts_with_static_path(trimmed) {
+        checker.report_diagnostic(&DjangoStaticUrl { attribute }, span(offset, trimmed.len()));
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
@@ -111,10 +111,7 @@ fn report_static_path(url: &str, offset: usize, attribute: &'static str, checker
         return;
     }
     // Browsers strip surrounding ASCII whitespace when resolving URL attributes.
-    let trimmed = url.trim_ascii_start();
-    let offset = offset + url.len() - trimmed.len();
-    let trimmed = trimmed.trim_ascii_end();
-    if starts_with_static_path(trimmed) {
-        checker.report_diagnostic(&DjangoStaticUrl { attribute }, span(offset, trimmed.len()));
+    if starts_with_static_path(url.trim_ascii()) {
+        checker.report_diagnostic(&DjangoStaticUrl { attribute }, span(offset, url.len()));
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
@@ -91,12 +91,16 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
     if contains_interpolation(value_str) {
         return;
     }
-    if is_hardcoded_internal_path(value_str) {
+    // Browsers strip surrounding ASCII whitespace when resolving URL attributes.
+    let trimmed = value_str.trim_ascii_start();
+    let offset = offset + value_str.len() - trimmed.len();
+    let trimmed = trimmed.trim_ascii_end();
+    if is_hardcoded_internal_path(trimmed) {
         checker.report_diagnostic(
             &DjangoUrlPattern {
                 attribute: canonical,
             },
-            span(*offset, value_str.len()),
+            span(offset, trimmed.len()),
         );
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
@@ -92,15 +92,12 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
         return;
     }
     // Browsers strip surrounding ASCII whitespace when resolving URL attributes.
-    let trimmed = value_str.trim_ascii_start();
-    let offset = offset + value_str.len() - trimmed.len();
-    let trimmed = trimmed.trim_ascii_end();
-    if is_hardcoded_internal_path(trimmed) {
+    if is_hardcoded_internal_path(value_str.trim_ascii()) {
         checker.report_diagnostic(
             &DjangoUrlPattern {
                 attribute: canonical,
             },
-            span(offset, trimmed.len()),
+            span(*offset, value_str.len()),
         );
     }
 }

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.html
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.html
@@ -29,3 +29,6 @@
 {% if show_logo %}
     <img src="/static/img/logo.png" alt="" width="0" height="0">
 {% endif %}
+
+<!-- Browsers strip surrounding whitespace, so a padded value still resolves the static path -->
+<img src=" /static/img/logo.png " alt="" width="0" height="0">

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
@@ -152,10 +152,10 @@ source: crates/djangofmt_lint/tests/check/main.rs
   help: Use `{% static 'path/to/file' %}` instead.
 
   × Hardcoded static path in `src`.
-    ╭─[tests/check/django_static_url/django_static_url.invalid.html:34:12]
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:34:11]
  33 │ <!-- Browsers strip surrounding whitespace, so a padded value still resolves the static path -->
  34 │ <img src=" /static/img/logo.png " alt="" width="0" height="0">
-    ·            ──────────┬─────────
+    ·           ───────────┬──────────
     ·                      ╰── here
     ╰────
   help: Use `{% static 'path/to/file' %}` instead.

--- a/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/django_static_url/django_static_url.invalid.snap
@@ -150,3 +150,12 @@ source: crates/djangofmt_lint/tests/check/main.rs
  31 │ {% endif %}
     ╰────
   help: Use `{% static 'path/to/file' %}` instead.
+
+  × Hardcoded static path in `src`.
+    ╭─[tests/check/django_static_url/django_static_url.invalid.html:34:12]
+ 33 │ <!-- Browsers strip surrounding whitespace, so a padded value still resolves the static path -->
+ 34 │ <img src=" /static/img/logo.png " alt="" width="0" height="0">
+    ·            ──────────┬─────────
+    ·                      ╰── here
+    ╰────
+  help: Use `{% static 'path/to/file' %}` instead.

--- a/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.html
+++ b/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.html
@@ -51,3 +51,6 @@
 <a href="/gaz-propane-en-citerne/">Propane</a>
 <a href="/devenir-partenaire">Become a partner</a>
 <form method="post" action="/widgetform?form_type=keyword_city"></form>
+
+<!-- Browsers strip surrounding whitespace, so a padded value still resolves the internal path -->
+<a href=" /profile/ ">Profile</a>

--- a/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.snap
@@ -237,5 +237,15 @@ source: crates/djangofmt_lint/tests/check/main.rs
  53 │ <form method="post" action="/widgetform?form_type=keyword_city"></form>
     ·                             ─────────────────┬────────────────
     ·                                              ╰── here
+ 54 │ 
+    ╰────
+  help: Use `{% url 'view_name' %}` to reference a named URL pattern.
+
+  × Hardcoded internal URL in `href`.
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:56:11]
+ 55 │ <!-- Browsers strip surrounding whitespace, so a padded value still resolves the internal path -->
+ 56 │ <a href=" /profile/ ">Profile</a>
+    ·           ────┬────
+    ·               ╰── here
     ╰────
   help: Use `{% url 'view_name' %}` to reference a named URL pattern.

--- a/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/django_url_pattern/django_url_pattern.invalid.snap
@@ -242,10 +242,10 @@ source: crates/djangofmt_lint/tests/check/main.rs
   help: Use `{% url 'view_name' %}` to reference a named URL pattern.
 
   × Hardcoded internal URL in `href`.
-    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:56:11]
+    ╭─[tests/check/django_url_pattern/django_url_pattern.invalid.html:56:10]
  55 │ <!-- Browsers strip surrounding whitespace, so a padded value still resolves the internal path -->
  56 │ <a href=" /profile/ ">Profile</a>
-    ·           ────┬────
+    ·          ─────┬─────
     ·               ╰── here
     ╰────
   help: Use `{% url 'view_name' %}` to reference a named URL pattern.


### PR DESCRIPTION
Browsers strip surrounding ASCII whitespace when resolving URL attributes, but `django-static-url` and `django-url-pattern` matched the raw value — `src=" /static/img/logo.png"` and `href=" /profile/"` were silently skipped while the unpadded values were flagged.

Both rules now trim ASCII whitespace before matching (as `use_https` already does). The diagnostic span covers the full attribute value, padding included.