### PR TITLE
feat(lint): Add `{# djangofmt: ignore[rule] #}` suppression comments

### DIFF
--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -173,15 +173,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         nb_parse_errors,
     );
 
-    // Surface files quarantined via `file-ignore[invalid-syntax]`, mirroring
-    // the format command's skip counter.
-    let skipped_count = results.iter().filter(|result| result.skipped).count();
-    if skipped_count > 0 {
-        info!(
-            "{skipped_count} file{} skipped !",
-            if skipped_count == 1 { "" } else { "s" }
-        );
-    }
+    print_skipped(&results);
 
     if config.show_fixes && total_applied > 0 {
         print_show_fixes(&results, total_applied);
@@ -286,6 +278,18 @@ fn print_summary(
         info!("Found {total} errors. ({hidden} hidden fixes can be enabled with --unsafe-fixes)");
     } else {
         info!("Found {total} errors.");
+    }
+}
+
+/// Surface files quarantined via `file-ignore[invalid-syntax]`, mirroring
+/// the format command's skip counter.
+fn print_skipped(results: &[CheckResult]) {
+    let skipped = results.iter().filter(|result| result.skipped).count();
+    if skipped > 0 {
+        info!(
+            "{skipped} file{} skipped !",
+            if skipped == 1 { "" } else { "s" }
+        );
     }
 }
 

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,6 +1,6 @@
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings,
-    file_ignores_invalid_syntax, lint_fix, lint_source,
+    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings, file_ignores, lint_fix,
+    lint_source,
 };
 use markup_fmt::FormatError;
 use miette::{SourceCode, SpanContents};
@@ -16,7 +16,7 @@ use tracing::{debug, error, info, warn};
 use crate::ExitStatus;
 use crate::args::{CheckCommand, OutputFormat, Profile};
 use crate::config::{resolve_bool_arg, resolve_profile, resolve_rule_selection};
-use crate::error::{CommandError, ParseError, Result};
+use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
 use crate::fs::relativize_path;
 use crate::per_file_ignores::PerFileIgnores;
 use crate::pyproject::LintSettings;
@@ -397,8 +397,6 @@ fn check_path(
     })
 }
 
-const PARSE_ERROR_HINT: &str = "Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of this file, or list it in `extend-exclude`, to skip it.";
-
 /// Handle a parse failure: a top-level `{# djangofmt: file-ignore[invalid-syntax] #}`
 /// directive skips the file entirely, otherwise the error is reported with a
 /// hint pointing at the available escape hatches.
@@ -407,7 +405,7 @@ fn parse_failure(
     source: String,
     err: markup_fmt::SyntaxError,
 ) -> std::result::Result<CheckResult, Box<CommandError>> {
-    if file_ignores_invalid_syntax(&source) {
+    if file_ignores(&source).invalid_syntax {
         debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
         return Ok(CheckResult {
             path: path.to_path_buf(),
@@ -419,7 +417,7 @@ fn parse_failure(
     }
     Err(Box::new(CommandError::Parse(
         ParseError::new(Some(path.to_path_buf()), source, &FormatError::Syntax(err))
-            .with_hint(PARSE_ERROR_HINT),
+            .with_hint(SKIP_FILE_HINT),
     )))
 }
 

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -281,8 +281,7 @@ fn print_summary(
     }
 }
 
-/// Surface files quarantined via `file-ignore[invalid-syntax]`, mirroring
-/// the format command's skip counter.
+/// Mirror the format command's skip counter for quarantined files.
 fn print_skipped(results: &[CheckResult]) {
     let skipped = results.iter().filter(|result| result.skipped).count();
     if skipped > 0 {
@@ -401,9 +400,8 @@ fn check_path(
     })
 }
 
-/// Handle a parse failure: a top-level `{# djangofmt: file-ignore[invalid-syntax] #}`
-/// directive skips the file entirely, otherwise the error is reported with a
-/// hint pointing at the available escape hatches.
+/// Skip the file if it is quarantined with `file-ignore[invalid-syntax]`,
+/// otherwise report the error with a hint at the escape hatches.
 fn parse_failure(
     path: &Path,
     source: String,

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,5 +1,6 @@
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings, lint_fix, lint_source,
+    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings,
+    file_ignores_invalid_syntax, lint_fix, lint_source,
 };
 use markup_fmt::FormatError;
 use miette::{SourceCode, SpanContents};
@@ -67,6 +68,8 @@ struct CheckResult {
     applied_count: usize,
     /// Per-rule applied summaries, for `--show-fixes`.
     fixes_by_rule: FxHashMap<&'static str, RuleFixSummary>,
+    /// Whether the file was skipped via `file-ignore[invalid-syntax]`.
+    skipped: bool,
 }
 
 /// Check the given source code for linting errors.
@@ -169,6 +172,16 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         config.unsafe_fixes,
         nb_parse_errors,
     );
+
+    // Surface files quarantined via `file-ignore[invalid-syntax]`, mirroring
+    // the format command's skip counter.
+    let skipped_count = results.iter().filter(|result| result.skipped).count();
+    if skipped_count > 0 {
+        info!(
+            "{skipped_count} file{} skipped !",
+            if skipped_count == 1 { "" } else { "s" }
+        );
+    }
 
     if config.show_fixes && total_applied > 0 {
         print_show_fixes(&results, total_applied);
@@ -343,14 +356,11 @@ fn check_path(
                     file_diagnostics,
                     applied_count: result.applied_count,
                     fixes_by_rule: result.applied_by_rule,
+                    skipped: false,
                 });
             }
             Err(FixerError::InitialParse(err)) => {
-                return Err(Box::new(CommandError::Parse(ParseError::new(
-                    Some(path.to_path_buf()),
-                    source,
-                    &FormatError::Syntax(err),
-                ))));
+                return parse_failure(path, source, err);
             }
             Err(FixerError::SyntaxRegression {
                 iteration,
@@ -369,11 +379,7 @@ fn check_path(
         match lint_source(&source, profile.into(), custom_blocks, settings, Some(path)) {
             Ok(diagnostics) => diagnostics,
             Err(err) => {
-                return Err(Box::new(CommandError::Parse(ParseError::new(
-                    Some(path.to_path_buf()),
-                    source,
-                    &FormatError::Syntax(err),
-                ))));
+                return parse_failure(path, source, err);
             }
         };
     let file_diagnostics = if diagnostics.is_empty() {
@@ -387,7 +393,34 @@ fn check_path(
         file_diagnostics,
         applied_count: 0,
         fixes_by_rule: FxHashMap::default(),
+        skipped: false,
     })
+}
+
+const PARSE_ERROR_HINT: &str = "Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of this file, or list it in `extend-exclude`, to skip it.";
+
+/// Handle a parse failure: a top-level `{# djangofmt: file-ignore[invalid-syntax] #}`
+/// directive skips the file entirely, otherwise the error is reported with a
+/// hint pointing at the available escape hatches.
+fn parse_failure(
+    path: &Path,
+    source: String,
+    err: markup_fmt::SyntaxError,
+) -> std::result::Result<CheckResult, Box<CommandError>> {
+    if file_ignores_invalid_syntax(&source) {
+        debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
+        return Ok(CheckResult {
+            path: path.to_path_buf(),
+            file_diagnostics: FileDiagnostics::empty(),
+            applied_count: 0,
+            fixes_by_rule: FxHashMap::default(),
+            skipped: true,
+        });
+    }
+    Err(Box::new(CommandError::Parse(
+        ParseError::new(Some(path.to_path_buf()), source, &FormatError::Syntax(err))
+            .with_hint(PARSE_ERROR_HINT),
+    )))
 }
 
 #[cfg(test)]

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -1,3 +1,4 @@
+use djangofmt_lint::file_ignores;
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::borrow::Cow;
@@ -11,7 +12,7 @@ use crate::ExitStatus;
 use crate::args::{FormatCommand, OutputFormat, Profile};
 use crate::config::{resolve_bool_arg, resolve_profile};
 use crate::editorconfig::{self, EditorconfigSettings};
-use crate::error::{CommandError, ParseError, Result};
+use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 use crate::pyproject::PyprojectSettings;
 use editorconfig_parser::EditorConfig;
@@ -109,14 +110,7 @@ pub(crate) fn merge_custom_blocks(
     }
 }
 
-macro_rules! ignore_directive {
-    () => {
-        "djangofmt:ignore"
-    };
-}
-const DJANGOFMT_IGNORE_COMMENT_DIRECTIVE: &str = ignore_directive!();
-const DJANGOFMT_IGNORE_COMMENT: &str = concat!("<!-- ", ignore_directive!(), " -->");
-const DJANGOFMT_IGNORE_COMMENT_JINJA: &str = concat!("{# ", ignore_directive!(), " #}");
+const DJANGOFMT_IGNORE_COMMENT_DIRECTIVE: &str = "djangofmt:ignore";
 
 /// Build default `markup_fmt` options for HTML/Jinja formatting.
 #[must_use]
@@ -317,12 +311,11 @@ pub fn format_text(
     config: &FormatterConfig,
     profile: Profile,
 ) -> std::result::Result<Option<String>, markup_fmt::FormatError> {
-    if source.starts_with(DJANGOFMT_IGNORE_COMMENT)
-        || source.starts_with(DJANGOFMT_IGNORE_COMMENT_JINJA)
-    {
+    let ignores = file_ignores(source);
+    if ignores.format {
         return Ok(None);
     }
-    markup_fmt::format_text(
+    let result = markup_fmt::format_text(
         source,
         markup_fmt::Language::from(profile),
         &config.markup,
@@ -377,8 +370,13 @@ pub fn format_text(
                 _ => Ok(code.into()),
             }
         },
-    )
-    .map(Some)
+    );
+    match result {
+        // A file quarantined with `file-ignore[invalid-syntax]` is skipped
+        // rather than reported when it indeed fails to parse.
+        Err(markup_fmt::FormatError::Syntax(_)) if ignores.invalid_syntax => Ok(None),
+        other => other.map(Some),
+    }
 }
 
 /// Format the file at the given [`Path`].
@@ -395,11 +393,10 @@ fn format_path(
     let formatted = match format_text(&unformatted, &config, profile) {
         Ok(f) => f,
         Err(err) => {
-            return Err(Box::new(CommandError::Parse(ParseError::new(
-                Some(path.to_path_buf()),
-                unformatted,
-                &err,
-            ))));
+            return Err(Box::new(CommandError::Parse(
+                ParseError::new(Some(path.to_path_buf()), unformatted, &err)
+                    .with_hint(SKIP_FILE_HINT),
+            )));
         }
     };
 

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -372,8 +372,7 @@ pub fn format_text(
         },
     );
     match result {
-        // A file quarantined with `file-ignore[invalid-syntax]` is skipped
-        // rather than reported when it indeed fails to parse.
+        // `file-ignore[invalid-syntax]` quarantines the file instead of reporting.
         Err(markup_fmt::FormatError::Syntax(_)) if ignores.invalid_syntax => Ok(None),
         other => other.map(Some),
     }

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -8,7 +8,7 @@ use crate::args::{FormatCommand, Profile};
 use crate::commands::format::{FormatterConfig, format_text};
 use crate::config::resolve_profile;
 use crate::editorconfig;
-use crate::error::{CommandError, ParseError, Result};
+use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
 use crate::pyproject::load_pyproject_from_cwd;
 use crate::resolver::{ResolvedDiscoveryConfig, is_force_excluded};
 
@@ -59,11 +59,10 @@ fn format_source_code(
     let formatted = match format_text(&source, config, profile) {
         Ok(f) => f,
         Err(err) => {
-            return Err(Box::new(CommandError::Parse(ParseError::new(
-                path.map(Path::to_path_buf),
-                source,
-                &err,
-            ))));
+            return Err(Box::new(CommandError::Parse(
+                ParseError::new(path.map(Path::to_path_buf), source, &err)
+                    .with_hint(SKIP_FILE_HINT),
+            )));
         }
     };
 

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -142,7 +142,7 @@ impl ParseError {
         }
     }
 
-    /// Append a help line to the error, preserving any existing hint.
+    /// Append a help line to the error, keeping any existing hint.
     #[must_use]
     pub fn with_hint(mut self, hint: &str) -> Self {
         self.hint = Some(self.hint.take().map_or_else(

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -139,6 +139,16 @@ impl ParseError {
         }
     }
 
+    /// Append a help line to the error, preserving any existing hint.
+    #[must_use]
+    pub fn with_hint(mut self, hint: &str) -> Self {
+        self.hint = Some(self.hint.take().map_or_else(
+            || hint.to_string(),
+            |existing| format!("{existing}\n{hint}"),
+        ));
+        self
+    }
+
     /// 1-based line and column the error points at.
     fn location(&self) -> (usize, usize) {
         self.src

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -91,6 +91,9 @@ impl CommandError {
     }
 }
 
+/// Escape hatches suggested when a file cannot be parsed.
+pub const SKIP_FILE_HINT: &str = "Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of this file, or list it in `extend-exclude`, to skip it.";
+
 impl ParseError {
     #[must_use]
     pub fn new(path: Option<PathBuf>, source: String, err: &markup_fmt::FormatError) -> Self {

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -656,30 +656,6 @@ fn check_skips_unparsable_files_that_opted_out() {
 }
 
 #[test]
-fn check_unparsable_file_reports_error_with_hint() {
-    let project = Project::new().file("test.html", "<div id=>\n</div>\n");
-    assert_cmd_snapshot_tmpdir!(cli().arg("check").arg(project.join("test.html")), @r##"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-
-      × expected attribute value
-       ╭─[[TMP]/test.html:1:9]
-     1 │ <div id=>
-       ·         ▲
-       ·         ╰── here
-     2 │ </div>
-       ╰────
-      help: Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
-            this file, or list it in `extend-exclude`, to skip it.
-
-    Couldn't check 1 files!
-    "##);
-}
-
-#[test]
 fn check_malformed_file_with_fix_surfaces_parse_error() {
     let project = Project::new().file("test.html", "{% if x %}\n  unclosed\n");
     assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r##"

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -80,21 +80,6 @@ fn format_file_with_jinja_ignore_directive() {
 }
 
 #[test]
-fn format_file_with_file_ignore_format_directive() {
-    let original = "{# djangofmt: file-ignore[format] #}\n<div   class=\"foo\"  ></div>\n";
-    let project = Project::new().file("test.html", original);
-    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    1 file skipped !
-    "#);
-    assert_eq!(project.read("test.html"), original);
-}
-
-#[test]
 fn format_unparsable_file_with_invalid_syntax_file_ignore() {
     let original = "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n";
     let project = Project::new().file("test.html", original);
@@ -650,36 +635,23 @@ fn check_fixable_file_with_show_fixes() {
 }
 
 #[test]
-fn check_unparsable_file_with_invalid_syntax_file_ignore() {
-    // `file-ignore[invalid-syntax]` at the top of the file skips it entirely,
-    // even though it cannot be parsed.
-    let project = Project::new().file(
-        "test.html",
-        "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n",
-    );
-    assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r###"
+fn check_skips_unparsable_files_that_opted_out() {
+    // Both the explicit code and the legacy bare directive (#373) skip a file
+    // `check` cannot parse.
+    let project = Project::new()
+        .file(
+            "bracketed.html",
+            "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n",
+        )
+        .file("legacy.html", "{# djangofmt:ignore #}\n<div id=>\n</div>\n");
+    assert_cmd_snapshot!(cli().arg("check").arg(project.path()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     All checks passed!
-    1 file skipped !
-    "###);
-}
-
-#[test]
-fn check_unparsable_file_with_legacy_ignore_directive() {
-    // The legacy bare directive keeps skipping unparsable files, in `check` too (#373).
-    let project = Project::new().file("test.html", "{# djangofmt:ignore #}\n<div id=>\n</div>\n");
-    assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    All checks passed!
-    1 file skipped !
+    2 files skipped !
     "###);
 }
 

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -80,6 +80,36 @@ fn format_file_with_jinja_ignore_directive() {
 }
 
 #[test]
+fn format_file_with_file_ignore_format_directive() {
+    let original = "{# djangofmt: file-ignore[format] #}\n<div   class=\"foo\"  ></div>\n";
+    let project = Project::new().file("test.html", original);
+    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    1 file skipped !
+    "#);
+    assert_eq!(project.read("test.html"), original);
+}
+
+#[test]
+fn format_unparsable_file_with_invalid_syntax_file_ignore() {
+    let original = "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n";
+    let project = Project::new().file("test.html", original);
+    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    1 file skipped !
+    "#);
+    assert_eq!(project.read("test.html"), original);
+}
+
+#[test]
 fn format_nonexistent_file() {
     assert_cmd_snapshot!(cli().arg("/nonexistent/path.html"), @r#"
     success: false
@@ -165,7 +195,7 @@ fn format_quiet() {
 #[test]
 fn format_file_parse_error_exits_2() {
     let project = Project::new().file("test.html", "<div   class=\"foo\"  >");
-    assert_cmd_snapshot_tmpdir!(cli().arg(project.join("test.html")), @r###"
+    assert_cmd_snapshot_tmpdir!(cli().arg(project.join("test.html")), @r##"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -181,9 +211,11 @@ fn format_file_parse_error_exits_2() {
       help: If a `</div>` does exist, it must live in the same block as the
             opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
             limitations/#conditional-openclose-tags
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't format 1 files!
-    "###);
+    "##);
 }
 
 // ── Format from stdin ────────────────────────────────────────────────
@@ -306,7 +338,7 @@ fn format_stdin_jinja_ignore_directive() {
 fn format_stdin_parse_error_exits_2() {
     assert_cmd_snapshot!(
         cli().arg("-").pass_stdin("<div   class=\"foo\"  >"),
-        @r###"
+        @r##"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -322,7 +354,9 @@ fn format_stdin_parse_error_exits_2() {
       help: If a `</div>` does exist, it must live in the same block as the
             opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
             limitations/#conditional-openclose-tags
-    "###);
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
+    "##);
 }
 
 #[test]
@@ -623,6 +657,21 @@ fn check_unparsable_file_with_invalid_syntax_file_ignore() {
         "test.html",
         "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n",
     );
+    assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    1 file skipped !
+    "###);
+}
+
+#[test]
+fn check_unparsable_file_with_legacy_ignore_directive() {
+    // The legacy bare directive keeps skipping unparsable files, in `check` too (#373).
+    let project = Project::new().file("test.html", "{# djangofmt:ignore #}\n<div id=>\n</div>\n");
     assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r###"
     success: true
     exit_code: 0

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -616,9 +616,52 @@ fn check_fixable_file_with_show_fixes() {
 }
 
 #[test]
+fn check_unparsable_file_with_invalid_syntax_file_ignore() {
+    // `file-ignore[invalid-syntax]` at the top of the file skips it entirely,
+    // even though it cannot be parsed.
+    let project = Project::new().file(
+        "test.html",
+        "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n",
+    );
+    assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    1 file skipped !
+    "###);
+}
+
+#[test]
+fn check_unparsable_file_reports_error_with_hint() {
+    let project = Project::new().file("test.html", "<div id=>\n</div>\n");
+    assert_cmd_snapshot_tmpdir!(cli().arg("check").arg(project.join("test.html")), @r##"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+
+      × expected attribute value
+       ╭─[[TMP]/test.html:1:9]
+     1 │ <div id=>
+       ·         ▲
+       ·         ╰── here
+     2 │ </div>
+       ╰────
+      help: Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
+
+    Couldn't check 1 files!
+    "##);
+}
+
+#[test]
 fn check_malformed_file_with_fix_surfaces_parse_error() {
     let project = Project::new().file("test.html", "{% if x %}\n  unclosed\n");
-    assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r###"
+    assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r##"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -634,9 +677,11 @@ fn check_malformed_file_with_fix_surfaces_parse_error() {
        ╰────
       help: Check for invalid HTML syntax inside the block that might prevent
             finding the end tag.
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't check 1 files!
-    "###);
+    "##);
 }
 
 #[test]
@@ -649,7 +694,7 @@ fn check_respects_pyproject_custom_blocks() {
             "[tool.djangofmt]\ncustom-blocks = [\"stage\"]\n",
         )
         .file("test.html", "{% stage %}\n<p>hi</p>\n");
-    assert_cmd_snapshot!(cli().current_dir(project.path()).args(["check", "test.html"]), @r###"
+    assert_cmd_snapshot!(cli().current_dir(project.path()).args(["check", "test.html"]), @r##"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -665,9 +710,11 @@ fn check_respects_pyproject_custom_blocks() {
        ╰────
       help: Check for invalid HTML syntax inside the block that might prevent
             finding the end tag.
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't check 1 files!
-    "###);
+    "##);
 }
 
 #[test]

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.html
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.html
@@ -1,0 +1,8 @@
+{# djangofmt: file-ignore[format] #}
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>
+
+{# Broken code doesn't crash djangofmt either: file-ignore[format] skips before parsing #}
+<div id=>
+</div>

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.snap
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.snap
@@ -1,0 +1,11 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+{# djangofmt: file-ignore[format] #}
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>
+
+{# Broken code doesn't crash djangofmt either: file-ignore[format] skips before parsing #}
+<div id=>
+</div>

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.html
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.html
@@ -1,0 +1,2 @@
+{# djangofmt: file-ignore[invalid-syntax] #}
+<p     class="reformatted"      >Parsable content is still formatted, the directive only quarantines parse errors</p>

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.snap
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.snap
@@ -1,0 +1,5 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+{# djangofmt: file-ignore[invalid-syntax] #}
+<p class="reformatted">Parsable content is still formatted, the directive only quarantines parse errors</p>

--- a/crates/djangofmt_dev/src/generate_rules_table.rs
+++ b/crates/djangofmt_dev/src/generate_rules_table.rs
@@ -46,6 +46,30 @@ To turn rules off for some files only, map a glob to the selectors to ignore the
 ```
 
 Every pattern is matched both against the file name and against the path relative to the directory holding `pyproject.toml`: `"*.jinja"` covers that extension at any depth, while `"emails/*.html"` is anchored at the project root (and, since `*` crosses `/`, covers nested files under `emails/` too). These are ruff's `per-file-ignores` semantics, so a block can be copied over unchanged.
+
+## Suppressing diagnostics
+
+Silence rules on a specific node with a `{# djangofmt: ignore[<rule>] #}` comment placed **immediately before** it. Anchoring to the following node (rather than a line) keeps the suppression attached to the right markup even after reformatting.
+
+```jinja
+{# djangofmt: ignore[invalid-attr-value] #}
+<form method="yes">Submit</form>
+```
+
+Suppress several rules at once with a comma-separated list:
+
+```jinja
+{# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
+<form method="yes" id=""></form>
+```
+
+Silence rules for a whole file with a `{# djangofmt: file-ignore[<rule>] #}` comment at the very top of the file:
+
+```jinja
+{# djangofmt: file-ignore[missing-img-alt] #}
+```
+
+Rules must always be listed explicitly: there is no blanket form, and only `{# #}` template comments carry directives — HTML comments survive in rendered output, so they are never a suppression. Lint suppression never affects formatting — the formatter has its own `{# djangofmt:ignore #}` directive.
 "#;
 
 fn render() -> String {

--- a/crates/djangofmt_dev/src/generate_rules_table.rs
+++ b/crates/djangofmt_dev/src/generate_rules_table.rs
@@ -49,27 +49,20 @@ Every pattern is matched both against the file name and against the path relativ
 
 ## Suppressing diagnostics
 
-Silence rules on a specific node with a `{# djangofmt: ignore[<rule>] #}` comment placed **immediately before** it. Anchoring to the following node (rather than a line) keeps the suppression attached to the right markup even after reformatting.
-
-```jinja
-{# djangofmt: ignore[invalid-attr-value] #}
-<form method="yes">Submit</form>
-```
-
-Suppress several rules at once with a comma-separated list:
+A `{# djangofmt: ignore[...] #}` comment silences the listed rules on the node that follows it. Anchoring to a node rather than a line keeps the suppression on the right markup across reformatting.
 
 ```jinja
 {# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
 <form method="yes" id=""></form>
 ```
 
-Silence rules for a whole file with a `{# djangofmt: file-ignore[<rule>] #}` comment at the very top of the file. Two special codes go beyond lint rules: `invalid-syntax` makes both commands skip a file they cannot parse, and `format` makes the formatter skip the file:
+A `{# djangofmt: file-ignore[...] #}` comment as the **first comment of the file** covers the whole file. It also accepts two codes that are not rules: `invalid-syntax` skips a file neither command can parse, and `format` skips the formatter.
 
 ```jinja
 {# djangofmt: file-ignore[invalid-syntax] #}
 ```
 
-Rules must always be listed explicitly: there is no blanket form, and only `{# #}` template comments carry directives — HTML comments survive in rendered output, so they are never a suppression. Node-level suppression never affects formatting — skip formatting a node with the formatter's `{# djangofmt:ignore #}` directive.
+Rules are always listed explicitly — there is no blanket form. Only `{# #}` comments carry directives, since HTML comments survive in rendered output. Suppression never affects formatting: skip formatting a node with the formatter's own `{# djangofmt:ignore #}` directive.
 "#;
 
 fn render() -> String {

--- a/crates/djangofmt_dev/src/generate_rules_table.rs
+++ b/crates/djangofmt_dev/src/generate_rules_table.rs
@@ -63,13 +63,13 @@ Suppress several rules at once with a comma-separated list:
 <form method="yes" id=""></form>
 ```
 
-Silence rules for a whole file with a `{# djangofmt: file-ignore[<rule>] #}` comment at the very top of the file. The special `invalid-syntax` rule suppresses parse errors, letting `djangofmt check` skip files it cannot parse:
+Silence rules for a whole file with a `{# djangofmt: file-ignore[<rule>] #}` comment at the very top of the file. Two special codes go beyond lint rules: `invalid-syntax` makes both commands skip a file they cannot parse, and `format` makes the formatter skip the file:
 
 ```jinja
 {# djangofmt: file-ignore[invalid-syntax] #}
 ```
 
-Rules must always be listed explicitly: there is no blanket form, and only `{# #}` template comments carry directives — HTML comments survive in rendered output, so they are never a suppression. Lint suppression never affects formatting — the formatter has its own `{# djangofmt:ignore #}` directive.
+Rules must always be listed explicitly: there is no blanket form, and only `{# #}` template comments carry directives — HTML comments survive in rendered output, so they are never a suppression. Node-level suppression never affects formatting — skip formatting a node with the formatter's `{# djangofmt:ignore #}` directive.
 "#;
 
 fn render() -> String {

--- a/crates/djangofmt_dev/src/generate_rules_table.rs
+++ b/crates/djangofmt_dev/src/generate_rules_table.rs
@@ -63,10 +63,10 @@ Suppress several rules at once with a comma-separated list:
 <form method="yes" id=""></form>
 ```
 
-Silence rules for a whole file with a `{# djangofmt: file-ignore[<rule>] #}` comment at the very top of the file:
+Silence rules for a whole file with a `{# djangofmt: file-ignore[<rule>] #}` comment at the very top of the file. The special `invalid-syntax` rule suppresses parse errors, letting `djangofmt check` skip files it cannot parse:
 
 ```jinja
-{# djangofmt: file-ignore[missing-img-alt] #}
+{# djangofmt: file-ignore[invalid-syntax] #}
 ```
 
 Rules must always be listed explicitly: there is no blanket form, and only `{# #}` template comments carry directives — HTML comments survive in rendered output, so they are never a suppression. Lint suppression never affects formatting — the formatter has its own `{# djangofmt:ignore #}` directive.

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -169,9 +169,8 @@ pub fn check_ast<'a>(
 ) -> Vec<LintDiagnostic> {
     let mut checker = Checker::new(source, settings, path);
     checker.visit_root(ast);
-    suppression::check_directives(ast, &checker);
-    let diagnostics = checker.into_diagnostics();
-    suppression::filter_suppressed(source, ast, diagnostics)
+    let suppressions = suppression::collect(source, ast, &checker);
+    suppression::filter(&suppressions, checker.into_diagnostics())
 }
 
 /// Parse `source`, treating each of `custom_blocks` as a `{% tag %}...{% endtag %}` block.

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -36,6 +36,7 @@ pub use registry::{Rule, RuleCategory, RuleGroup};
 pub use rule_selector::{RuleSelector, SelectionWarning, SelectorParseError};
 pub use rule_set::RuleSet;
 pub use settings::{LintConfiguration, Settings};
+pub use suppression::file_ignores_invalid_syntax;
 pub use violation::{Violation, ViolationMetadata};
 
 use std::borrow::Cow;

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -169,6 +169,7 @@ pub fn check_ast<'a>(
 ) -> Vec<LintDiagnostic> {
     let mut checker = Checker::new(source, settings, path);
     checker.visit_root(ast);
+    suppression::check_directives(ast, &checker);
     let diagnostics = checker.into_diagnostics();
     suppression::filter_suppressed(source, ast, diagnostics)
 }

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -36,7 +36,7 @@ pub use registry::{Rule, RuleCategory, RuleGroup};
 pub use rule_selector::{RuleSelector, SelectionWarning, SelectorParseError};
 pub use rule_set::RuleSet;
 pub use settings::{LintConfiguration, Settings};
-pub use suppression::file_ignores_invalid_syntax;
+pub use suppression::{FileIgnores, file_ignores};
 pub use violation::{Violation, ViolationMetadata};
 
 use std::borrow::Cow;

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -22,6 +22,7 @@ pub mod rule_selector;
 pub mod rule_set;
 mod rules;
 pub mod settings;
+mod suppression;
 mod violation;
 
 pub use checker::Checker;
@@ -167,7 +168,8 @@ pub fn check_ast<'a>(
 ) -> Vec<LintDiagnostic> {
     let mut checker = Checker::new(source, settings, path);
     checker.visit_root(ast);
-    checker.into_diagnostics()
+    let diagnostics = checker.into_diagnostics();
+    suppression::filter_suppressed(source, ast, diagnostics)
 }
 
 /// Parse `source`, treating each of `custom_blocks` as a `{% tag %}...{% endtag %}` block.

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -266,4 +266,5 @@ define_rules! {
     (UnsortedTailwindClasses, rules::style::unsorted_tailwind_classes::UnsortedTailwindClasses),
     (InvalidIgnoreComment, rules::suspicious::invalid_ignore_comment::InvalidIgnoreComment),
     (UnknownIgnoreCode, rules::suspicious::unknown_ignore_code::UnknownIgnoreCode),
+    (RedirectedIgnore, rules::style::redirected_ignore::RedirectedIgnore),
 }

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -264,4 +264,6 @@ define_rules! {
     (TableHeaderMissingScope, rules::accessibility::table_header_missing_scope::TableHeaderMissingScope),
     (SameFilePartialInclude, rules::style::same_file_partial_include::SameFilePartialInclude),
     (UnsortedTailwindClasses, rules::style::unsorted_tailwind_classes::UnsortedTailwindClasses),
+    (InvalidIgnoreComment, rules::suspicious::invalid_ignore_comment::InvalidIgnoreComment),
+    (UnknownIgnoreCode, rules::suspicious::unknown_ignore_code::UnknownIgnoreCode),
 }

--- a/crates/djangofmt_lint/src/rules/style/mod.rs
+++ b/crates/djangofmt_lint/src/rules/style/mod.rs
@@ -1,6 +1,7 @@
 pub mod empty_attr_value;
 pub mod form_action_whitespace;
 pub mod missing_doctype;
+pub mod redirected_ignore;
 pub mod redundant_type_attr;
 pub mod same_file_partial_include;
 pub mod unsorted_tailwind_classes;

--- a/crates/djangofmt_lint/src/rules/style/redirected_ignore.rs
+++ b/crates/djangofmt_lint/src/rules/style/redirected_ignore.rs
@@ -1,0 +1,69 @@
+use std::borrow::Cow;
+
+use crate::fix::{Edit, Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+use crate::{Checker, span};
+
+/// ## What it does
+/// Checks for djangofmt directives written in HTML comments, like `<!-- djangofmt:ignore -->`.
+///
+/// ## Why is this bad?
+/// HTML comments are shipped to the client, so the directive ends up in every rendered page.
+/// Worse, only `{# #}` template comments carry suppression directives: an HTML comment like
+/// `<!-- djangofmt: ignore[some-rule] -->` suppresses nothing. The template comment style works
+/// everywhere and is stripped at render time.
+///
+/// ## Example
+/// ```html
+/// <!-- djangofmt:ignore -->
+/// <div   class="keep-this-unformatted"   >Content</div>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {# djangofmt:ignore #}
+/// <div   class="keep-this-unformatted"   >Content</div>
+/// ```
+///
+/// ## Fix safety
+/// Marked as safe: djangofmt treats both comment styles the same, and the directive no longer
+/// leaks into rendered HTML.
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct RedirectedIgnore;
+
+impl Violation for RedirectedIgnore {
+    const RULE: Rule = Rule::RedirectedIgnore;
+    const CATEGORY: RuleCategory = RuleCategory::Style;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> Cow<'static, str> {
+        "djangofmt directive in an HTML comment.".into()
+    }
+
+    fn help(&self) -> Option<Cow<'static, str>> {
+        Some("Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.".into())
+    }
+
+    fn fix_title(&self) -> Option<&'static str> {
+        Some("Rewrite as a `{# #}` template comment")
+    }
+}
+
+/// Lint one HTML comment; `body` is its inner text and `comment_raw` the whole `<!-- -->` slice.
+pub fn check(body: &str, comment_raw: &str, checker: &Checker<'_>) {
+    if !body.trim_start().starts_with("djangofmt:") {
+        return;
+    }
+    let offset = checker.source_offset(comment_raw);
+    let range = span(offset, comment_raw.len());
+    let Some(mut guard) = checker.report_diagnostic_if_enabled(&RedirectedIgnore, range) else {
+        return;
+    };
+    guard.set_fix(Fix::safe_edit(Edit::replacement(
+        format!("{{#{body}#}}"),
+        range,
+    )));
+}

--- a/crates/djangofmt_lint/src/rules/style/redirected_ignore.rs
+++ b/crates/djangofmt_lint/src/rules/style/redirected_ignore.rs
@@ -9,10 +9,9 @@ use crate::{Checker, span};
 /// Checks for djangofmt directives written in HTML comments, like `<!-- djangofmt:ignore -->`.
 ///
 /// ## Why is this bad?
-/// HTML comments are shipped to the client, so the directive ends up in every rendered page.
-/// Worse, only `{# #}` template comments carry suppression directives: an HTML comment like
-/// `<!-- djangofmt: ignore[some-rule] -->` suppresses nothing. The template comment style works
-/// everywhere and is stripped at render time.
+/// HTML comments are shipped to the client, so the directive ends up in every rendered page. And
+/// only `{# #}` template comments carry suppression directives: `<!-- djangofmt: ignore[rule] -->`
+/// silences nothing.
 ///
 /// ## Example
 /// ```html
@@ -27,8 +26,8 @@ use crate::{Checker, span};
 /// ```
 ///
 /// ## Fix safety
-/// Marked as safe: djangofmt treats both comment styles the same, and the directive no longer
-/// leaks into rendered HTML.
+/// Marked as safe: the formatter treats both comment styles the same, and the directive stops
+/// leaking into rendered HTML.
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
 #[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct RedirectedIgnore;
@@ -44,7 +43,7 @@ impl Violation for RedirectedIgnore {
     }
 
     fn help(&self) -> Option<Cow<'static, str>> {
-        Some("Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.".into())
+        Some("Move the directive into a `{# #}` template comment: it is stripped at render time, and it is the only style suppressions are read from.".into())
     }
 
     fn fix_title(&self) -> Option<&'static str> {
@@ -52,7 +51,7 @@ impl Violation for RedirectedIgnore {
     }
 }
 
-/// Lint one HTML comment; `body` is its inner text and `comment_raw` the whole `<!-- -->` slice.
+/// Lint one HTML comment; `body` is its inner text, `comment_raw` the whole `<!-- -->` slice.
 pub fn check(body: &str, comment_raw: &str, checker: &Checker<'_>) {
     if !body.trim_start().starts_with("djangofmt:") {
         return;

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -21,11 +21,12 @@ pub enum IgnoreCommentViolation {
 /// Checks for `djangofmt:` suppression comments that are malformed or misplaced.
 ///
 /// ## Why is this bad?
-/// A suppression comment djangofmt does not recognize is silently skipped, so the diagnostics it
-/// was meant to silence keep firing — or the author believes something is suppressed when nothing
-/// is. This covers directives with a syntax error (missing brackets, an empty rule list, trailing
-/// text), a `file-ignore[...]` that is not the first comment in the file, and codes that only make
-/// sense file-wide (`invalid-syntax`, `format`) listed in a node-level `ignore[...]`.
+/// A directive djangofmt does not recognize is skipped silently, so the diagnostics it was meant to
+/// silence keep firing while the author believes they are suppressed.
+///
+/// This covers a syntax error in the directive (missing bracket, empty rule list, trailing text), a
+/// `file-ignore[...]` that is not the file's first comment, and the file-wide codes `invalid-syntax`
+/// and `format` listed in a node-level `ignore[...]`.
 ///
 /// ## Example
 /// ```html
@@ -65,13 +66,13 @@ impl Violation for InvalidIgnoreComment {
     fn help(&self) -> Option<Cow<'static, str>> {
         Some(match self.kind {
             IgnoreCommentViolation::Malformed => {
-                "Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.".into()
+                "Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.".into()
             }
             IgnoreCommentViolation::MisplacedFileIgnore => {
-                "Move the comment to the very top of the file, or use `ignore[...]` to target the next node.".into()
+                "Move the comment to the top of the file, or use `ignore[...]` to target the next node.".into()
             }
             IgnoreCommentViolation::InvalidSyntaxOnNode => {
-                "A file that does not parse has no nodes to attach to; use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.".into()
+                "An unparsable file has no nodes to attach to: use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.".into()
             }
             IgnoreCommentViolation::FormatOnNode => {
                 "Use a bare `{# djangofmt:ignore #}` comment to skip formatting the next node.".into()
@@ -80,8 +81,7 @@ impl Violation for InvalidIgnoreComment {
     }
 }
 
-/// Lint one directive comment. The caller guarantees the comment body starts with `djangofmt:`
-/// and is not the formatter's bare legacy directive; `directive` is its parse outcome.
+/// Lint one directive comment; `directive` is its parse outcome.
 pub fn check(
     directive: Option<&Directive<'_>>,
     comment_raw: &str,

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -1,0 +1,110 @@
+use std::borrow::Cow;
+
+use crate::registry::{Rule, RuleCategory};
+use crate::suppression::{Directive, FORMAT, INVALID_SYNTAX};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+use crate::{Checker, span};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum IgnoreCommentViolation {
+    /// The comment starts with `djangofmt:` but is not a recognized directive.
+    Malformed,
+    /// A `file-ignore[...]` directive that is not the file's first comment.
+    MisplacedFileIgnore,
+    /// `invalid-syntax` listed in a node-level `ignore[...]`.
+    InvalidSyntaxOnNode,
+    /// `format` listed in a node-level `ignore[...]`.
+    FormatOnNode,
+}
+
+/// ## What it does
+/// Checks for `djangofmt:` suppression comments that are malformed or misplaced.
+///
+/// ## Why is this bad?
+/// A suppression comment djangofmt does not recognize is silently skipped, so the diagnostics it
+/// was meant to silence keep firing — or the author believes something is suppressed when nothing
+/// is. This covers directives with a syntax error (missing brackets, an empty rule list, trailing
+/// text), a `file-ignore[...]` that is not the first comment in the file, and codes that only make
+/// sense file-wide (`invalid-syntax`, `format`) listed in a node-level `ignore[...]`.
+///
+/// ## Example
+/// ```html
+/// {# djangofmt: ignore[] #}
+/// <form method="yes">Submit</form>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {# djangofmt: ignore[invalid-attr-value] #}
+/// <form method="yes">Submit</form>
+/// ```
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct InvalidIgnoreComment {
+    pub kind: IgnoreCommentViolation,
+}
+
+impl Violation for InvalidIgnoreComment {
+    const RULE: Rule = Rule::InvalidIgnoreComment;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+
+    #[derive_message_formats]
+    fn message(&self) -> Cow<'static, str> {
+        match self.kind {
+            IgnoreCommentViolation::Malformed => "Malformed `djangofmt:` directive comment.".into(),
+            IgnoreCommentViolation::MisplacedFileIgnore => {
+                "`file-ignore[...]` must be the first comment in the file.".into()
+            }
+            IgnoreCommentViolation::InvalidSyntaxOnNode => {
+                "`invalid-syntax` cannot be scoped to a node.".into()
+            }
+            IgnoreCommentViolation::FormatOnNode => "`format` cannot be scoped to a node.".into(),
+        }
+    }
+
+    fn help(&self) -> Option<Cow<'static, str>> {
+        Some(match self.kind {
+            IgnoreCommentViolation::Malformed => {
+                "Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.".into()
+            }
+            IgnoreCommentViolation::MisplacedFileIgnore => {
+                "Move the comment to the very top of the file, or use `ignore[...]` to target the next node.".into()
+            }
+            IgnoreCommentViolation::InvalidSyntaxOnNode => {
+                "A file that does not parse has no nodes to attach to; use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.".into()
+            }
+            IgnoreCommentViolation::FormatOnNode => {
+                "Use a bare `{# djangofmt:ignore #}` comment to skip formatting the next node.".into()
+            }
+        })
+    }
+}
+
+/// Lint one directive comment. The caller guarantees the comment body starts with `djangofmt:`
+/// and is not the formatter's bare legacy directive; `directive` is its parse outcome.
+pub fn check(
+    directive: Option<&Directive<'_>>,
+    comment_raw: &str,
+    is_file_head: bool,
+    checker: &Checker<'_>,
+) {
+    // Point at the offending code when one is singled out, at the whole comment otherwise.
+    let (kind, slice) = match directive {
+        None => (IgnoreCommentViolation::Malformed, comment_raw),
+        Some(Directive::FileIgnore(_)) if !is_file_head => {
+            (IgnoreCommentViolation::MisplacedFileIgnore, comment_raw)
+        }
+        Some(Directive::Ignore(codes)) => {
+            if let Some(code) = codes.iter().find(|code| **code == INVALID_SYNTAX) {
+                (IgnoreCommentViolation::InvalidSyntaxOnNode, *code)
+            } else if let Some(code) = codes.iter().find(|code| **code == FORMAT) {
+                (IgnoreCommentViolation::FormatOnNode, *code)
+            } else {
+                return;
+            }
+        }
+        Some(Directive::FileIgnore(_)) => return,
+    };
+    let offset = checker.source_offset(slice);
+    checker.report_diagnostic_if_enabled(&InvalidIgnoreComment { kind }, span(offset, slice.len()));
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/mod.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/mod.rs
@@ -2,5 +2,7 @@ pub mod django_static_url;
 pub mod django_url_pattern;
 pub mod duplicate_attr;
 pub mod empty_tag_pair;
+pub mod invalid_ignore_comment;
 pub mod javascript_url;
+pub mod unknown_ignore_code;
 pub mod use_https;

--- a/crates/djangofmt_lint/src/rules/suspicious/unknown_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/unknown_ignore_code.rs
@@ -1,0 +1,64 @@
+use std::borrow::Cow;
+
+use crate::registry::{Rule, RuleCategory};
+use crate::suppression::{FORMAT, INVALID_SYNTAX};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+use crate::{Checker, span};
+
+/// ## What it does
+/// Checks for `ignore[...]` / `file-ignore[...]` suppression comments listing a code that does not
+/// name any rule.
+///
+/// ## Why is this bad?
+/// An unknown code suppresses nothing: the diagnostic the comment was meant to silence keeps
+/// firing. It is usually a typo in a rule name, or a leftover from a rule that was renamed.
+///
+/// Besides rule names, `file-ignore[...]` accepts the special codes `format` (skip formatting the
+/// file) and `invalid-syntax` (skip a file that does not parse).
+///
+/// ## Example
+/// ```html
+/// {# djangofmt: ignore[invalid-attr-values] #}
+/// <form method="yes">Submit</form>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {# djangofmt: ignore[invalid-attr-value] #}
+/// <form method="yes">Submit</form>
+/// ```
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct UnknownIgnoreCode {
+    pub code: String,
+}
+
+impl Violation for UnknownIgnoreCode {
+    const RULE: Rule = Rule::UnknownIgnoreCode;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+
+    #[derive_message_formats]
+    fn message(&self) -> Cow<'static, str> {
+        format!("Unknown rule code `{}` in suppression comment.", self.code).into()
+    }
+
+    fn help(&self) -> Option<Cow<'static, str>> {
+        Some("Fix the typo or remove the code; valid codes are the rule names listed in the documentation.".into())
+    }
+}
+
+/// Report every code that names neither a rule nor a reserved code (`format`, `invalid-syntax`).
+pub fn check(codes: &[&str], checker: &Checker<'_>) {
+    for code in codes {
+        if *code == FORMAT || *code == INVALID_SYNTAX || code.parse::<Rule>().is_ok() {
+            continue;
+        }
+        let offset = checker.source_offset(code);
+        checker.report_diagnostic_if_enabled(
+            &UnknownIgnoreCode {
+                code: (*code).to_string(),
+            },
+            span(offset, code.len()),
+        );
+    }
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/unknown_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/unknown_ignore_code.rs
@@ -10,11 +10,11 @@ use crate::{Checker, span};
 /// name any rule.
 ///
 /// ## Why is this bad?
-/// An unknown code suppresses nothing: the diagnostic the comment was meant to silence keeps
-/// firing. It is usually a typo in a rule name, or a leftover from a rule that was renamed.
+/// An unknown code suppresses nothing, so the diagnostic the comment was meant to silence keeps
+/// firing. It is usually a typo, or a leftover from a rule that was renamed.
 ///
-/// Besides rule names, `file-ignore[...]` accepts the special codes `format` (skip formatting the
-/// file) and `invalid-syntax` (skip a file that does not parse).
+/// Besides rule names, `file-ignore[...]` accepts the codes `format` (skip formatting the file) and
+/// `invalid-syntax` (skip a file that does not parse).
 ///
 /// ## Example
 /// ```html
@@ -43,11 +43,11 @@ impl Violation for UnknownIgnoreCode {
     }
 
     fn help(&self) -> Option<Cow<'static, str>> {
-        Some("Fix the typo or remove the code; valid codes are the rule names listed in the documentation.".into())
+        Some("Fix the typo or remove the code: valid codes are the documented rule names.".into())
     }
 }
 
-/// Report every code that names neither a rule nor a reserved code (`format`, `invalid-syntax`).
+/// Report every code naming neither a rule nor a reserved code.
 pub fn check(codes: &[&str], checker: &Checker<'_>) {
     for code in codes {
         if *code == FORMAT || *code == INVALID_SYNTAX || code.parse::<Rule>().is_ok() {

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -1,0 +1,333 @@
+//! Inline diagnostic suppression via `{# djangofmt: ignore[...] #}` comments.
+//!
+//! A `{# djangofmt: ignore[rule1, rule2] #}` comment silences the listed rules
+//! on the node that immediately follows it (whitespace and other comments
+//! aside, so directives can stack or carry an explanation). Anchoring the
+//! suppression to the following node, rather than to a line or column, keeps it
+//! attached to the offending markup across reformatting.
+//!
+//! A `{# djangofmt: file-ignore[rule1, rule2] #}` comment at the top of the
+//! file silences the listed rules for the whole file.
+//!
+//! Rules must always be listed explicitly: there is no blanket form, and the
+//! formatter's bare `djangofmt:ignore` directive is unrelated to lint
+//! suppression. Only `{# #}` template comments carry directives: HTML
+//! comments survive in rendered output, so they are never a suppression.
+
+use std::ops::Range;
+
+use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
+
+use crate::LintDiagnostic;
+
+/// A parsed suppression directive.
+#[derive(Debug, PartialEq)]
+enum Directive<'s> {
+    /// `djangofmt: ignore[...]` — suppress on the following node.
+    Ignore(Vec<&'s str>),
+    /// `djangofmt: file-ignore[...]` — suppress for the whole file.
+    FileIgnore(Vec<&'s str>),
+}
+
+/// Rule codes suppressed over a byte range of the source.
+struct Suppression<'s> {
+    range: Range<usize>,
+    codes: Vec<&'s str>,
+}
+
+/// Drop diagnostics silenced by `ignore[...]` / `file-ignore[...]` comments.
+pub fn filter_suppressed<'s>(
+    source: &'s str,
+    root: &Root<'s>,
+    mut diagnostics: Vec<LintDiagnostic>,
+) -> Vec<LintDiagnostic> {
+    // Cheap prescan: most files carry no directive at all, skip the AST walk.
+    if diagnostics.is_empty() || !source.contains("djangofmt:") {
+        return diagnostics;
+    }
+
+    let mut suppressions = Vec::new();
+    if let Some(codes) = file_ignore_codes(&root.children) {
+        suppressions.push(Suppression {
+            range: 0..source.len(),
+            codes,
+        });
+    }
+    collect(source, &root.children, &mut suppressions);
+    if suppressions.is_empty() {
+        return diagnostics;
+    }
+
+    diagnostics.retain(|diagnostic| {
+        let offset = diagnostic.span.offset() as usize;
+        !suppressions.iter().any(|suppression| {
+            suppression.range.contains(&offset) && suppression.codes.contains(&diagnostic.code)
+        })
+    });
+    diagnostics
+}
+
+/// Codes of a `file-ignore[...]` directive on the first non-whitespace node.
+fn file_ignore_codes<'s>(nodes: &[Node<'s>]) -> Option<Vec<&'s str>> {
+    let node = nodes.iter().find(|node| !is_whitespace_text(node))?;
+    match parse_directive(comment_body(node)?) {
+        Some(Directive::FileIgnore(codes)) => Some(codes),
+        _ => None,
+    }
+}
+
+/// Walk sibling lists, recording each `ignore[...]` comment against the node it precedes.
+fn collect<'s>(source: &'s str, nodes: &[Node<'s>], out: &mut Vec<Suppression<'s>>) {
+    for (index, node) in nodes.iter().enumerate() {
+        if let Some(body) = comment_body(node) {
+            record(source, body, nodes, index, out);
+        } else {
+            match &node.kind {
+                NodeKind::Element(element) => collect(source, &element.children, out),
+                NodeKind::JinjaBlock(block) => collect_block(source, block, out),
+                _ => {}
+            }
+        }
+    }
+}
+
+fn collect_block<'s>(
+    source: &'s str,
+    block: &JinjaBlock<'s, Node<'s>>,
+    out: &mut Vec<Suppression<'s>>,
+) {
+    for item in &block.body {
+        if let JinjaTagOrChildren::Children(children) = item {
+            collect(source, children, out);
+        }
+    }
+}
+
+/// Record a suppression for the meaningful node following the comment at `index`.
+fn record<'s>(
+    source: &'s str,
+    raw: &'s str,
+    nodes: &[Node<'s>],
+    index: usize,
+    out: &mut Vec<Suppression<'s>>,
+) {
+    let Some(Directive::Ignore(codes)) = parse_directive(raw) else {
+        return;
+    };
+    // Whitespace and other comments may sit between the comment and the node
+    // it guards: diagnostics never fire on comments, and skipping them lets
+    // directives stack or carry an explanation comment.
+    let Some(target) = nodes[index + 1..]
+        .iter()
+        .find(|node| !is_whitespace_text(node) && !is_comment(node))
+    else {
+        return;
+    };
+    let start = offset_of(source, target.raw);
+    out.push(Suppression {
+        range: start..start + target.raw.len(),
+        codes,
+    });
+}
+
+/// The directive-carrying body of a `{# #}` template comment.
+const fn comment_body<'s>(node: &Node<'s>) -> Option<&'s str> {
+    match &node.kind {
+        NodeKind::JinjaComment(comment) => Some(comment.raw),
+        _ => None,
+    }
+}
+
+const fn is_comment(node: &Node<'_>) -> bool {
+    matches!(node.kind, NodeKind::JinjaComment(_) | NodeKind::Comment(_))
+}
+
+fn is_whitespace_text(node: &Node<'_>) -> bool {
+    matches!(node.kind, NodeKind::Text(_)) && node.raw.trim().is_empty()
+}
+
+/// Byte offset of `slice` within `source` (both must share the same allocation).
+fn offset_of(source: &str, slice: &str) -> usize {
+    slice.as_ptr() as usize - source.as_ptr() as usize
+}
+
+/// Parse a comment body into a suppression directive.
+///
+/// Grammar: `djangofmt:`, optional whitespace, then `ignore[...]` or
+/// `file-ignore[...]` with a non-empty comma-separated rule list and nothing
+/// after the closing bracket. Anything else — including the formatter's bare
+/// `djangofmt:ignore` — is not a lint directive.
+fn parse_directive(raw: &str) -> Option<Directive<'_>> {
+    let rest = raw.trim().strip_prefix("djangofmt:")?.trim_start();
+    let (file_level, rest) = match rest.strip_prefix("file-ignore[") {
+        Some(rest) => (true, rest),
+        None => (false, rest.strip_prefix("ignore[")?),
+    };
+    let codes: Vec<&str> = rest
+        .strip_suffix(']')?
+        .split(',')
+        .map(str::trim)
+        .filter(|code| !code.is_empty())
+        .collect();
+    if codes.is_empty() {
+        return None;
+    }
+    Some(if file_level {
+        Directive::FileIgnore(codes)
+    } else {
+        Directive::Ignore(codes)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Settings, lint_source};
+    use markup_fmt::Language;
+
+    #[test]
+    fn parse_node_directives() {
+        assert_eq!(
+            parse_directive(" djangofmt: ignore[invalid-attr-value] "),
+            Some(Directive::Ignore(vec!["invalid-attr-value"]))
+        );
+        assert_eq!(
+            parse_directive("djangofmt:ignore[a, b ,c]"),
+            Some(Directive::Ignore(vec!["a", "b", "c"]))
+        );
+    }
+
+    #[test]
+    fn parse_file_directives() {
+        assert_eq!(
+            parse_directive(" djangofmt: file-ignore[invalid-syntax] "),
+            Some(Directive::FileIgnore(vec!["invalid-syntax"]))
+        );
+        assert_eq!(
+            parse_directive("djangofmt:file-ignore[a,b]"),
+            Some(Directive::FileIgnore(vec!["a", "b"]))
+        );
+    }
+
+    #[test]
+    fn reject_non_directives() {
+        assert_eq!(parse_directive(" djangofmt:ignore "), None); // formatter directive
+        assert_eq!(parse_directive("djangofmt: ignore[]"), None); // explicit rules only
+        assert_eq!(parse_directive("djangofmt: ignore[ , ]"), None); // only separators
+        assert_eq!(parse_directive("djangofmt: ignore[a] trailing"), None); // nothing after bracket
+        assert_eq!(parse_directive("ignore[a]"), None); // must start with djangofmt:
+        assert_eq!(parse_directive("noqa: a"), None);
+    }
+
+    fn count_diagnostics(source: &str) -> usize {
+        lint_source(source, Language::Django, &[], &Settings::all(), None)
+            .expect("parse")
+            .len()
+    }
+
+    #[test]
+    fn ignore_suppresses_following_node() {
+        // `<form method="yes">` trips `invalid-attr-value`; the comment silences it.
+        assert_eq!(count_diagnostics("<form method=\"yes\"></form>"), 1);
+        assert_eq!(
+            count_diagnostics(
+                "{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>"
+            ),
+            0
+        );
+        // A non-matching code leaves the diagnostic in place.
+        assert_eq!(
+            count_diagnostics(
+                "{# djangofmt: ignore[empty-attr-value] #}\n<form method=\"yes\"></form>"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn ignore_reaches_past_intervening_comments() {
+        // An explanation comment between the directive and its target is skipped.
+        assert_eq!(
+            count_diagnostics(
+                "{# djangofmt: ignore[invalid-attr-value] #}\n{# TODO: fix this legacy form #}\n<form method=\"yes\"></form>"
+            ),
+            0
+        );
+        // Stacked directives all reach the same target.
+        assert_eq!(
+            count_diagnostics(
+                "{# djangofmt: ignore[invalid-attr-value] #}\n{# djangofmt: ignore[empty-attr-value] #}\n<form method=\"yes\" id=\"\"></form>"
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn ignore_works_on_nested_nodes() {
+        // Inside an element.
+        assert_eq!(
+            count_diagnostics(
+                "<div>\n  {# djangofmt: ignore[invalid-attr-value] #}\n  <form method=\"yes\"></form>\n</div>"
+            ),
+            0
+        );
+        // Inside a template block body.
+        assert_eq!(
+            count_diagnostics(
+                "{% if x %}\n  {# djangofmt: ignore[invalid-attr-value] #}\n  <form method=\"yes\"></form>\n{% endif %}"
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn ignore_does_not_reach_backward_or_leak() {
+        // A directive after the node does not reach back to it.
+        assert_eq!(
+            count_diagnostics(
+                "<form method=\"yes\"></form>\n{# djangofmt: ignore[invalid-attr-value] #}"
+            ),
+            1
+        );
+        // The suppression stops at its target: a later sibling still fires.
+        assert_eq!(
+            count_diagnostics(
+                "{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>\n<form method=\"put\"></form>"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn html_comments_are_not_directives() {
+        // HTML comments survive in rendered output, so they never suppress.
+        assert_eq!(
+            count_diagnostics(
+                "<!-- djangofmt: ignore[invalid-attr-value] -->\n<form method=\"yes\"></form>"
+            ),
+            1
+        );
+        // They are still skipped when looking for the directive's target.
+        assert_eq!(
+            count_diagnostics(
+                "{# djangofmt: ignore[invalid-attr-value] #}\n<!-- legacy form -->\n<form method=\"yes\"></form>"
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn file_ignore_suppresses_whole_file() {
+        let source = "{# djangofmt: file-ignore[invalid-attr-value] #}\n\
+                      <form method=\"yes\"></form>\n\
+                      <div><form method=\"put\"></form></div>";
+        assert_eq!(count_diagnostics(source), 0);
+        // Only honored at the top of the file.
+        assert_eq!(
+            count_diagnostics(
+                "<p>hi</p>\n{# djangofmt: file-ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>"
+            ),
+            1
+        );
+    }
+}

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -20,6 +20,7 @@ use std::ops::Range;
 use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
 
 use crate::registry::Rule;
+use crate::rules::style::redirected_ignore;
 use crate::rules::suspicious::{invalid_ignore_comment, unknown_ignore_code};
 use crate::{Checker, LintDiagnostic};
 
@@ -127,9 +128,12 @@ fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str
 /// Runs its own walk rather than piggybacking on [`filter_suppressed`], which
 /// bails out early when a file produced no diagnostics.
 pub fn check_directives(root: &Root<'_>, checker: &Checker<'_>) {
-    if !checker.any_rule_enabled(&[Rule::InvalidIgnoreComment, Rule::UnknownIgnoreCode])
-        || !checker.context().source().contains("djangofmt:")
-    {
+    let rules = [
+        Rule::InvalidIgnoreComment,
+        Rule::UnknownIgnoreCode,
+        Rule::RedirectedIgnore,
+    ];
+    if !checker.any_rule_enabled(&rules) || !checker.context().source().contains("djangofmt:") {
         return;
     }
     let file_head = root.children.iter().find(|node| !is_whitespace_text(node));
@@ -143,6 +147,9 @@ fn walk_directives<'s>(nodes: &[Node<'s>], file_head: Option<&Node<'s>>, checker
             check_directive_comment(node, body, is_file_head, checker);
         } else {
             match &node.kind {
+                NodeKind::Comment(comment) => {
+                    redirected_ignore::check(comment.raw, node.raw, checker);
+                }
                 NodeKind::Element(element) => {
                     walk_directives(&element.children, file_head, checker);
                 }
@@ -415,12 +422,13 @@ mod tests {
 
     #[test]
     fn html_comments_are_not_directives() {
-        // HTML comments survive in rendered output, so they never suppress.
+        // HTML comments survive in rendered output, so they never suppress:
+        // the rule still fires, plus a `redirected-ignore` on the comment.
         assert_eq!(
             count_diagnostics(
                 "<!-- djangofmt: ignore[invalid-attr-value] -->\n<form method=\"yes\"></form>"
             ),
-            1
+            2
         );
         // They are still skipped when looking for the directive's target.
         assert_eq!(

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -88,7 +88,7 @@ fn walk<'s>(
                 match directive {
                     Some(Directive::Ignore(codes)) => {
                         unknown_ignore_code::check(&codes, checker);
-                        if let Some(range) = following_node(source, &nodes[index + 1..]) {
+                        if let Some(range) = following_node(checker, &nodes[index + 1..]) {
                             out.push(Suppression { range, codes });
                         }
                     }
@@ -119,12 +119,21 @@ fn walk<'s>(
 }
 
 /// Byte range of the first node a directive comment can guard.
-fn following_node(source: &str, rest: &[Node<'_>]) -> Option<Range<usize>> {
+fn following_node(checker: &Checker<'_>, rest: &[Node<'_>]) -> Option<Range<usize>> {
     let target = rest
         .iter()
         .find(|node| !is_whitespace_text(node) && !is_comment(node))?;
-    let start = offset_of(source, target.raw);
+    let start = checker.source_offset(target.raw);
     Some(start..start + target.raw.len())
+}
+
+/// A comment body stripped of Jinja's whitespace-control markers (`{#- ... -#}`),
+/// which are part of the delimiter rather than of the directive.
+fn directive_body(raw: &str) -> &str {
+    raw.trim()
+        .trim_start_matches(['-', '+'])
+        .trim_end_matches('-')
+        .trim()
 }
 
 /// Whether a comment body claims to be a lint directive.
@@ -132,7 +141,7 @@ fn following_node(source: &str, rest: &[Node<'_>]) -> Option<Range<usize>> {
 /// The bare `djangofmt:ignore`, optionally followed by an explanation, is the
 /// formatter's own directive and never a lint suppression.
 fn is_lint_directive(body: &str) -> bool {
-    let Some(after) = body.trim().strip_prefix("djangofmt:") else {
+    let Some(after) = directive_body(body).strip_prefix("djangofmt:") else {
         return false;
     };
     !after
@@ -146,7 +155,7 @@ fn is_lint_directive(body: &str) -> bool {
 /// `file-ignore[...]` with a non-empty comma-separated rule list and nothing
 /// after the closing bracket.
 fn parse_directive(raw: &str) -> Option<Directive<'_>> {
-    let rest = raw.trim().strip_prefix("djangofmt:")?.trim_start();
+    let rest = directive_body(raw).strip_prefix("djangofmt:")?.trim_start();
     let (file_level, rest) = match rest.strip_prefix("file-ignore[") {
         Some(rest) => (true, rest),
         None => (false, rest.strip_prefix("ignore[")?),
@@ -190,7 +199,7 @@ pub fn file_ignores(source: &str) -> FileIgnores {
         .trim_start();
     let jinja_body = leading_comment(trimmed, "{#", "#}");
     if let Some(body) = jinja_body.or_else(|| leading_comment(trimmed, "<!--", "-->"))
-        && body.trim() == "djangofmt:ignore"
+        && directive_body(body) == "djangofmt:ignore"
     {
         return FileIgnores {
             format: true,
@@ -216,13 +225,13 @@ const fn is_comment(node: &Node<'_>) -> bool {
     matches!(node.kind, NodeKind::JinjaComment(_) | NodeKind::Comment(_))
 }
 
+/// A BOM is not Rust whitespace, but it does not displace the file's first comment.
 fn is_whitespace_text(node: &Node<'_>) -> bool {
-    matches!(node.kind, NodeKind::Text(_)) && node.raw.trim().is_empty()
-}
-
-/// Byte offset of `slice` within `source` (both must share the same allocation).
-fn offset_of(source: &str, slice: &str) -> usize {
-    slice.as_ptr() as usize - source.as_ptr() as usize
+    matches!(node.kind, NodeKind::Text(_))
+        && node
+            .raw
+            .chars()
+            .all(|char| char.is_whitespace() || char == '\u{feff}')
 }
 
 #[cfg(test)]
@@ -312,6 +321,31 @@ mod tests {
             "{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>";
         assert!(codes(&format!("<div>\n{GUARDED}\n</div>")).is_empty());
         assert!(codes(&format!("{{% if x %}}\n{GUARDED}\n{{% endif %}}")).is_empty());
+    }
+
+    #[test]
+    fn jinja_whitespace_control_markers_are_not_part_of_the_directive() {
+        assert!(
+            codes("{#- djangofmt: ignore[invalid-attr-value] -#}\n<form method=\"yes\"></form>")
+                .is_empty()
+        );
+        assert_eq!(
+            file_ignores("{#- djangofmt: file-ignore[format] -#}"),
+            FileIgnores {
+                format: true,
+                invalid_syntax: false,
+            }
+        );
+    }
+
+    #[test]
+    fn a_bom_does_not_displace_the_first_comment() {
+        assert!(
+            codes(
+                "\u{feff}{# djangofmt: file-ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>"
+            )
+            .is_empty()
+        );
     }
 
     #[test]

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -7,7 +7,8 @@
 //! attached to the offending markup across reformatting.
 //!
 //! A `{# djangofmt: file-ignore[rule1, rule2] #}` comment at the top of the
-//! file silences the listed rules for the whole file.
+//! file silences the listed rules for the whole file. The special
+//! `invalid-syntax` code suppresses parse errors ([`file_ignores_invalid_syntax`]).
 //!
 //! Rules must always be listed explicitly: there is no blanket form, and the
 //! formatter's bare `djangofmt:ignore` directive is unrelated to lint
@@ -19,6 +20,9 @@ use std::ops::Range;
 use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
 
 use crate::LintDiagnostic;
+
+/// Code accepted by `file-ignore[...]` to suppress parse errors.
+pub const INVALID_SYNTAX: &str = "invalid-syntax";
 
 /// A parsed suppression directive.
 #[derive(Debug, PartialEq)]
@@ -65,6 +69,29 @@ pub fn filter_suppressed<'s>(
         })
     });
     diagnostics
+}
+
+/// Whether the file opens with a `file-ignore[...]` directive listing `invalid-syntax`.
+///
+/// Reads the leading comment straight from the raw source so `check` can honor
+/// the directive even when the file fails to parse.
+#[must_use]
+pub fn file_ignores_invalid_syntax(source: &str) -> bool {
+    // A UTF-8 BOM is not Rust whitespace; strip it so the directive still
+    // matches on BOM-prefixed files.
+    let trimmed = source
+        .strip_prefix('\u{feff}')
+        .unwrap_or(source)
+        .trim_start();
+    [("{#", "#}"), ("<!--", "-->")]
+        .iter()
+        .find_map(|(open, close)| {
+            let body = trimmed.strip_prefix(open)?;
+            Some(&body[..body.find(close)?])
+        })
+        .is_some_and(|raw| {
+            matches!(parse_directive(raw), Some(Directive::FileIgnore(codes)) if codes.contains(&INVALID_SYNTAX))
+        })
 }
 
 /// Codes of a `file-ignore[...]` directive on the first non-whitespace node.
@@ -329,5 +356,29 @@ mod tests {
             ),
             1
         );
+    }
+
+    #[test]
+    fn detect_file_level_invalid_syntax() {
+        assert!(file_ignores_invalid_syntax(
+            "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"
+        ));
+        assert!(file_ignores_invalid_syntax(
+            "\n  <!-- djangofmt: file-ignore[foo, invalid-syntax] -->\n<div id=>"
+        ));
+        // A UTF-8 BOM before the directive is tolerated.
+        assert!(file_ignores_invalid_syntax(
+            "\u{feff}{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"
+        ));
+        assert!(!file_ignores_invalid_syntax(
+            "{# djangofmt: file-ignore[missing-img-alt] #}\n<div id=>"
+        ));
+        assert!(!file_ignores_invalid_syntax(
+            "{# djangofmt: ignore[invalid-syntax] #}\n<div id=>"
+        ));
+        assert!(!file_ignores_invalid_syntax(
+            "{# djangofmt:ignore #}\n<div id=>"
+        ));
+        assert!(!file_ignores_invalid_syntax("<div id=>"));
     }
 }

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -1,33 +1,26 @@
 //! Inline diagnostic suppression via `{# djangofmt: ignore[...] #}` comments.
 //!
-//! A `{# djangofmt: ignore[rule1, rule2] #}` comment silences the listed rules
-//! on the node that immediately follows it (whitespace and other comments
-//! aside, so directives can stack or carry an explanation). Anchoring the
-//! suppression to the following node, rather than to a line or column, keeps it
-//! attached to the offending markup across reformatting.
+//! A directive binds to the node that follows it — whitespace and other comments
+//! aside, so directives can stack or carry an explanation. Anchoring to a node
+//! rather than a line keeps the suppression on the right markup across
+//! reformatting. `{# djangofmt: file-ignore[...] #}` as the file's first comment
+//! covers the whole file instead.
 //!
-//! A `{# djangofmt: file-ignore[rule1, rule2] #}` comment at the top of the
-//! file silences the listed rules for the whole file. The special
-//! `invalid-syntax` code suppresses parse errors ([`file_ignores`]).
-//!
-//! Rules must always be listed explicitly: there is no blanket form, and the
-//! formatter's bare `djangofmt:ignore` directive is unrelated to lint
-//! suppression. Only `{# #}` template comments carry directives: HTML
-//! comments survive in rendered output, so they are never a suppression.
+//! Rules are always listed explicitly, and only `{# #}` comments carry
+//! directives: HTML comments survive in rendered output.
 
 use std::ops::Range;
 
-use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
+use markup_fmt::ast::{JinjaTagOrChildren, Node, NodeKind, Root};
 
-use crate::registry::Rule;
 use crate::rules::style::redirected_ignore;
 use crate::rules::suspicious::{invalid_ignore_comment, unknown_ignore_code};
 use crate::{Checker, LintDiagnostic};
 
-/// Code accepted by `file-ignore[...]` to suppress parse errors.
+/// `file-ignore[...]` code suppressing parse errors.
 pub const INVALID_SYNTAX: &str = "invalid-syntax";
 
-/// Code accepted by `file-ignore[...]` to skip formatting.
+/// `file-ignore[...]` code skipping the formatter.
 pub const FORMAT: &str = "format";
 
 /// A parsed suppression directive.
@@ -40,34 +33,36 @@ pub enum Directive<'s> {
 }
 
 /// Rule codes suppressed over a byte range of the source.
-struct Suppression<'s> {
+pub struct Suppression<'s> {
     range: Range<usize>,
     codes: Vec<&'s str>,
 }
 
-/// Drop diagnostics silenced by `ignore[...]` / `file-ignore[...]` comments.
-pub fn filter_suppressed<'s>(
+/// Collect what each `djangofmt:` comment suppresses, linting misuse on the way.
+#[must_use]
+pub fn collect<'s>(
     source: &'s str,
     root: &Root<'s>,
+    checker: &Checker<'_>,
+) -> Vec<Suppression<'s>> {
+    let mut suppressions = Vec::new();
+    // Cheap prescan: most files carry no directive at all, skip the AST walk.
+    if source.contains("djangofmt:") {
+        let head = root.children.iter().find(|node| !is_whitespace_text(node));
+        walk(source, &root.children, head, checker, &mut suppressions);
+    }
+    suppressions
+}
+
+/// Drop the diagnostics silenced by `suppressions`.
+#[must_use]
+pub fn filter(
+    suppressions: &[Suppression<'_>],
     mut diagnostics: Vec<LintDiagnostic>,
 ) -> Vec<LintDiagnostic> {
-    // Cheap prescan: most files carry no directive at all, skip the AST walk.
-    if diagnostics.is_empty() || !source.contains("djangofmt:") {
-        return diagnostics;
-    }
-
-    let mut suppressions = Vec::new();
-    if let Some(codes) = file_ignore_codes(&root.children) {
-        suppressions.push(Suppression {
-            range: 0..source.len(),
-            codes,
-        });
-    }
-    collect(source, &root.children, &mut suppressions);
     if suppressions.is_empty() {
         return diagnostics;
     }
-
     diagnostics.retain(|diagnostic| {
         let offset = diagnostic.span.offset() as usize;
         !suppressions.iter().any(|suppression| {
@@ -75,6 +70,101 @@ pub fn filter_suppressed<'s>(
         })
     });
     diagnostics
+}
+
+fn walk<'s>(
+    source: &'s str,
+    nodes: &[Node<'s>],
+    head: Option<&Node<'s>>,
+    checker: &Checker<'_>,
+    out: &mut Vec<Suppression<'s>>,
+) {
+    for (index, node) in nodes.iter().enumerate() {
+        match &node.kind {
+            NodeKind::JinjaComment(comment) if is_lint_directive(comment.raw) => {
+                let is_head = head.is_some_and(|head| std::ptr::eq(head, node));
+                let directive = parse_directive(comment.raw);
+                invalid_ignore_comment::check(directive.as_ref(), node.raw, is_head, checker);
+                match directive {
+                    Some(Directive::Ignore(codes)) => {
+                        unknown_ignore_code::check(&codes, checker);
+                        if let Some(range) = following_node(source, &nodes[index + 1..]) {
+                            out.push(Suppression { range, codes });
+                        }
+                    }
+                    Some(Directive::FileIgnore(codes)) => {
+                        unknown_ignore_code::check(&codes, checker);
+                        if is_head {
+                            out.push(Suppression {
+                                range: 0..source.len(),
+                                codes,
+                            });
+                        }
+                    }
+                    None => {}
+                }
+            }
+            NodeKind::Comment(comment) => redirected_ignore::check(comment.raw, node.raw, checker),
+            NodeKind::Element(element) => walk(source, &element.children, head, checker, out),
+            NodeKind::JinjaBlock(block) => {
+                for item in &block.body {
+                    if let JinjaTagOrChildren::Children(children) = item {
+                        walk(source, children, head, checker, out);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Byte range of the first node a directive comment can guard.
+fn following_node(source: &str, rest: &[Node<'_>]) -> Option<Range<usize>> {
+    let target = rest
+        .iter()
+        .find(|node| !is_whitespace_text(node) && !is_comment(node))?;
+    let start = offset_of(source, target.raw);
+    Some(start..start + target.raw.len())
+}
+
+/// Whether a comment body claims to be a lint directive.
+///
+/// The bare `djangofmt:ignore`, optionally followed by an explanation, is the
+/// formatter's own directive and never a lint suppression.
+fn is_lint_directive(body: &str) -> bool {
+    let Some(after) = body.trim().strip_prefix("djangofmt:") else {
+        return false;
+    };
+    !after
+        .strip_prefix("ignore")
+        .is_some_and(|rest| rest.chars().next().is_none_or(char::is_whitespace))
+}
+
+/// Parse a comment body into a suppression directive.
+///
+/// Grammar: `djangofmt:`, optional whitespace, then `ignore[...]` or
+/// `file-ignore[...]` with a non-empty comma-separated rule list and nothing
+/// after the closing bracket.
+fn parse_directive(raw: &str) -> Option<Directive<'_>> {
+    let rest = raw.trim().strip_prefix("djangofmt:")?.trim_start();
+    let (file_level, rest) = match rest.strip_prefix("file-ignore[") {
+        Some(rest) => (true, rest),
+        None => (false, rest.strip_prefix("ignore[")?),
+    };
+    let codes: Vec<&str> = rest
+        .strip_suffix(']')?
+        .split(',')
+        .map(str::trim)
+        .filter(|code| !code.is_empty())
+        .collect();
+    if codes.is_empty() {
+        return None;
+    }
+    Some(if file_level {
+        Directive::FileIgnore(codes)
+    } else {
+        Directive::Ignore(codes)
+    })
 }
 
 /// File-wide opt-outs declared by the leading comment of a file.
@@ -86,15 +176,14 @@ pub struct FileIgnores {
     pub invalid_syntax: bool,
 }
 
-/// Opt-outs from the file's leading comment, read straight from the raw
-/// source so they can be honored even when the file fails to parse.
+/// Opt-outs from the file's leading comment, read straight from the raw source
+/// so they can be honored even when the file fails to parse.
 ///
 /// The bare legacy `djangofmt:ignore` (in either comment style) predates rule
 /// codes and opted the file out of everything: it maps to both flags.
 #[must_use]
 pub fn file_ignores(source: &str) -> FileIgnores {
-    // A UTF-8 BOM is not Rust whitespace; strip it so the directive still
-    // matches on BOM-prefixed files.
+    // A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
     let trimmed = source
         .strip_prefix('\u{feff}')
         .unwrap_or(source)
@@ -123,143 +212,6 @@ fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str
     Some(&body[..body.find(close)?])
 }
 
-/// Lint every `djangofmt:` comment for misuse (the `*-ignore-*` rules).
-///
-/// Runs its own walk rather than piggybacking on [`filter_suppressed`], which
-/// bails out early when a file produced no diagnostics.
-pub fn check_directives(root: &Root<'_>, checker: &Checker<'_>) {
-    let rules = [
-        Rule::InvalidIgnoreComment,
-        Rule::UnknownIgnoreCode,
-        Rule::RedirectedIgnore,
-    ];
-    if !checker.any_rule_enabled(&rules) || !checker.context().source().contains("djangofmt:") {
-        return;
-    }
-    let file_head = root.children.iter().find(|node| !is_whitespace_text(node));
-    walk_directives(&root.children, file_head, checker);
-}
-
-fn walk_directives<'s>(nodes: &[Node<'s>], file_head: Option<&Node<'s>>, checker: &Checker<'_>) {
-    for node in nodes {
-        if let Some(body) = comment_body(node) {
-            let is_file_head = file_head.is_some_and(|head| std::ptr::eq(head, node));
-            check_directive_comment(node, body, is_file_head, checker);
-        } else {
-            match &node.kind {
-                NodeKind::Comment(comment) => {
-                    redirected_ignore::check(comment.raw, node.raw, checker);
-                }
-                NodeKind::Element(element) => {
-                    walk_directives(&element.children, file_head, checker);
-                }
-                NodeKind::JinjaBlock(block) => {
-                    for item in &block.body {
-                        if let JinjaTagOrChildren::Children(children) = item {
-                            walk_directives(children, file_head, checker);
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-}
-
-fn check_directive_comment<'s>(
-    node: &Node<'s>,
-    body: &'s str,
-    is_file_head: bool,
-    checker: &Checker<'_>,
-) {
-    let Some(after) = body.trim().strip_prefix("djangofmt:") else {
-        return;
-    };
-    // The formatter's bare legacy directive, optionally followed by an
-    // explanation, is valid and handled by markup_fmt.
-    if let Some(rest) = after.strip_prefix("ignore")
-        && rest.chars().next().is_none_or(char::is_whitespace)
-    {
-        return;
-    }
-    let directive = parse_directive(body);
-    invalid_ignore_comment::check(directive.as_ref(), node.raw, is_file_head, checker);
-    if let Some(Directive::Ignore(codes) | Directive::FileIgnore(codes)) = &directive {
-        unknown_ignore_code::check(codes, checker);
-    }
-}
-
-/// Codes of a `file-ignore[...]` directive on the first non-whitespace node.
-fn file_ignore_codes<'s>(nodes: &[Node<'s>]) -> Option<Vec<&'s str>> {
-    let node = nodes.iter().find(|node| !is_whitespace_text(node))?;
-    match parse_directive(comment_body(node)?) {
-        Some(Directive::FileIgnore(codes)) => Some(codes),
-        _ => None,
-    }
-}
-
-/// Walk sibling lists, recording each `ignore[...]` comment against the node it precedes.
-fn collect<'s>(source: &'s str, nodes: &[Node<'s>], out: &mut Vec<Suppression<'s>>) {
-    for (index, node) in nodes.iter().enumerate() {
-        if let Some(body) = comment_body(node) {
-            record(source, body, nodes, index, out);
-        } else {
-            match &node.kind {
-                NodeKind::Element(element) => collect(source, &element.children, out),
-                NodeKind::JinjaBlock(block) => collect_block(source, block, out),
-                _ => {}
-            }
-        }
-    }
-}
-
-fn collect_block<'s>(
-    source: &'s str,
-    block: &JinjaBlock<'s, Node<'s>>,
-    out: &mut Vec<Suppression<'s>>,
-) {
-    for item in &block.body {
-        if let JinjaTagOrChildren::Children(children) = item {
-            collect(source, children, out);
-        }
-    }
-}
-
-/// Record a suppression for the meaningful node following the comment at `index`.
-fn record<'s>(
-    source: &'s str,
-    raw: &'s str,
-    nodes: &[Node<'s>],
-    index: usize,
-    out: &mut Vec<Suppression<'s>>,
-) {
-    let Some(Directive::Ignore(codes)) = parse_directive(raw) else {
-        return;
-    };
-    // Whitespace and other comments may sit between the comment and the node
-    // it guards: diagnostics never fire on comments, and skipping them lets
-    // directives stack or carry an explanation comment.
-    let Some(target) = nodes[index + 1..]
-        .iter()
-        .find(|node| !is_whitespace_text(node) && !is_comment(node))
-    else {
-        return;
-    };
-    let start = offset_of(source, target.raw);
-    out.push(Suppression {
-        range: start..start + target.raw.len(),
-        codes,
-    });
-}
-
-/// The directive-carrying body of a `{# #}` template comment.
-const fn comment_body<'s>(node: &Node<'s>) -> Option<&'s str> {
-    match &node.kind {
-        NodeKind::JinjaComment(comment) => Some(comment.raw),
-        _ => None,
-    }
-}
-
 const fn is_comment(node: &Node<'_>) -> bool {
     matches!(node.kind, NodeKind::JinjaComment(_) | NodeKind::Comment(_))
 }
@@ -273,61 +225,30 @@ fn offset_of(source: &str, slice: &str) -> usize {
     slice.as_ptr() as usize - source.as_ptr() as usize
 }
 
-/// Parse a comment body into a suppression directive.
-///
-/// Grammar: `djangofmt:`, optional whitespace, then `ignore[...]` or
-/// `file-ignore[...]` with a non-empty comma-separated rule list and nothing
-/// after the closing bracket. Anything else — including the formatter's bare
-/// `djangofmt:ignore` — is not a lint directive.
-fn parse_directive(raw: &str) -> Option<Directive<'_>> {
-    let rest = raw.trim().strip_prefix("djangofmt:")?.trim_start();
-    let (file_level, rest) = match rest.strip_prefix("file-ignore[") {
-        Some(rest) => (true, rest),
-        None => (false, rest.strip_prefix("ignore[")?),
-    };
-    let codes: Vec<&str> = rest
-        .strip_suffix(']')?
-        .split(',')
-        .map(str::trim)
-        .filter(|code| !code.is_empty())
-        .collect();
-    if codes.is_empty() {
-        return None;
-    }
-    Some(if file_level {
-        Directive::FileIgnore(codes)
-    } else {
-        Directive::Ignore(codes)
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{Settings, lint_source};
     use markup_fmt::Language;
 
-    #[test]
-    fn parse_node_directives() {
-        assert_eq!(
-            parse_directive(" djangofmt: ignore[invalid-attr-value] "),
-            Some(Directive::Ignore(vec!["invalid-attr-value"]))
-        );
-        assert_eq!(
-            parse_directive("djangofmt:ignore[a, b ,c]"),
-            Some(Directive::Ignore(vec!["a", "b", "c"]))
-        );
+    /// `<form method="yes">` trips `invalid-attr-value`, `id=""` trips `empty-attr-value`.
+    fn codes(source: &str) -> Vec<&'static str> {
+        lint_source(source, Language::Django, &[], &Settings::all(), None)
+            .expect("parse")
+            .iter()
+            .map(|diagnostic| diagnostic.code)
+            .collect()
     }
 
     #[test]
-    fn parse_file_directives() {
+    fn parse_directives() {
         assert_eq!(
-            parse_directive(" djangofmt: file-ignore[invalid-syntax] "),
-            Some(Directive::FileIgnore(vec!["invalid-syntax"]))
+            parse_directive(" djangofmt: ignore[a, b ,c] "),
+            Some(Directive::Ignore(vec!["a", "b", "c"]))
         );
         assert_eq!(
-            parse_directive("djangofmt:file-ignore[a,b]"),
-            Some(Directive::FileIgnore(vec!["a", "b"]))
+            parse_directive("djangofmt:file-ignore[invalid-syntax]"),
+            Some(Directive::FileIgnore(vec!["invalid-syntax"]))
         );
     }
 
@@ -338,120 +259,86 @@ mod tests {
         assert_eq!(parse_directive("djangofmt: ignore[ , ]"), None); // only separators
         assert_eq!(parse_directive("djangofmt: ignore[a] trailing"), None); // nothing after bracket
         assert_eq!(parse_directive("ignore[a]"), None); // must start with djangofmt:
-        assert_eq!(parse_directive("noqa: a"), None);
-    }
-
-    fn count_diagnostics(source: &str) -> usize {
-        lint_source(source, Language::Django, &[], &Settings::all(), None)
-            .expect("parse")
-            .len()
     }
 
     #[test]
-    fn ignore_suppresses_following_node() {
-        // `<form method="yes">` trips `invalid-attr-value`; the comment silences it.
-        assert_eq!(count_diagnostics("<form method=\"yes\"></form>"), 1);
+    fn ignore_binds_to_the_following_node() {
         assert_eq!(
-            count_diagnostics(
-                "{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>"
-            ),
-            0
+            codes("<form method=\"yes\"></form>"),
+            ["invalid-attr-value"]
         );
-        // A non-matching code leaves the diagnostic in place.
+        assert!(
+            codes("{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>")
+                .is_empty()
+        );
+        // A non-matching code, a directive placed after the node, and a later
+        // sibling all keep their diagnostic.
         assert_eq!(
-            count_diagnostics(
-                "{# djangofmt: ignore[empty-attr-value] #}\n<form method=\"yes\"></form>"
+            codes("{# djangofmt: ignore[empty-attr-value] #}\n<form method=\"yes\"></form>"),
+            ["invalid-attr-value"]
+        );
+        assert_eq!(
+            codes("<form method=\"yes\"></form>\n{# djangofmt: ignore[invalid-attr-value] #}"),
+            ["invalid-attr-value"]
+        );
+        assert_eq!(
+            codes(
+                "{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>\n<form method=\"put\"></form>"
             ),
-            1
+            ["invalid-attr-value"]
         );
     }
 
     #[test]
     fn ignore_reaches_past_intervening_comments() {
-        // An explanation comment between the directive and its target is skipped.
-        assert_eq!(
-            count_diagnostics(
-                "{# djangofmt: ignore[invalid-attr-value] #}\n{# TODO: fix this legacy form #}\n<form method=\"yes\"></form>"
-            ),
-            0
-        );
+        for filler in ["{# TODO: fix this legacy form #}", "<!-- legacy form -->"] {
+            let source = format!(
+                "{{# djangofmt: ignore[invalid-attr-value] #}}\n{filler}\n<form method=\"yes\"></form>"
+            );
+            assert!(!codes(&source).contains(&"invalid-attr-value"), "{filler}");
+        }
         // Stacked directives all reach the same target.
-        assert_eq!(
-            count_diagnostics(
+        assert!(
+            codes(
                 "{# djangofmt: ignore[invalid-attr-value] #}\n{# djangofmt: ignore[empty-attr-value] #}\n<form method=\"yes\" id=\"\"></form>"
-            ),
-            0
+            )
+            .is_empty()
         );
     }
 
     #[test]
-    fn ignore_works_on_nested_nodes() {
-        // Inside an element.
-        assert_eq!(
-            count_diagnostics(
-                "<div>\n  {# djangofmt: ignore[invalid-attr-value] #}\n  <form method=\"yes\"></form>\n</div>"
-            ),
-            0
-        );
-        // Inside a template block body.
-        assert_eq!(
-            count_diagnostics(
-                "{% if x %}\n  {# djangofmt: ignore[invalid-attr-value] #}\n  <form method=\"yes\"></form>\n{% endif %}"
-            ),
-            0
+    fn ignore_applies_inside_nested_nodes() {
+        const GUARDED: &str =
+            "{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>";
+        assert!(codes(&format!("<div>\n{GUARDED}\n</div>")).is_empty());
+        assert!(codes(&format!("{{% if x %}}\n{GUARDED}\n{{% endif %}}")).is_empty());
+    }
+
+    #[test]
+    fn html_comments_never_suppress() {
+        // The rule still fires, plus a `redirected-ignore` on the comment.
+        assert!(
+            codes("<!-- djangofmt: ignore[invalid-attr-value] -->\n<form method=\"yes\"></form>")
+                .contains(&"invalid-attr-value")
         );
     }
 
     #[test]
-    fn ignore_does_not_reach_backward_or_leak() {
-        // A directive after the node does not reach back to it.
-        assert_eq!(
-            count_diagnostics(
-                "<form method=\"yes\"></form>\n{# djangofmt: ignore[invalid-attr-value] #}"
-            ),
-            1
+    fn file_ignore_is_honored_at_the_top_only() {
+        assert!(
+            codes(
+                "{# djangofmt: file-ignore[invalid-attr-value] #}\n\
+                 <form method=\"yes\"></form>\n\
+                 <div><form method=\"put\"></form></div>"
+            )
+            .is_empty()
         );
-        // The suppression stops at its target: a later sibling still fires.
+        // Elsewhere it suppresses nothing and earns an `invalid-ignore-comment`.
         assert_eq!(
-            count_diagnostics(
-                "{# djangofmt: ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>\n<form method=\"put\"></form>"
-            ),
-            1
-        );
-    }
-
-    #[test]
-    fn html_comments_are_not_directives() {
-        // HTML comments survive in rendered output, so they never suppress:
-        // the rule still fires, plus a `redirected-ignore` on the comment.
-        assert_eq!(
-            count_diagnostics(
-                "<!-- djangofmt: ignore[invalid-attr-value] -->\n<form method=\"yes\"></form>"
-            ),
-            2
-        );
-        // They are still skipped when looking for the directive's target.
-        assert_eq!(
-            count_diagnostics(
-                "{# djangofmt: ignore[invalid-attr-value] #}\n<!-- legacy form -->\n<form method=\"yes\"></form>"
-            ),
-            0
-        );
-    }
-
-    #[test]
-    fn file_ignore_suppresses_whole_file() {
-        let source = "{# djangofmt: file-ignore[invalid-attr-value] #}\n\
-                      <form method=\"yes\"></form>\n\
-                      <div><form method=\"put\"></form></div>";
-        assert_eq!(count_diagnostics(source), 0);
-        // Only honored at the top of the file: the rule still fires, and the
-        // misplaced directive earns an `invalid-ignore-comment` of its own.
-        assert_eq!(
-            count_diagnostics(
+            codes(
                 "<p>hi</p>\n{# djangofmt: file-ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>"
             ),
-            2
+            ["invalid-attr-value", "invalid-ignore-comment"]
         );
     }
 

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -8,7 +8,7 @@
 //!
 //! A `{# djangofmt: file-ignore[rule1, rule2] #}` comment at the top of the
 //! file silences the listed rules for the whole file. The special
-//! `invalid-syntax` code suppresses parse errors ([`file_ignores_invalid_syntax`]).
+//! `invalid-syntax` code suppresses parse errors ([`file_ignores`]).
 //!
 //! Rules must always be listed explicitly: there is no blanket form, and the
 //! formatter's bare `djangofmt:ignore` directive is unrelated to lint
@@ -23,6 +23,9 @@ use crate::LintDiagnostic;
 
 /// Code accepted by `file-ignore[...]` to suppress parse errors.
 pub const INVALID_SYNTAX: &str = "invalid-syntax";
+
+/// Code accepted by `file-ignore[...]` to skip formatting.
+pub const FORMAT: &str = "format";
 
 /// A parsed suppression directive.
 #[derive(Debug, PartialEq)]
@@ -71,27 +74,50 @@ pub fn filter_suppressed<'s>(
     diagnostics
 }
 
-/// Whether the file opens with a `file-ignore[...]` directive listing `invalid-syntax`.
+/// File-wide opt-outs declared by the leading comment of a file.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct FileIgnores {
+    /// The formatter skips the whole file (`file-ignore[format]`).
+    pub format: bool,
+    /// Parse errors are suppressed and the file skipped (`file-ignore[invalid-syntax]`).
+    pub invalid_syntax: bool,
+}
+
+/// Opt-outs from the file's leading comment, read straight from the raw
+/// source so they can be honored even when the file fails to parse.
 ///
-/// Reads the leading comment straight from the raw source so `check` can honor
-/// the directive even when the file fails to parse.
+/// The bare legacy `djangofmt:ignore` (in either comment style) predates rule
+/// codes and opted the file out of everything: it maps to both flags.
 #[must_use]
-pub fn file_ignores_invalid_syntax(source: &str) -> bool {
+pub fn file_ignores(source: &str) -> FileIgnores {
     // A UTF-8 BOM is not Rust whitespace; strip it so the directive still
     // matches on BOM-prefixed files.
     let trimmed = source
         .strip_prefix('\u{feff}')
         .unwrap_or(source)
         .trim_start();
-    [("{#", "#}"), ("<!--", "-->")]
-        .iter()
-        .find_map(|(open, close)| {
-            let body = trimmed.strip_prefix(open)?;
-            Some(&body[..body.find(close)?])
-        })
-        .is_some_and(|raw| {
-            matches!(parse_directive(raw), Some(Directive::FileIgnore(codes)) if codes.contains(&INVALID_SYNTAX))
-        })
+    let jinja_body = leading_comment(trimmed, "{#", "#}");
+    if let Some(body) = jinja_body.or_else(|| leading_comment(trimmed, "<!--", "-->"))
+        && body.trim() == "djangofmt:ignore"
+    {
+        return FileIgnores {
+            format: true,
+            invalid_syntax: true,
+        };
+    }
+    match jinja_body.map(parse_directive) {
+        Some(Some(Directive::FileIgnore(codes))) => FileIgnores {
+            format: codes.contains(&FORMAT),
+            invalid_syntax: codes.contains(&INVALID_SYNTAX),
+        },
+        _ => FileIgnores::default(),
+    }
+}
+
+/// The body of a leading `open`..`close` comment, if the text starts with one.
+fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str> {
+    let body = text.strip_prefix(open)?;
+    Some(&body[..body.find(close)?])
 }
 
 /// Codes of a `file-ignore[...]` directive on the first non-whitespace node.
@@ -359,26 +385,61 @@ mod tests {
     }
 
     #[test]
-    fn detect_file_level_invalid_syntax() {
-        assert!(file_ignores_invalid_syntax(
-            "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"
-        ));
-        assert!(file_ignores_invalid_syntax(
-            "\n  <!-- djangofmt: file-ignore[foo, invalid-syntax] -->\n<div id=>"
-        ));
-        // A UTF-8 BOM before the directive is tolerated.
-        assert!(file_ignores_invalid_syntax(
-            "\u{feff}{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"
-        ));
-        assert!(!file_ignores_invalid_syntax(
-            "{# djangofmt: file-ignore[missing-img-alt] #}\n<div id=>"
-        ));
-        assert!(!file_ignores_invalid_syntax(
-            "{# djangofmt: ignore[invalid-syntax] #}\n<div id=>"
-        ));
-        assert!(!file_ignores_invalid_syntax(
-            "{# djangofmt:ignore #}\n<div id=>"
-        ));
-        assert!(!file_ignores_invalid_syntax("<div id=>"));
+    fn detect_file_level_opt_outs() {
+        let all = FileIgnores {
+            format: true,
+            invalid_syntax: true,
+        };
+        let syntax_only = FileIgnores {
+            format: false,
+            invalid_syntax: true,
+        };
+        let format_only = FileIgnores {
+            format: true,
+            invalid_syntax: false,
+        };
+
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"),
+            syntax_only
+        );
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[format] #}\n<div></div>"),
+            format_only
+        );
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[format, invalid-syntax] #}"),
+            all
+        );
+        // A UTF-8 BOM or leading whitespace before the directive is tolerated.
+        assert_eq!(
+            file_ignores("\u{feff}{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"),
+            syntax_only
+        );
+        assert_eq!(
+            file_ignores("\n  {# djangofmt: file-ignore[foo, invalid-syntax] #}\n<div id=>"),
+            syntax_only
+        );
+
+        // The bare legacy directive opts out of everything, in both styles.
+        assert_eq!(file_ignores("{# djangofmt:ignore #}\n<div id=>"), all);
+        assert_eq!(file_ignores("<!-- djangofmt:ignore -->\n<div id=>"), all);
+        assert_eq!(file_ignores("{#  djangofmt:ignore  #}\n<div id=>"), all);
+
+        // Bracketed directives only count in `{# #}` comments.
+        assert_eq!(
+            file_ignores("<!-- djangofmt: file-ignore[invalid-syntax] -->\n<div id=>"),
+            FileIgnores::default()
+        );
+        // Lint codes, node-level directives and plain markup are not opt-outs.
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[missing-img-alt] #}\n<div id=>"),
+            FileIgnores::default()
+        );
+        assert_eq!(
+            file_ignores("{# djangofmt: ignore[invalid-syntax] #}\n<div id=>"),
+            FileIgnores::default()
+        );
+        assert_eq!(file_ignores("<div id=>"), FileIgnores::default());
     }
 }

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -19,7 +19,9 @@ use std::ops::Range;
 
 use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
 
-use crate::LintDiagnostic;
+use crate::registry::Rule;
+use crate::rules::suspicious::{invalid_ignore_comment, unknown_ignore_code};
+use crate::{Checker, LintDiagnostic};
 
 /// Code accepted by `file-ignore[...]` to suppress parse errors.
 pub const INVALID_SYNTAX: &str = "invalid-syntax";
@@ -28,8 +30,8 @@ pub const INVALID_SYNTAX: &str = "invalid-syntax";
 pub const FORMAT: &str = "format";
 
 /// A parsed suppression directive.
-#[derive(Debug, PartialEq)]
-enum Directive<'s> {
+#[derive(Debug, PartialEq, Eq)]
+pub enum Directive<'s> {
     /// `djangofmt: ignore[...]` — suppress on the following node.
     Ignore(Vec<&'s str>),
     /// `djangofmt: file-ignore[...]` — suppress for the whole file.
@@ -118,6 +120,66 @@ pub fn file_ignores(source: &str) -> FileIgnores {
 fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str> {
     let body = text.strip_prefix(open)?;
     Some(&body[..body.find(close)?])
+}
+
+/// Lint every `djangofmt:` comment for misuse (the `*-ignore-*` rules).
+///
+/// Runs its own walk rather than piggybacking on [`filter_suppressed`], which
+/// bails out early when a file produced no diagnostics.
+pub fn check_directives(root: &Root<'_>, checker: &Checker<'_>) {
+    if !checker.any_rule_enabled(&[Rule::InvalidIgnoreComment, Rule::UnknownIgnoreCode])
+        || !checker.context().source().contains("djangofmt:")
+    {
+        return;
+    }
+    let file_head = root.children.iter().find(|node| !is_whitespace_text(node));
+    walk_directives(&root.children, file_head, checker);
+}
+
+fn walk_directives<'s>(nodes: &[Node<'s>], file_head: Option<&Node<'s>>, checker: &Checker<'_>) {
+    for node in nodes {
+        if let Some(body) = comment_body(node) {
+            let is_file_head = file_head.is_some_and(|head| std::ptr::eq(head, node));
+            check_directive_comment(node, body, is_file_head, checker);
+        } else {
+            match &node.kind {
+                NodeKind::Element(element) => {
+                    walk_directives(&element.children, file_head, checker);
+                }
+                NodeKind::JinjaBlock(block) => {
+                    for item in &block.body {
+                        if let JinjaTagOrChildren::Children(children) = item {
+                            walk_directives(children, file_head, checker);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn check_directive_comment<'s>(
+    node: &Node<'s>,
+    body: &'s str,
+    is_file_head: bool,
+    checker: &Checker<'_>,
+) {
+    let Some(after) = body.trim().strip_prefix("djangofmt:") else {
+        return;
+    };
+    // The formatter's bare legacy directive, optionally followed by an
+    // explanation, is valid and handled by markup_fmt.
+    if let Some(rest) = after.strip_prefix("ignore")
+        && rest.chars().next().is_none_or(char::is_whitespace)
+    {
+        return;
+    }
+    let directive = parse_directive(body);
+    invalid_ignore_comment::check(directive.as_ref(), node.raw, is_file_head, checker);
+    if let Some(Directive::Ignore(codes) | Directive::FileIgnore(codes)) = &directive {
+        unknown_ignore_code::check(codes, checker);
+    }
 }
 
 /// Codes of a `file-ignore[...]` directive on the first non-whitespace node.
@@ -375,12 +437,13 @@ mod tests {
                       <form method=\"yes\"></form>\n\
                       <div><form method=\"put\"></form></div>";
         assert_eq!(count_diagnostics(source), 0);
-        // Only honored at the top of the file.
+        // Only honored at the top of the file: the rule still fires, and the
+        // misplaced directive earns an `invalid-ignore-comment` of its own.
         assert_eq!(
             count_diagnostics(
                 "<p>hi</p>\n{# djangofmt: file-ignore[invalid-attr-value] #}\n<form method=\"yes\"></form>"
             ),
-            1
+            2
         );
     }
 

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
@@ -1,0 +1,37 @@
+<!-- Malformed: empty rule list -->
+{# djangofmt: ignore[] #}
+<form method="yes"></form>
+
+<!-- Malformed: missing closing bracket -->
+{# djangofmt: ignore[invalid-attr-value #}
+<div></div>
+
+<!-- Malformed: trailing text after the bracket -->
+{# djangofmt: ignore[invalid-attr-value] because reasons #}
+<div></div>
+
+<!-- Malformed: the bare directive takes no space before `ignore` -->
+{# djangofmt: ignore #}
+<div></div>
+
+<!-- Malformed: unknown keyword -->
+{# djangofmt: silence[invalid-attr-value] #}
+<div></div>
+
+<!-- Misplaced: file-ignore is only honored as the first comment of the file -->
+{# djangofmt: file-ignore[invalid-attr-value] #}
+<div></div>
+
+<!-- Misplaced: nested file-ignore -->
+<div>
+  {# djangofmt: file-ignore[empty-attr-value] #}
+  <p>hi</p>
+</div>
+
+<!-- invalid-syntax cannot be scoped to a node -->
+{# djangofmt: ignore[invalid-syntax] #}
+<div></div>
+
+<!-- format cannot be scoped to a node -->
+{# djangofmt: ignore[format, invalid-attr-value] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
@@ -6,7 +6,7 @@
 {# djangofmt: ignore[invalid-attr-value #}
 <div></div>
 
-<!-- Malformed: trailing text after the bracket -->
+<!-- Malformed: trailing text -->
 {# djangofmt: ignore[invalid-attr-value] because reasons #}
 <div></div>
 
@@ -18,20 +18,20 @@
 {# djangofmt: silence[invalid-attr-value] #}
 <div></div>
 
-<!-- Misplaced: file-ignore is only honored as the first comment of the file -->
+<!-- Misplaced: `file-ignore` is only honored as the file's first comment -->
 {# djangofmt: file-ignore[invalid-attr-value] #}
 <div></div>
 
-<!-- Misplaced: nested file-ignore -->
+<!-- Misplaced: nested `file-ignore` -->
 <div>
   {# djangofmt: file-ignore[empty-attr-value] #}
   <p>hi</p>
 </div>
 
-<!-- invalid-syntax cannot be scoped to a node -->
+<!-- `invalid-syntax` cannot be scoped to a node -->
 {# djangofmt: ignore[invalid-syntax] #}
 <div></div>
 
-<!-- format cannot be scoped to a node -->
+<!-- `format` cannot be scoped to a node -->
 {# djangofmt: ignore[format, invalid-attr-value] #}
 <div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
@@ -9,7 +9,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·             ╰── here
  3 │ <form method="yes"></form>
    ╰────
-  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
 
   × Malformed `djangofmt:` directive comment.
    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:6:1]
@@ -19,17 +19,17 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                      ╰── here
  7 │ <div></div>
    ╰────
-  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
 
   × Malformed `djangofmt:` directive comment.
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:10:1]
-  9 │ <!-- Malformed: trailing text after the bracket -->
+  9 │ <!-- Malformed: trailing text -->
  10 │ {# djangofmt: ignore[invalid-attr-value] because reasons #}
     · ─────────────────────────────┬─────────────────────────────
     ·                              ╰── here
  11 │ <div></div>
     ╰────
-  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
 
   × Malformed `djangofmt:` directive comment.
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:14:1]
@@ -39,7 +39,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ·            ╰── here
  15 │ <div></div>
     ╰────
-  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
 
   × Malformed `djangofmt:` directive comment.
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:18:1]
@@ -49,17 +49,17 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ·                       ╰── here
  19 │ <div></div>
     ╰────
-  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
 
   × `file-ignore[...]` must be the first comment in the file.
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:22:1]
- 21 │ <!-- Misplaced: file-ignore is only honored as the first comment of the file -->
+ 21 │ <!-- Misplaced: `file-ignore` is only honored as the file's first comment -->
  22 │ {# djangofmt: file-ignore[invalid-attr-value] #}
     · ────────────────────────┬───────────────────────
     ·                         ╰── here
  23 │ <div></div>
     ╰────
-  help: Move the comment to the very top of the file, or use `ignore[...]` to target the next node.
+  help: Move the comment to the top of the file, or use `ignore[...]` to target the next node.
 
   × `file-ignore[...]` must be the first comment in the file.
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:27:3]
@@ -69,21 +69,21 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ·                          ╰── here
  28 │   <p>hi</p>
     ╰────
-  help: Move the comment to the very top of the file, or use `ignore[...]` to target the next node.
+  help: Move the comment to the top of the file, or use `ignore[...]` to target the next node.
 
   × `invalid-syntax` cannot be scoped to a node.
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:32:22]
- 31 │ <!-- invalid-syntax cannot be scoped to a node -->
+ 31 │ <!-- `invalid-syntax` cannot be scoped to a node -->
  32 │ {# djangofmt: ignore[invalid-syntax] #}
     ·                      ───────┬──────
     ·                             ╰── here
  33 │ <div></div>
     ╰────
-  help: A file that does not parse has no nodes to attach to; use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.
+  help: An unparsable file has no nodes to attach to: use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.
 
   × `format` cannot be scoped to a node.
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:36:22]
- 35 │ <!-- format cannot be scoped to a node -->
+ 35 │ <!-- `format` cannot be scoped to a node -->
  36 │ {# djangofmt: ignore[format, invalid-attr-value] #}
     ·                      ───┬──
     ·                         ╰── here

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
@@ -1,0 +1,92 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Malformed `djangofmt:` directive comment.
+   ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:2:1]
+ 1 │ <!-- Malformed: empty rule list -->
+ 2 │ {# djangofmt: ignore[] #}
+   · ────────────┬────────────
+   ·             ╰── here
+ 3 │ <form method="yes"></form>
+   ╰────
+  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+
+  × Malformed `djangofmt:` directive comment.
+   ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:6:1]
+ 5 │ <!-- Malformed: missing closing bracket -->
+ 6 │ {# djangofmt: ignore[invalid-attr-value #}
+   · ─────────────────────┬────────────────────
+   ·                      ╰── here
+ 7 │ <div></div>
+   ╰────
+  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+
+  × Malformed `djangofmt:` directive comment.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:10:1]
+  9 │ <!-- Malformed: trailing text after the bracket -->
+ 10 │ {# djangofmt: ignore[invalid-attr-value] because reasons #}
+    · ─────────────────────────────┬─────────────────────────────
+    ·                              ╰── here
+ 11 │ <div></div>
+    ╰────
+  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+
+  × Malformed `djangofmt:` directive comment.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:14:1]
+ 13 │ <!-- Malformed: the bare directive takes no space before `ignore` -->
+ 14 │ {# djangofmt: ignore #}
+    · ───────────┬───────────
+    ·            ╰── here
+ 15 │ <div></div>
+    ╰────
+  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+
+  × Malformed `djangofmt:` directive comment.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:18:1]
+ 17 │ <!-- Malformed: unknown keyword -->
+ 18 │ {# djangofmt: silence[invalid-attr-value] #}
+    · ──────────────────────┬─────────────────────
+    ·                       ╰── here
+ 19 │ <div></div>
+    ╰────
+  help: Write `{# djangofmt: ignore[rule1, rule2] #}` before a node, or `{# djangofmt: file-ignore[...] #}` at the top of the file.
+
+  × `file-ignore[...]` must be the first comment in the file.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:22:1]
+ 21 │ <!-- Misplaced: file-ignore is only honored as the first comment of the file -->
+ 22 │ {# djangofmt: file-ignore[invalid-attr-value] #}
+    · ────────────────────────┬───────────────────────
+    ·                         ╰── here
+ 23 │ <div></div>
+    ╰────
+  help: Move the comment to the very top of the file, or use `ignore[...]` to target the next node.
+
+  × `file-ignore[...]` must be the first comment in the file.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:27:3]
+ 26 │ <div>
+ 27 │   {# djangofmt: file-ignore[empty-attr-value] #}
+    ·   ───────────────────────┬──────────────────────
+    ·                          ╰── here
+ 28 │   <p>hi</p>
+    ╰────
+  help: Move the comment to the very top of the file, or use `ignore[...]` to target the next node.
+
+  × `invalid-syntax` cannot be scoped to a node.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:32:22]
+ 31 │ <!-- invalid-syntax cannot be scoped to a node -->
+ 32 │ {# djangofmt: ignore[invalid-syntax] #}
+    ·                      ───────┬──────
+    ·                             ╰── here
+ 33 │ <div></div>
+    ╰────
+  help: A file that does not parse has no nodes to attach to; use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.
+
+  × `format` cannot be scoped to a node.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:36:22]
+ 35 │ <!-- format cannot be scoped to a node -->
+ 36 │ {# djangofmt: ignore[format, invalid-attr-value] #}
+    ·                      ───┬──
+    ·                         ╰── here
+ 37 │ <div></div>
+    ╰────
+  help: Use a bare `{# djangofmt:ignore #}` comment to skip formatting the next node.

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.valid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.valid.html
@@ -1,0 +1,22 @@
+{# djangofmt: file-ignore[missing-img-alt, empty-attr-value] #}
+{# The file-ignore above is the first comment, exactly where it belongs #}
+
+{# djangofmt: ignore[invalid-attr-value] #}
+<form method="yes"></form>
+
+{# Unknown codes are unknown-ignore-code's concern, not a malformed directive #}
+{# djangofmt: ignore[not-a-real-rule] #}
+<div></div>
+
+{# The formatter's bare directive is valid, with or without an explanation #}
+{# djangofmt:ignore #}
+<div   class="kept"  ></div>
+{# djangofmt:ignore this table is generated #}
+<div></div>
+
+{# A comment merely mentioning djangofmt: something is not a directive #}
+{# See djangofmt: https://unknownplatypus.github.io/djangofmt/ #}
+<div></div>
+
+<!-- HTML comments never carry directives: <!-- djangofmt: ignore[] --> is redirected-ignore's concern -->
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.valid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.valid.html
@@ -1,22 +1,23 @@
 {# djangofmt: file-ignore[missing-img-alt, empty-attr-value] #}
-{# The file-ignore above is the first comment, exactly where it belongs #}
+{# The file-ignore above is the first comment, where it belongs #}
 
 {# djangofmt: ignore[invalid-attr-value] #}
 <form method="yes"></form>
 
-{# Unknown codes are unknown-ignore-code's concern, not a malformed directive #}
+{# Unknown codes are unknown-ignore-code's concern #}
 {# djangofmt: ignore[not-a-real-rule] #}
 <div></div>
 
-{# The formatter's bare directive is valid, with or without an explanation #}
+{# The formatter's bare directive, with and without an explanation #}
 {# djangofmt:ignore #}
-<div   class="kept"  ></div>
+<div></div>
 {# djangofmt:ignore this table is generated #}
 <div></div>
 
-{# A comment merely mentioning djangofmt: something is not a directive #}
+{# Merely mentioning djangofmt: is not a directive #}
 {# See djangofmt: https://unknownplatypus.github.io/djangofmt/ #}
 <div></div>
 
-<!-- HTML comments never carry directives: <!-- djangofmt: ignore[] --> is redirected-ignore's concern -->
+{# A directive in an HTML comment is redirected-ignore's concern #}
+<!-- djangofmt: ignore[] -->
 <div></div>

--- a/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.fixed.snap
@@ -1,0 +1,20 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+<!-- Legacy formatter directive in an HTML comment -->
+{# djangofmt:ignore #}
+<div   class="kept"  ></div>
+
+<!-- A suppression in an HTML comment silently does nothing -->
+{# djangofmt: ignore[invalid-attr-value] #}
+<form method="yes"></form>
+
+<!-- No spaces around the directive -->
+{#djangofmt:ignore#}
+<div></div>
+
+<!-- Nested inside an element -->
+<div>
+  {# djangofmt:ignore #}
+  <p     class="kept"  >hi</p>
+</div>

--- a/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.html
+++ b/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.html
@@ -1,0 +1,17 @@
+<!-- Legacy formatter directive in an HTML comment -->
+<!-- djangofmt:ignore -->
+<div   class="kept"  ></div>
+
+<!-- A suppression in an HTML comment silently does nothing -->
+<!-- djangofmt: ignore[invalid-attr-value] -->
+<form method="yes"></form>
+
+<!-- No spaces around the directive -->
+<!--djangofmt:ignore-->
+<div></div>
+
+<!-- Nested inside an element -->
+<div>
+  <!-- djangofmt:ignore -->
+  <p     class="kept"  >hi</p>
+</div>

--- a/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.snap
@@ -9,7 +9,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·             ╰── here
  3 │ <div   class="kept"  ></div>
    ╰────
-  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.
+  help: Move the directive into a `{# #}` template comment: it is stripped at render time, and it is the only style suppressions are read from.
 
   × djangofmt directive in an HTML comment.
    ╭─[tests/check/redirected_ignore/redirected_ignore.invalid.html:6:1]
@@ -19,7 +19,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                        ╰── here
  7 │ <form method="yes"></form>
    ╰────
-  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.
+  help: Move the directive into a `{# #}` template comment: it is stripped at render time, and it is the only style suppressions are read from.
 
   × djangofmt directive in an HTML comment.
     ╭─[tests/check/redirected_ignore/redirected_ignore.invalid.html:10:1]
@@ -29,7 +29,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ·            ╰── here
  11 │ <div></div>
     ╰────
-  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.
+  help: Move the directive into a `{# #}` template comment: it is stripped at render time, and it is the only style suppressions are read from.
 
   × djangofmt directive in an HTML comment.
     ╭─[tests/check/redirected_ignore/redirected_ignore.invalid.html:15:3]
@@ -39,4 +39,4 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ·               ╰── here
  16 │   <p     class="kept"  >hi</p>
     ╰────
-  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.
+  help: Move the directive into a `{# #}` template comment: it is stripped at render time, and it is the only style suppressions are read from.

--- a/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.invalid.snap
@@ -1,0 +1,42 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × djangofmt directive in an HTML comment.
+   ╭─[tests/check/redirected_ignore/redirected_ignore.invalid.html:2:1]
+ 1 │ <!-- Legacy formatter directive in an HTML comment -->
+ 2 │ <!-- djangofmt:ignore -->
+   · ────────────┬────────────
+   ·             ╰── here
+ 3 │ <div   class="kept"  ></div>
+   ╰────
+  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.
+
+  × djangofmt directive in an HTML comment.
+   ╭─[tests/check/redirected_ignore/redirected_ignore.invalid.html:6:1]
+ 5 │ <!-- A suppression in an HTML comment silently does nothing -->
+ 6 │ <!-- djangofmt: ignore[invalid-attr-value] -->
+   · ───────────────────────┬──────────────────────
+   ·                        ╰── here
+ 7 │ <form method="yes"></form>
+   ╰────
+  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.
+
+  × djangofmt directive in an HTML comment.
+    ╭─[tests/check/redirected_ignore/redirected_ignore.invalid.html:10:1]
+  9 │ <!-- No spaces around the directive -->
+ 10 │ <!--djangofmt:ignore-->
+    · ───────────┬───────────
+    ·            ╰── here
+ 11 │ <div></div>
+    ╰────
+  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.
+
+  × djangofmt directive in an HTML comment.
+    ╭─[tests/check/redirected_ignore/redirected_ignore.invalid.html:15:3]
+ 14 │ <div>
+ 15 │   <!-- djangofmt:ignore -->
+    ·   ────────────┬────────────
+    ·               ╰── here
+ 16 │   <p     class="kept"  >hi</p>
+    ╰────
+  help: Directives belong in a `{# #}` template comment: it is not rendered to the client, and it is the only style lint suppressions are read from.

--- a/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.valid.html
+++ b/crates/djangofmt_lint/tests/check/redirected_ignore/redirected_ignore.valid.html
@@ -1,0 +1,12 @@
+{# djangofmt:ignore #}
+<div   class="kept"  ></div>
+
+{# Template-comment directives are already the right style #}
+{# djangofmt: ignore[invalid-attr-value] #}
+<form method="yes"></form>
+
+<!-- A plain HTML comment is fine -->
+<div></div>
+
+<!-- See djangofmt: https://unknownplatypus.github.io/djangofmt/ for details -->
+<div></div>

--- a/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.invalid.html
+++ b/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.invalid.html
@@ -1,0 +1,11 @@
+<!-- Typo in a rule name -->
+{# djangofmt: ignore[invalid-attr-values] #}
+<form method="yes"></form>
+
+<!-- Unknown code hiding among valid ones -->
+{# djangofmt: ignore[invalid-attr-value, not-a-rule] #}
+<div></div>
+
+<!-- file-ignore codes are checked too -->
+{# djangofmt: file-ignore[nonexistent-rule] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.invalid.snap
@@ -1,0 +1,32 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+  × Unknown rule code `invalid-attr-values` in suppression comment.
+   ╭─[tests/check/unknown_ignore_code/unknown_ignore_code.invalid.html:2:22]
+ 1 │ <!-- Typo in a rule name -->
+ 2 │ {# djangofmt: ignore[invalid-attr-values] #}
+   ·                      ─────────┬─────────
+   ·                               ╰── here
+ 3 │ <form method="yes"></form>
+   ╰────
+  help: Fix the typo or remove the code; valid codes are the rule names listed in the documentation.
+
+  × Unknown rule code `not-a-rule` in suppression comment.
+   ╭─[tests/check/unknown_ignore_code/unknown_ignore_code.invalid.html:6:42]
+ 5 │ <!-- Unknown code hiding among valid ones -->
+ 6 │ {# djangofmt: ignore[invalid-attr-value, not-a-rule] #}
+   ·                                          ─────┬────
+   ·                                               ╰── here
+ 7 │ <div></div>
+   ╰────
+  help: Fix the typo or remove the code; valid codes are the rule names listed in the documentation.
+
+  × Unknown rule code `nonexistent-rule` in suppression comment.
+    ╭─[tests/check/unknown_ignore_code/unknown_ignore_code.invalid.html:10:27]
+  9 │ <!-- file-ignore codes are checked too -->
+ 10 │ {# djangofmt: file-ignore[nonexistent-rule] #}
+    ·                           ────────┬───────
+    ·                                   ╰── here
+ 11 │ <div></div>
+    ╰────
+  help: Fix the typo or remove the code; valid codes are the rule names listed in the documentation.

--- a/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.invalid.snap
@@ -9,7 +9,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                               ╰── here
  3 │ <form method="yes"></form>
    ╰────
-  help: Fix the typo or remove the code; valid codes are the rule names listed in the documentation.
+  help: Fix the typo or remove the code: valid codes are the documented rule names.
 
   × Unknown rule code `not-a-rule` in suppression comment.
    ╭─[tests/check/unknown_ignore_code/unknown_ignore_code.invalid.html:6:42]
@@ -19,7 +19,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                                               ╰── here
  7 │ <div></div>
    ╰────
-  help: Fix the typo or remove the code; valid codes are the rule names listed in the documentation.
+  help: Fix the typo or remove the code: valid codes are the documented rule names.
 
   × Unknown rule code `nonexistent-rule` in suppression comment.
     ╭─[tests/check/unknown_ignore_code/unknown_ignore_code.invalid.html:10:27]
@@ -29,4 +29,4 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ·                                   ╰── here
  11 │ <div></div>
     ╰────
-  help: Fix the typo or remove the code; valid codes are the rule names listed in the documentation.
+  help: Fix the typo or remove the code: valid codes are the documented rule names.

--- a/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.valid.html
+++ b/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.valid.html
@@ -4,7 +4,7 @@
 {# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
 <form method="yes"></form>
 
-{# Where a code may appear is invalid-ignore-comment's concern, not this rule's #}
+{# Where a code may appear is invalid-ignore-comment's concern #}
 {# djangofmt: ignore[format] #}
 <div></div>
 

--- a/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.valid.html
+++ b/crates/djangofmt_lint/tests/check/unknown_ignore_code/unknown_ignore_code.valid.html
@@ -1,0 +1,13 @@
+{# djangofmt: file-ignore[format, invalid-syntax] #}
+{# The reserved codes above are known, and so are real rule names #}
+
+{# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
+<form method="yes"></form>
+
+{# Where a code may appear is invalid-ignore-comment's concern, not this rule's #}
+{# djangofmt: ignore[format] #}
+<div></div>
+
+{# A malformed directive has no codes to check #}
+{# djangofmt: ignore[] #}
+<div></div>

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,7 +2,7 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, Settings, file_ignores_invalid_syntax, lint_source};
+use djangofmt_lint::{FileDiagnostics, Settings, file_ignores, lint_source};
 use miette::{GraphicalReportHandler, GraphicalTheme};
 use serde::Serialize;
 use std::path::PathBuf;
@@ -191,7 +191,7 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
         Ok(diagnostics) => diagnostics,
         Err(e) => {
             // Match the CLI: `file-ignore[invalid-syntax]` skips the file.
-            if file_ignores_invalid_syntax(source) {
+            if file_ignores(source).invalid_syntax {
                 return Ok(LintResult::new(0, String::new()));
             }
             let err = markup_fmt::FormatError::Syntax(e);

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,7 +2,7 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, Settings, lint_source};
+use djangofmt_lint::{FileDiagnostics, Settings, file_ignores_invalid_syntax, lint_source};
 use miette::{GraphicalReportHandler, GraphicalTheme};
 use serde::Serialize;
 use std::path::PathBuf;
@@ -190,6 +190,10 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
     let diagnostics = match lint_source(source, profile.into(), &[], &Settings::all(), None) {
         Ok(diagnostics) => diagnostics,
         Err(e) => {
+            // Match the CLI: `file-ignore[invalid-syntax]` skips the file.
+            if file_ignores_invalid_syntax(source) {
+                return Ok(LintResult::new(0, String::new()));
+            }
             let err = markup_fmt::FormatError::Syntax(e);
             return Ok(LintResult::new(1, render_parse_error(source, &err)));
         }

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -63,20 +63,25 @@ attribute values to pass non-string types (booleans, numbers, template variables
 
 ## Disabling formatting
 
-To disable formatting for an entire file, add `<!-- djangofmt:ignore -->` at the very top of the file.
-
-To disable formatting for a specific node, prefix it with the same comment:
+To disable formatting for an entire file, add `{# djangofmt: file-ignore[format] #}` at the very top of the file:
 
 ```html
-<!-- djangofmt:ignore -->
+{# djangofmt: file-ignore[format] #}
 <div   class="keep-this-unformatted"   >Content</div>
-<div class="this-will-be-formatted">Content</div>
 ```
 
-A Django/Jinja comment works the same way, both inline and at the top of a file.
-Unlike an HTML comment, it isn't rendered to the client:
+To disable formatting for a specific node, prefix it with a `{# djangofmt:ignore #}` comment:
 
 ```html
 {# djangofmt:ignore #}
 <div   class="keep-this-unformatted"   >Content</div>
+<div class="this-will-be-formatted">Content</div>
 ```
+
+A file that djangofmt cannot parse at all can be quarantined with `{# djangofmt: file-ignore[invalid-syntax] #}`
+at the very top: both `format` and `check` then skip it instead of reporting a parse error.
+
+For backward compatibility, a bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the
+very top of a file still skips it entirely, parse errors included. Prefer the explicit
+`file-ignore[...]` form: it says what is being opted out of, and the `{# #}` comment style isn't
+rendered to the client.

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -78,10 +78,9 @@ To disable formatting for a specific node, prefix it with a `{# djangofmt:ignore
 <div class="this-will-be-formatted">Content</div>
 ```
 
-A file that djangofmt cannot parse at all can be quarantined with `{# djangofmt: file-ignore[invalid-syntax] #}`
-at the very top: both `format` and `check` then skip it instead of reporting a parse error.
+A file djangofmt cannot parse at all can be quarantined with `{# djangofmt: file-ignore[invalid-syntax] #}`
+at the very top: both `format` and `check` skip it instead of reporting a parse error.
 
-For backward compatibility, a bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the
-very top of a file still skips it entirely, parse errors included. Prefer the explicit
-`file-ignore[...]` form: it says what is being opted out of, and the `{# #}` comment style isn't
-rendered to the client.
+A bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the very top still skips the
+whole file, parse errors included, for backward compatibility. Prefer `file-ignore[...]`: it states
+what is opted out of, and `{# #}` comments aren't rendered to the client.


### PR DESCRIPTION

One pattern for everything: `ignore[...]` always takes at least one code, the formatter is just a code (`format`).
File-wide suppression is a distinct keyword (`file-ignore`). We need this because most template have many top level nodes so a top level `ignore[...]` would be ambiguous.

```jinja
# Formatter
{# djangofmt: ignore[format] #}          ← formatter skips the next node
{# djangofmt: file-ignore[format] #}     ← formatter skips the whole file

# Linter
{# djangofmt: ignore[missing-img-alt, empty-attr-value] #}   ← silence rules on the next node + subtree
{# djangofmt: file-ignore[missing-img-alt] #}                ← silence rules for the whole file

# Unparsable file — both commands skip it (raw text scan of the leading comment, since we can't parse)
{# djangofmt: file-ignore[invalid-syntax] #}

# Backward compat, deprecated
{# djangofmt: ignore #}      ← alias of ignore[format]; of file-ignore[format] when first in the file
<!-- djangofmt:ignore -->    ← same
```

Semantics:
- `ignore[...]` / `file-ignore[...]` require at least one code. No blanket form allowed
- Only support django comment styles (`{# #}` , not `<!-- -->`) 
  - whitespace around `djangofmt:` is tolerated.
  - `<!-- djangofmt:ignore -->` get's rewritten by `redirected-ignore` lint rule but still works for backward compat
- `file-ignore` must be the first comment in the file, anywhere else → diagnostic.
- `invalid-syntax` is only valid in `file-ignore` — node-level is meaningless (can't locate
  a node in a file we can't parse) → error with a hint.
- Unknown codes should cause warning.
- Mixing concerns in one comment (`ignore[format, missing-img-alt]`) is nice to have but only if it's not too much work.

Fix #289
Fix #373