### PR TITLE
fix(format): Keep the opening tag of an ignored nested block tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=6345c548496168903cd4a06ed6321556436992d0#6345c548496168903cd4a06ed6321556436992d0"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=2f7e5c1fc609c6dd90339d85dc823e5b12a78cae#2f7e5c1fc609c6dd90339d85dc823e5b12a78cae"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ insta-cmd = { version = "0.7.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "6345c548496168903cd4a06ed6321556436992d0"
+  rev = "2f7e5c1fc609c6dd90339d85dc823e5b12a78cae"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/crates/djangofmt/tests/fmt/ignore/ignore_block_tag_inside_block.html
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_block_tag_inside_block.html
@@ -1,0 +1,10 @@
+{% if outer %}
+    {# djangofmt:ignore #}
+    {% verbatim %}
+        <p     class="unformatted"      >{{s|signature}}</p>
+    {% endverbatim %}
+    {# djangofmt:ignore #}
+    {% if inner %}
+        <p     class="unformatted"      >a</p>
+    {% endif %}
+{% endif %}

--- a/crates/djangofmt/tests/fmt/ignore/ignore_block_tag_inside_block.snap
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_block_tag_inside_block.snap
@@ -1,0 +1,13 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+{% if outer %}
+    {# djangofmt:ignore #}
+    {% verbatim %}
+        <p     class="unformatted"      >{{s|signature}}</p>
+    {% endverbatim %}
+    {# djangofmt:ignore #}
+    {% if inner %}
+        <p     class="unformatted"      >a</p>
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
`{# djangofmt:ignore #}` before a block tag nested in another block (e.g. `{% verbatim %}` inside `{% if %}`) dropped the opening tag, because the parser recorded the node's raw slice after that tag was already consumed. 

Fixed in markup_fmt. This just bump the pin.