### PR TITLE
fix(cli): honor a leading `djangofmt:ignore` on unparsable files in `check`

### DIFF
--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -20,7 +20,7 @@ use crate::fs::relativize_path;
 use crate::per_file_ignores::PerFileIgnores;
 use crate::pyproject::LintSettings;
 
-use super::format::merge_custom_blocks;
+use super::format::{is_file_ignored, merge_custom_blocks};
 
 /// Resolved fix-related configuration after merging CLI args with pyproject settings.
 #[derive(Debug, PartialEq, Eq)]
@@ -346,11 +346,7 @@ fn check_path(
                 });
             }
             Err(FixerError::InitialParse(err)) => {
-                return Err(Box::new(CommandError::Parse(ParseError::new(
-                    Some(path.to_path_buf()),
-                    source,
-                    &FormatError::Syntax(err),
-                ))));
+                return parse_failure(path, source, err);
             }
             Err(FixerError::SyntaxRegression {
                 iteration,
@@ -369,11 +365,7 @@ fn check_path(
         match lint_source(&source, profile.into(), custom_blocks, settings, Some(path)) {
             Ok(diagnostics) => diagnostics,
             Err(err) => {
-                return Err(Box::new(CommandError::Parse(ParseError::new(
-                    Some(path.to_path_buf()),
-                    source,
-                    &FormatError::Syntax(err),
-                ))));
+                return parse_failure(path, source, err);
             }
         };
     let file_diagnostics = if diagnostics.is_empty() {
@@ -388,6 +380,29 @@ fn check_path(
         applied_count: 0,
         fixes_by_rule: FxHashMap::default(),
     })
+}
+
+/// Report a parse error, unless the file opts out with a leading `djangofmt:ignore`
+/// comment — `format` already skips those, so `check` must too.
+fn parse_failure(
+    path: &Path,
+    source: String,
+    err: markup_fmt::SyntaxError,
+) -> std::result::Result<CheckResult, Box<CommandError>> {
+    if is_file_ignored(&source) {
+        debug!("Skipping unparsable {} (djangofmt:ignore)", path.display());
+        return Ok(CheckResult {
+            path: path.to_path_buf(),
+            file_diagnostics: FileDiagnostics::empty(),
+            applied_count: 0,
+            fixes_by_rule: FxHashMap::default(),
+        });
+    }
+    Err(Box::new(CommandError::Parse(ParseError::new(
+        Some(path.to_path_buf()),
+        source,
+        &FormatError::Syntax(err),
+    ))))
 }
 
 #[cfg(test)]

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -118,6 +118,13 @@ const DJANGOFMT_IGNORE_COMMENT_DIRECTIVE: &str = ignore_directive!();
 const DJANGOFMT_IGNORE_COMMENT: &str = concat!("<!-- ", ignore_directive!(), " -->");
 const DJANGOFMT_IGNORE_COMMENT_JINJA: &str = concat!("{# ", ignore_directive!(), " #}");
 
+/// Whether the file opts out of djangofmt entirely with a leading ignore comment.
+#[must_use]
+pub(crate) fn is_file_ignored(source: &str) -> bool {
+    source.starts_with(DJANGOFMT_IGNORE_COMMENT)
+        || source.starts_with(DJANGOFMT_IGNORE_COMMENT_JINJA)
+}
+
 /// Build default `markup_fmt` options for HTML/Jinja formatting.
 #[must_use]
 pub fn build_markup_options(
@@ -317,9 +324,7 @@ pub fn format_text(
     config: &FormatterConfig,
     profile: Profile,
 ) -> std::result::Result<Option<String>, markup_fmt::FormatError> {
-    if source.starts_with(DJANGOFMT_IGNORE_COMMENT)
-        || source.starts_with(DJANGOFMT_IGNORE_COMMENT_JINJA)
-    {
+    if is_file_ignored(source) {
         return Ok(None);
     }
     markup_fmt::format_text(

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -52,6 +52,19 @@ fn format_file_with_ignore_directive() {
 }
 
 #[test]
+fn check_unparsable_file_with_ignore_directive() {
+    let project = Project::new().file("test.html", "{# djangofmt:ignore #}\n<div>\n");
+    assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    ");
+}
+
+#[test]
 fn format_nonexistent_file() {
     assert_cmd_snapshot!(cli().arg("/nonexistent/path.html"), @r#"
     success: false

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -65,6 +65,9 @@ attribute values to pass non-string types (booleans, numbers, template variables
 
 To disable formatting for an entire file, add `<!-- djangofmt:ignore -->` at the very top of the file.
 
+A file ignored this way is also skipped by `djangofmt check` when it cannot be parsed,
+so templates that break the parser can be quarantined from both commands.
+
 To disable formatting for a specific node, prefix it with the same comment:
 
 ```html


### PR DESCRIPTION
Fixes #373 by respecting the existing `{# djangofmt:ignore #}` pending the ignore redisign in https://github.com/UnknownPlatypus/djangofmt/issues/289#issuecomment-5246206996