### PR TITLE
feat(cli): Add `{# djangofmt: file-ignore[...] #}` file-level opt-outs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "insta",
  "markup_fmt",
  "oxc-miette",
+ "rstest",
  "rustc-hash",
  "rustywind_core",
  "serde",

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,5 +1,6 @@
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings, lint_fix, lint_source,
+    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings, file_ignores, lint_fix,
+    lint_source,
 };
 use markup_fmt::FormatError;
 use miette::{SourceCode, SpanContents};
@@ -15,12 +16,12 @@ use tracing::{debug, error, info, warn};
 use crate::ExitStatus;
 use crate::args::{CheckCommand, OutputFormat, Profile};
 use crate::config::{resolve_bool_arg, resolve_profile, resolve_rule_selection};
-use crate::error::{CommandError, ParseError, Result};
+use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
 use crate::fs::relativize_path;
 use crate::per_file_ignores::PerFileIgnores;
 use crate::pyproject::LintSettings;
 
-use super::format::{is_file_ignored, merge_custom_blocks};
+use super::format::merge_custom_blocks;
 
 /// Resolved fix-related configuration after merging CLI args with pyproject settings.
 #[derive(Debug, PartialEq, Eq)]
@@ -67,6 +68,8 @@ struct CheckResult {
     applied_count: usize,
     /// Per-rule applied summaries, for `--show-fixes`.
     fixes_by_rule: FxHashMap<&'static str, RuleFixSummary>,
+    /// Whether the file was skipped via `file-ignore[invalid-syntax]`.
+    skipped: bool,
 }
 
 /// Check the given source code for linting errors.
@@ -171,6 +174,8 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         config.unsafe_fixes,
         nb_errors,
     );
+
+    print_skipped(&results);
 
     if config.show_fixes && total_applied > 0 {
         print_show_fixes(&results, total_applied);
@@ -278,6 +283,17 @@ fn print_summary(
     }
 }
 
+/// Mirror the format command's skip counter for quarantined files.
+fn print_skipped(results: &[CheckResult]) {
+    let skipped = results.iter().filter(|result| result.skipped).count();
+    if skipped > 0 {
+        info!(
+            "{skipped} file{} skipped !",
+            if skipped == 1 { "" } else { "s" }
+        );
+    }
+}
+
 fn print_show_fixes(results: &[CheckResult], total_applied: usize) {
     info!("Fixed {total_applied} errors:");
     for result in results {
@@ -345,6 +361,7 @@ fn check_path(
                     file_diagnostics,
                     applied_count: result.applied_count,
                     fixes_by_rule: result.applied_by_rule,
+                    skipped: false,
                 });
             }
             Err(FixerError::InitialParse(err)) => {
@@ -381,30 +398,31 @@ fn check_path(
         file_diagnostics,
         applied_count: 0,
         fixes_by_rule: FxHashMap::default(),
+        skipped: false,
     })
 }
 
-/// Report a parse error, unless the file opts out with a leading `djangofmt:ignore`
-/// comment — `format` already skips those, so `check` must too.
+/// Skip the file if it is quarantined with `file-ignore[invalid-syntax]`,
+/// otherwise report the error with a hint at the escape hatches.
 fn parse_failure(
     path: &Path,
     source: String,
     err: markup_fmt::SyntaxError,
 ) -> std::result::Result<CheckResult, Box<CommandError>> {
-    if is_file_ignored(&source) {
-        debug!("Skipping unparsable {} (djangofmt:ignore)", path.display());
+    if file_ignores(&source).invalid_syntax {
+        debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
         return Ok(CheckResult {
             path: path.to_path_buf(),
             file_diagnostics: FileDiagnostics::empty(),
             applied_count: 0,
             fixes_by_rule: FxHashMap::default(),
+            skipped: true,
         });
     }
-    Err(Box::new(CommandError::Parse(ParseError::new(
-        Some(path.to_path_buf()),
-        source,
-        &FormatError::Syntax(err),
-    ))))
+    Err(Box::new(CommandError::Parse(
+        ParseError::new(Some(path.to_path_buf()), source, &FormatError::Syntax(err))
+            .with_hint(SKIP_FILE_HINT),
+    )))
 }
 
 #[cfg(test)]

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,5 +1,5 @@
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, FixerError, RuleFixSummary, Settings, file_ignores, lint_fix,
+    Applicability, FileDiagnostics, FileIgnores, FixerError, RuleFixSummary, Settings, lint_fix,
     lint_source,
 };
 use markup_fmt::FormatError;
@@ -409,7 +409,7 @@ fn parse_failure(
     source: String,
     err: markup_fmt::SyntaxError,
 ) -> std::result::Result<CheckResult, Box<CommandError>> {
-    if file_ignores(&source).invalid_syntax {
+    if FileIgnores::parse(&source).invalid_syntax {
         debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
         return Ok(CheckResult {
             path: path.to_path_buf(),

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -419,10 +419,11 @@ fn parse_failure(
             skipped: true,
         });
     }
-    Err(Box::new(CommandError::Parse(
+    Err(
         ParseError::new(Some(path.to_path_buf()), source, &FormatError::Syntax(err))
-            .with_hint(SKIP_FILE_HINT),
-    )))
+            .with_fallback_hint(SKIP_FILE_HINT)
+            .into(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -1,4 +1,4 @@
-use djangofmt_lint::file_ignores;
+use djangofmt_lint::FileIgnores;
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::borrow::Cow;
@@ -317,7 +317,7 @@ pub fn format_text(
     profile: Profile,
     path: Option<&Path>,
 ) -> std::result::Result<Option<String>, markup_fmt::FormatError> {
-    let ignores = file_ignores(source);
+    let ignores = FileIgnores::parse(source);
     if ignores.format {
         return Ok(None);
     }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -422,10 +422,9 @@ fn format_path(
     let formatted = match format_text(&unformatted, &config, profile, Some(path)) {
         Ok(f) => f,
         Err(err) => {
-            return Err(Box::new(CommandError::Parse(
-                ParseError::new(Some(path.to_path_buf()), unformatted, &err)
-                    .with_hint(SKIP_FILE_HINT),
-            )));
+            return Err(ParseError::new(Some(path.to_path_buf()), unformatted, &err)
+                .with_fallback_hint(SKIP_FILE_HINT)
+                .into());
         }
     };
 

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -1,3 +1,4 @@
+use djangofmt_lint::file_ignores;
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::borrow::Cow;
@@ -12,7 +13,7 @@ use crate::ExitStatus;
 use crate::args::{FormatCommand, OutputFormat, Profile};
 use crate::config::{resolve_bool_arg, resolve_profile};
 use crate::editorconfig::{self, EditorconfigSettings};
-use crate::error::{CommandError, ParseError, Result};
+use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
 use crate::fs::relativize_path;
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 use crate::panic::catch_unwind;
@@ -113,17 +114,6 @@ pub(crate) fn merge_custom_blocks(
 }
 
 const DJANGOFMT_IGNORE_COMMENT_DIRECTIVE: &str = "djangofmt:ignore";
-
-/// Whether the file opts out of djangofmt entirely with a leading ignore comment.
-#[must_use]
-pub(crate) fn is_file_ignored(source: &str) -> bool {
-    source
-        .strip_prefix("<!--")
-        .or_else(|| source.strip_prefix("{#"))
-        .is_some_and(|comment| {
-            markup_fmt::starts_with_directive(comment, DJANGOFMT_IGNORE_COMMENT_DIRECTIVE)
-        })
-}
 
 /// Build default `markup_fmt` options for HTML/Jinja formatting.
 #[must_use]
@@ -327,10 +317,11 @@ pub fn format_text(
     profile: Profile,
     path: Option<&Path>,
 ) -> std::result::Result<Option<String>, markup_fmt::FormatError> {
-    if is_file_ignored(source) {
+    let ignores = file_ignores(source);
+    if ignores.format {
         return Ok(None);
     }
-    markup_fmt::format_text(
+    let result = markup_fmt::format_text(
         source,
         markup_fmt::Language::from(profile),
         &config.markup,
@@ -388,8 +379,12 @@ pub fn format_text(
                 _ => Ok(code.into()),
             }
         },
-    )
-    .map(Some)
+    );
+    match result {
+        // `file-ignore[invalid-syntax]` quarantines the file instead of reporting.
+        Err(markup_fmt::FormatError::Syntax(_)) if ignores.invalid_syntax => Ok(None),
+        other => other.map(Some),
+    }
 }
 
 /// Run an embedded formatter, falling back to the original `code` if it panics.
@@ -427,11 +422,10 @@ fn format_path(
     let formatted = match format_text(&unformatted, &config, profile, Some(path)) {
         Ok(f) => f,
         Err(err) => {
-            return Err(Box::new(CommandError::Parse(ParseError::new(
-                Some(path.to_path_buf()),
-                unformatted,
-                &err,
-            ))));
+            return Err(Box::new(CommandError::Parse(
+                ParseError::new(Some(path.to_path_buf()), unformatted, &err)
+                    .with_hint(SKIP_FILE_HINT),
+            )));
         }
     };
 

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -8,7 +8,7 @@ use crate::args::{FormatCommand, Profile};
 use crate::commands::format::{FormatterConfig, format_text};
 use crate::config::resolve_profile;
 use crate::editorconfig;
-use crate::error::{CommandError, ParseError, Result};
+use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
 use crate::pyproject::load_pyproject_from_cwd;
 use crate::resolver::{ResolvedDiscoveryConfig, is_force_excluded};
 
@@ -59,11 +59,10 @@ fn format_source_code(
     let formatted = match format_text(&source, config, profile, path) {
         Ok(f) => f,
         Err(err) => {
-            return Err(Box::new(CommandError::Parse(ParseError::new(
-                path.map(Path::to_path_buf),
-                source,
-                &err,
-            ))));
+            return Err(Box::new(CommandError::Parse(
+                ParseError::new(path.map(Path::to_path_buf), source, &err)
+                    .with_hint(SKIP_FILE_HINT),
+            )));
         }
     };
 

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -54,15 +54,14 @@ fn format_source_code(
     stdin()
         .lock()
         .read_to_string(&mut source)
-        .map_err(|err| Box::new(CommandError::Read(path.map(Path::to_path_buf), err)))?;
+        .map_err(|err| CommandError::Read(path.map(Path::to_path_buf), err))?;
 
     let formatted = match format_text(&source, config, profile, path) {
         Ok(f) => f,
         Err(err) => {
-            return Err(Box::new(CommandError::Parse(
-                ParseError::new(path.map(Path::to_path_buf), source, &err)
-                    .with_hint(SKIP_FILE_HINT),
-            )));
+            return Err(ParseError::new(path.map(Path::to_path_buf), source, &err)
+                .with_fallback_hint(SKIP_FILE_HINT)
+                .into());
         }
     };
 
@@ -70,6 +69,6 @@ fn format_source_code(
     stdout()
         .lock()
         .write_all(output.as_bytes())
-        .map_err(|err| Box::new(CommandError::Write(path.map(Path::to_path_buf), err)))?;
+        .map_err(|err| CommandError::Write(path.map(Path::to_path_buf), err))?;
     Ok(())
 }

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -106,6 +106,9 @@ impl CommandError {
     }
 }
 
+/// Escape hatches suggested when a file cannot be parsed.
+pub const SKIP_FILE_HINT: &str = "Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of this file, or list it in `extend-exclude`, to skip it.";
+
 impl ParseError {
     #[must_use]
     pub fn new(path: Option<PathBuf>, source: String, err: &markup_fmt::FormatError) -> Self {
@@ -152,6 +155,16 @@ impl ParseError {
             span,
             hint,
         }
+    }
+
+    /// Append a help line to the error, keeping any existing hint.
+    #[must_use]
+    pub fn with_hint(mut self, hint: &str) -> Self {
+        self.hint = Some(self.hint.take().map_or_else(
+            || hint.to_string(),
+            |existing| format!("{existing}\n{hint}"),
+        ));
+        self
     }
 
     /// 1-based line and column the error points at.

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -78,6 +78,12 @@ pub enum CommandError {
     Panic(Option<PathBuf>, Box<PanicError>),
 }
 
+impl From<ParseError> for Box<CommandError> {
+    fn from(err: ParseError) -> Self {
+        Self::new(CommandError::Parse(err))
+    }
+}
+
 impl CommandError {
     #[must_use]
     pub fn path(&self) -> Option<&Path> {
@@ -157,13 +163,10 @@ impl ParseError {
         }
     }
 
-    /// Append a help line to the error, keeping any existing hint.
+    /// Help text used only when the error carries no more specific hint.
     #[must_use]
-    pub fn with_hint(mut self, hint: &str) -> Self {
-        self.hint = Some(self.hint.take().map_or_else(
-            || hint.to_string(),
-            |existing| format!("{existing}\n{hint}"),
-        ));
+    pub fn with_fallback_hint(mut self, hint: &str) -> Self {
+        self.hint.get_or_insert_with(|| hint.to_string());
         self
     }
 

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -109,7 +109,7 @@ fn format_quiet() {
 #[test]
 fn format_file_parse_error_exits_2() {
     let project = Project::new().file("test.html", "<div   class=\"foo\"  >");
-    assert_cmd_snapshot_tmpdir!(cli().arg(project.join("test.html")), @r##"
+    assert_cmd_snapshot_tmpdir!(cli().arg(project.join("test.html")), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -123,13 +123,11 @@ fn format_file_parse_error_exits_2() {
        ·   ╰── here
        ╰────
       help: If a `</div>` does exist, it must live in the same block as the
-            opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
-            limitations/#conditional-openclose-tags
-            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
-            this file, or list it in `extend-exclude`, to skip it.
+            opening tag.
+            https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
 
     Couldn't format 1 files!
-    "##);
+    "###);
 }
 
 // ── Format from stdin ────────────────────────────────────────────────
@@ -220,8 +218,9 @@ fn format_stdin_ignore_directive() {
 
 #[test]
 fn format_stdin_parse_error_exits_2() {
+    // A generic parse error has no specific hint: the skip-file one shows instead.
     assert_cmd_snapshot!(
-        cli().arg("-").pass_stdin("<div   class=\"foo\"  >"),
+        cli().arg("-").pass_stdin("<div id=></div>"),
         @r##"
     success: false
     exit_code: 2
@@ -229,18 +228,15 @@ fn format_stdin_parse_error_exits_2() {
 
     ----- stderr -----
 
-      × expected close tag for opening tag <div>
-       ╭─[<unknown>:1:2]
-     1 │ <div   class="foo"  >
-       ·  ─┬─
-       ·   ╰── here
+      × expected attribute value
+       ╭─[<unknown>:1:9]
+     1 │ <div id=></div>
+       ·         ▲
+       ·         ╰── here
        ╰────
-      help: If a `</div>` does exist, it must live in the same block as the
-            opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
-            limitations/#conditional-openclose-tags
-            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+      help: Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
             this file, or list it in `extend-exclude`, to skip it.
-    "###);
+    "##);
 }
 
 #[test]
@@ -504,7 +500,7 @@ fn check_skips_unparsable_files_that_opted_out() {
 #[test]
 fn check_malformed_file_with_fix_surfaces_parse_error() {
     let project = Project::new().file("test.html", "{% if x %}\n  unclosed\n");
-    assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r###"
+    assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -520,11 +516,9 @@ fn check_malformed_file_with_fix_surfaces_parse_error() {
        ╰────
       help: Check for invalid HTML syntax inside the block that might prevent
             finding the end tag.
-            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
-            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't check 1 files!
-    "###);
+    "#);
 }
 
 #[test]
@@ -537,7 +531,7 @@ fn check_respects_pyproject_custom_blocks() {
             "[tool.djangofmt]\ncustom-blocks = [\"stage\"]\n",
         )
         .file("test.html", "{% stage %}\n<p>hi</p>\n");
-    assert_cmd_snapshot!(cli().current_dir(project.path()).args(["check", "test.html"]), @r###"
+    assert_cmd_snapshot!(cli().current_dir(project.path()).args(["check", "test.html"]), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -553,11 +547,9 @@ fn check_respects_pyproject_custom_blocks() {
        ╰────
       help: Check for invalid HTML syntax inside the block that might prevent
             finding the end tag.
-            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
-            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't check 1 files!
-    "###);
+    "#);
 }
 
 #[test]

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -486,7 +486,10 @@ fn check_skips_unparsable_files_that_opted_out() {
             "bracketed.html",
             "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n",
         )
-        .file("legacy.html", "{# djangofmt: ignore #}\n<div id=>\n</div>\n");
+        .file(
+            "legacy.html",
+            "{# djangofmt: ignore #}\n<div id=>\n</div>\n",
+        );
     assert_cmd_snapshot!(cli().arg("check").arg(project.path()), @r"
     success: true
     exit_code: 0

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -52,21 +52,6 @@ fn format_file_with_ignore_directive() {
 }
 
 #[test]
-fn format_unparsable_file_with_invalid_syntax_file_ignore() {
-    let original = "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n";
-    let project = Project::new().file("test.html", original);
-    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    1 file skipped !
-    "#);
-    assert_eq!(project.read("test.html"), original);
-}
-
-#[test]
 fn format_nonexistent_file() {
     assert_cmd_snapshot!(cli().arg("/nonexistent/path.html"), @r#"
     success: false

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -52,16 +52,18 @@ fn format_file_with_ignore_directive() {
 }
 
 #[test]
-fn check_unparsable_file_with_ignore_directive() {
-    let project = Project::new().file("test.html", "{# djangofmt:   ignore #}\n<div>\n");
-    assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r"
+fn format_unparsable_file_with_invalid_syntax_file_ignore() {
+    let original = "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n";
+    let project = Project::new().file("test.html", original);
+    assert_cmd_snapshot!(cli().arg(project.join("test.html")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    All checks passed!
-    ");
+    1 file skipped !
+    "#);
+    assert_eq!(project.read("test.html"), original);
 }
 
 #[test]
@@ -121,8 +123,10 @@ fn format_file_parse_error_exits_2() {
        ·   ╰── here
        ╰────
       help: If a `</div>` does exist, it must live in the same block as the
-            opening tag.
-            https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
+            opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
+            limitations/#conditional-openclose-tags
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't format 1 files!
     "##);
@@ -232,9 +236,11 @@ fn format_stdin_parse_error_exits_2() {
        ·   ╰── here
        ╰────
       help: If a `</div>` does exist, it must live in the same block as the
-            opening tag.
-            https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
-    "##);
+            opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
+            limitations/#conditional-openclose-tags
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
+    "###);
 }
 
 #[test]
@@ -472,6 +478,27 @@ fn check_fixable_file_with_show_fixes() {
 }
 
 #[test]
+fn check_skips_unparsable_files_that_opted_out() {
+    // Both the explicit code and the legacy bare directive (#373) skip a file
+    // `check` cannot parse.
+    let project = Project::new()
+        .file(
+            "bracketed.html",
+            "{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>\n</div>\n",
+        )
+        .file("legacy.html", "{# djangofmt: ignore #}\n<div id=>\n</div>\n");
+    assert_cmd_snapshot!(cli().arg("check").arg(project.path()), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    All checks passed!
+    2 files skipped !
+    ");
+}
+
+#[test]
 fn check_malformed_file_with_fix_surfaces_parse_error() {
     let project = Project::new().file("test.html", "{% if x %}\n  unclosed\n");
     assert_cmd_snapshot_tmpdir!(cli().args(["check", "--fix"]).arg(project.join("test.html")), @r###"
@@ -490,6 +517,8 @@ fn check_malformed_file_with_fix_surfaces_parse_error() {
        ╰────
       help: Check for invalid HTML syntax inside the block that might prevent
             finding the end tag.
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't check 1 files!
     "###);
@@ -521,6 +550,8 @@ fn check_respects_pyproject_custom_blocks() {
        ╰────
       help: Check for invalid HTML syntax inside the block that might prevent
             finding the end tag.
+            Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of
+            this file, or list it in `extend-exclude`, to skip it.
 
     Couldn't check 1 files!
     "###);

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.html
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.html
@@ -1,0 +1,8 @@
+{# djangofmt: file-ignore[format] #}
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>
+
+{# Broken code doesn't crash djangofmt either: file-ignore[format] skips before parsing #}
+<div id=>
+</div>

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.snap
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_format_directive.snap
@@ -1,0 +1,11 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+{# djangofmt: file-ignore[format] #}
+<div>
+    <p     class="unformatted"      >This entire file should not be formatted</p>
+</div>
+
+{# Broken code doesn't crash djangofmt either: file-ignore[format] skips before parsing #}
+<div id=>
+</div>

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.html
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.html
@@ -1,0 +1,2 @@
+{# djangofmt: file-ignore[invalid-syntax] #}
+<p     class="reformatted"      >Parsable content is still formatted, the directive only quarantines parse errors</p>

--- a/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.snap
+++ b/crates/djangofmt/tests/fmt/ignore/file_ignore_invalid_syntax_directive.snap
@@ -1,0 +1,5 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+{# djangofmt: file-ignore[invalid-syntax] #}
+<p class="reformatted">Parsable content is still formatted, the directive only quarantines parse errors</p>

--- a/crates/djangofmt_lint/Cargo.toml
+++ b/crates/djangofmt_lint/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+rstest = { workspace = true }
 strum = { workspace = true }
 
 [lints]

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -22,6 +22,7 @@ pub mod rule_selector;
 pub mod rule_set;
 mod rules;
 pub mod settings;
+mod suppression;
 mod violation;
 
 pub use checker::Checker;
@@ -35,6 +36,7 @@ pub use registry::{Rule, RuleCategory, RuleGroup};
 pub use rule_selector::{RuleSelector, SelectionWarning, SelectorParseError};
 pub use rule_set::RuleSet;
 pub use settings::{LintConfiguration, Settings};
+pub use suppression::{FileIgnores, file_ignores};
 pub use violation::{Violation, ViolationMetadata};
 
 use std::borrow::Cow;

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -36,7 +36,7 @@ pub use registry::{Rule, RuleCategory, RuleGroup};
 pub use rule_selector::{RuleSelector, SelectionWarning, SelectorParseError};
 pub use rule_set::RuleSet;
 pub use settings::{LintConfiguration, Settings};
-pub use suppression::{FileIgnores, file_ignores};
+pub use suppression::FileIgnores;
 pub use violation::{Violation, ViolationMetadata};
 
 use std::borrow::Cow;

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -240,11 +240,16 @@ mod tests {
     }
 
     #[test]
-    fn no_rule_name_collides_with_a_group() {
-        for group in std::iter::once("all").chain(RuleCategory::VARIANTS.iter().copied()) {
+    fn no_rule_name_collides_with_a_reserved_word() {
+        // `format`/`invalid-syntax` are `file-ignore[...]` codes; `lint` is kept free for group suppression.
+        let reserved = ["all", "lint", "format", "invalid-syntax"];
+        for word in reserved
+            .into_iter()
+            .chain(RuleCategory::VARIANTS.iter().copied())
+        {
             assert!(
-                Rule::from_str(group).is_err(),
-                "category/group `{group}` collides with a rule name"
+                Rule::from_str(word).is_err(),
+                "reserved word `{word}` collides with a rule name"
             );
         }
     }

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -1,0 +1,199 @@
+//! File-wide opt-outs declared by `{# djangofmt: file-ignore[...] #}` comments.
+//!
+//! Rules are always listed explicitly, and only `{# #}` comments carry
+//! directives: HTML comments survive in rendered output.
+
+/// `file-ignore[...]` code suppressing parse errors.
+pub const INVALID_SYNTAX: &str = "invalid-syntax";
+
+/// `file-ignore[...]` code skipping the formatter.
+pub const FORMAT: &str = "format";
+
+/// A parsed suppression directive.
+#[derive(Debug, PartialEq, Eq)]
+enum Directive<'s> {
+    /// `djangofmt: ignore[...]` — suppress on the following node.
+    Ignore(Vec<&'s str>),
+    /// `djangofmt: file-ignore[...]` — suppress for the whole file.
+    FileIgnore(Vec<&'s str>),
+}
+
+/// A comment body stripped of Jinja's whitespace-control markers (`{#- ... -#}`),
+/// which are part of the delimiter rather than of the directive.
+fn directive_body(raw: &str) -> &str {
+    raw.trim()
+        .trim_start_matches(['-', '+'])
+        .trim_end_matches('-')
+        .trim()
+}
+
+/// Parse a comment body into a suppression directive.
+///
+/// Grammar: `djangofmt:` (whitespace allowed around the colon), then
+/// `ignore[...]` or `file-ignore[...]` with a non-empty comma-separated rule
+/// list and nothing after the closing bracket.
+fn parse_directive(raw: &str) -> Option<Directive<'_>> {
+    let rest = directive_body(raw)
+        .strip_prefix("djangofmt")?
+        .trim_start()
+        .strip_prefix(':')?
+        .trim_start();
+    let (file_level, rest) = match rest.strip_prefix("file-ignore[") {
+        Some(rest) => (true, rest),
+        None => (false, rest.strip_prefix("ignore[")?),
+    };
+    let codes: Vec<&str> = rest
+        .strip_suffix(']')?
+        .split(',')
+        .map(str::trim)
+        .filter(|code| !code.is_empty())
+        .collect();
+    if codes.is_empty() {
+        return None;
+    }
+    Some(if file_level {
+        Directive::FileIgnore(codes)
+    } else {
+        Directive::Ignore(codes)
+    })
+}
+
+/// File-wide opt-outs declared by the leading comment of a file.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct FileIgnores {
+    /// The formatter skips the whole file (`file-ignore[format]`).
+    pub format: bool,
+    /// Parse errors are suppressed and the file skipped (`file-ignore[invalid-syntax]`).
+    pub invalid_syntax: bool,
+}
+
+/// Opt-outs from the file's leading comment, read straight from the raw source
+/// so they can be honored even when the file fails to parse.
+///
+/// The bare legacy `djangofmt:ignore` (in either comment style) predates rule
+/// codes and opted the file out of everything: it maps to both flags.
+#[must_use]
+pub fn file_ignores(source: &str) -> FileIgnores {
+    // A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
+    let trimmed = source
+        .strip_prefix('\u{feff}')
+        .unwrap_or(source)
+        .trim_start();
+    let jinja_body = leading_comment(trimmed, "{#", "#}");
+    if let Some(body) = jinja_body.or_else(|| leading_comment(trimmed, "<!--", "-->"))
+        && markup_fmt::starts_with_directive(directive_body(body), "djangofmt:ignore")
+    {
+        return FileIgnores {
+            format: true,
+            invalid_syntax: true,
+        };
+    }
+    match jinja_body.map(parse_directive) {
+        Some(Some(Directive::FileIgnore(codes))) => FileIgnores {
+            format: codes.contains(&FORMAT),
+            invalid_syntax: codes.contains(&INVALID_SYNTAX),
+        },
+        _ => FileIgnores::default(),
+    }
+}
+
+/// The body of a leading `open`..`close` comment, if the text starts with one.
+fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str> {
+    let body = text.strip_prefix(open)?;
+    Some(&body[..body.find(close)?])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_directives() {
+        assert_eq!(
+            parse_directive(" djangofmt: ignore[a, b ,c] "),
+            Some(Directive::Ignore(vec!["a", "b", "c"]))
+        );
+        assert_eq!(
+            parse_directive("djangofmt:file-ignore[invalid-syntax]"),
+            Some(Directive::FileIgnore(vec!["invalid-syntax"]))
+        );
+        assert_eq!(
+            parse_directive("djangofmt : file-ignore[invalid-syntax]"),
+            Some(Directive::FileIgnore(vec!["invalid-syntax"]))
+        );
+    }
+
+    #[test]
+    fn reject_non_directives() {
+        assert_eq!(parse_directive(" djangofmt:ignore "), None); // formatter directive
+        assert_eq!(parse_directive("djangofmt: ignore[]"), None); // explicit rules only
+        assert_eq!(parse_directive("djangofmt: ignore[ , ]"), None); // only separators
+        assert_eq!(parse_directive("djangofmt: ignore[a] trailing"), None); // nothing after bracket
+        assert_eq!(parse_directive("ignore[a]"), None); // must start with djangofmt:
+    }
+
+    #[test]
+    fn detect_file_level_opt_outs() {
+        let all = FileIgnores {
+            format: true,
+            invalid_syntax: true,
+        };
+        let syntax_only = FileIgnores {
+            format: false,
+            invalid_syntax: true,
+        };
+        let format_only = FileIgnores {
+            format: true,
+            invalid_syntax: false,
+        };
+
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"),
+            syntax_only
+        );
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[format] #}\n<div></div>"),
+            format_only
+        );
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[format, invalid-syntax] #}"),
+            all
+        );
+        // Jinja whitespace-control markers are part of the delimiter.
+        assert_eq!(
+            file_ignores("{#- djangofmt: file-ignore[format] -#}"),
+            format_only
+        );
+        // A UTF-8 BOM or leading whitespace before the directive is tolerated.
+        assert_eq!(
+            file_ignores("\u{feff}{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"),
+            syntax_only
+        );
+        assert_eq!(
+            file_ignores("\n  {# djangofmt: file-ignore[foo, invalid-syntax] #}\n<div id=>"),
+            syntax_only
+        );
+
+        // The bare legacy directive opts out of everything, in both styles,
+        // with whitespace tolerated around the colon.
+        assert_eq!(file_ignores("{# djangofmt:ignore #}\n<div id=>"), all);
+        assert_eq!(file_ignores("<!-- djangofmt:ignore -->\n<div id=>"), all);
+        assert_eq!(file_ignores("{# djangofmt : ignore #}\n<div id=>"), all);
+
+        // Bracketed directives only count in `{# #}` comments.
+        assert_eq!(
+            file_ignores("<!-- djangofmt: file-ignore[invalid-syntax] -->\n<div id=>"),
+            FileIgnores::default()
+        );
+        // Lint codes, node-level directives and plain markup are not opt-outs.
+        assert_eq!(
+            file_ignores("{# djangofmt: file-ignore[missing-img-alt] #}\n<div id=>"),
+            FileIgnores::default()
+        );
+        assert_eq!(
+            file_ignores("{# djangofmt: ignore[invalid-syntax] #}\n<div id=>"),
+            FileIgnores::default()
+        );
+        assert_eq!(file_ignores("<div id=>"), FileIgnores::default());
+    }
+}

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -1,13 +1,16 @@
 //! File-wide opt-outs declared by `{# djangofmt: file-ignore[...] #}` comments.
-//!
-//! Rules are always listed explicitly, and only `{# #}` comments carry
-//! directives: HTML comments survive in rendered output.
 
-/// `file-ignore[...]` code suppressing parse errors.
-pub const INVALID_SYNTAX: &str = "invalid-syntax";
+use std::str::FromStr;
 
-/// `file-ignore[...]` code skipping the formatter.
-pub const FORMAT: &str = "format";
+/// A code accepted in `file-ignore[...]`; unknown codes are ignored.
+#[derive(Debug, PartialEq, Eq, strum::EnumString)]
+#[strum(serialize_all = "kebab-case")]
+enum FileIgnoreCode {
+    /// Suppress parse errors: both commands skip the file.
+    InvalidSyntax,
+    /// Skip the formatter.
+    Format,
+}
 
 /// A parsed suppression directive.
 #[derive(Debug, PartialEq, Eq)]
@@ -92,10 +95,16 @@ pub fn file_ignores(source: &str) -> FileIgnores {
     }
     // `file-ignore[...]` is unambiguously file-level: leading whitespace is fine.
     match leading_comment(source.trim_start(), "{#", "#}").map(parse_directive) {
-        Some(Some(Directive::FileIgnore(codes))) => FileIgnores {
-            format: codes.contains(&FORMAT),
-            invalid_syntax: codes.contains(&INVALID_SYNTAX),
-        },
+        Some(Some(Directive::FileIgnore(codes))) => {
+            let codes: Vec<_> = codes
+                .iter()
+                .filter_map(|code| FileIgnoreCode::from_str(code).ok())
+                .collect();
+            FileIgnores {
+                format: codes.contains(&FileIgnoreCode::Format),
+                invalid_syntax: codes.contains(&FileIgnoreCode::InvalidSyntax),
+            }
+        }
         _ => FileIgnores::default(),
     }
 }

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -71,38 +71,40 @@ pub struct FileIgnores {
     pub invalid_syntax: bool,
 }
 
-/// Opt-outs from the file's leading comment, read straight from the raw source
-/// so they can be honored even when the file fails to parse.
-#[must_use]
-pub fn file_ignores(source: &str) -> FileIgnores {
-    // A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
-    let source = source.strip_prefix('\u{feff}').unwrap_or(source);
+impl FileIgnores {
+    /// Opt-outs from the file's leading comment, read straight from the raw source
+    /// so they can be honored even when the file fails to parse.
+    #[must_use]
+    pub fn parse(source: &str) -> Self {
+        // A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
+        let source = source.strip_prefix('\u{feff}').unwrap_or(source);
 
-    // The bare legacy directive doubles as a node-level formatter directive,
-    // so it is only file-level when nothing (not even whitespace) precedes it.
-    let legacy_body =
-        leading_comment(source, "{#", "#}").or_else(|| leading_comment(source, "<!--", "-->"));
-    if let Some(body) = legacy_body
-        && markup_fmt::starts_with_directive(directive_body(body), "djangofmt:ignore")
-    {
-        return FileIgnores {
-            format: true,
-            invalid_syntax: true,
-        };
-    }
-    // `file-ignore[...]` is unambiguously file-level: leading whitespace is fine.
-    match leading_comment(source.trim_start(), "{#", "#}").map(parse_directive) {
-        Some(Some(Directive::FileIgnore(codes))) => {
-            let codes: Vec<_> = codes
+        // The bare legacy directive doubles as a node-level formatter directive,
+        // so it is only file-level when nothing (not even whitespace) precedes it.
+        let legacy_body =
+            leading_comment(source, "{#", "#}").or_else(|| leading_comment(source, "<!--", "-->"));
+        if let Some(body) = legacy_body
+            && markup_fmt::starts_with_directive(directive_body(body), "djangofmt:ignore")
+        {
+            return Self {
+                format: true,
+                invalid_syntax: true,
+            };
+        }
+        // `file-ignore[...]` is unambiguously file-level: leading whitespace is fine.
+        match leading_comment(source.trim_start(), "{#", "#}").map(parse_directive) {
+            Some(Some(Directive::FileIgnore(codes))) => codes
                 .iter()
                 .filter_map(|code| FileIgnoreCode::from_str(code).ok())
-                .collect();
-            FileIgnores {
-                format: codes.contains(&FileIgnoreCode::Format),
-                invalid_syntax: codes.contains(&FileIgnoreCode::InvalidSyntax),
-            }
+                .fold(Self::default(), |mut ignores, code| {
+                    match code {
+                        FileIgnoreCode::Format => ignores.format = true,
+                        FileIgnoreCode::InvalidSyntax => ignores.invalid_syntax = true,
+                    }
+                    ignores
+                }),
+            _ => Self::default(),
         }
-        _ => FileIgnores::default(),
     }
 }
 
@@ -146,8 +148,8 @@ mod tests {
     #[rstest]
     fn reject_non_directives(
         #[values(
-            " djangofmt:ignore ",            // formatter directive
-            "djangofmt: ignore[]",           // explicit rules only
+            " djangofmt:ignore ",     // formatter directive
+            "djangofmt: ignore[]",    // explicit rules only
             "djangofmt: ignore[ , ]", // only separators
             "ignore[a]"               // must start with djangofmt:
         )]
@@ -189,6 +191,6 @@ mod tests {
     #[case::node_level("{# djangofmt: ignore[invalid-syntax] #}\n<div id=>", NONE)]
     #[case::plain_markup("<div id=>", NONE)]
     fn detect_file_level_opt_outs(#[case] source: &str, #[case] expected: FileIgnores) {
-        assert_eq!(file_ignores(source), expected);
+        assert_eq!(FileIgnores::parse(source), expected);
     }
 }

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -33,7 +33,8 @@ fn directive_body(raw: &str) -> &str {
 /// Parse a comment body into a suppression directive.
 ///
 /// Grammar: `djangofmt:` (whitespace allowed around the colon),
-/// then `ignore[...]` or `file-ignore[...]` with a non-empty comma-separated rule list
+/// then `ignore[...]` or `file-ignore[...]` with a non-empty comma-separated rule list.
+/// Anything after the closing bracket is a free-text reason, ignored.
 fn parse_directive(raw: &str) -> Option<Directive<'_>> {
     let rest = directive_body(raw)
         .strip_prefix("djangofmt")?
@@ -45,7 +46,8 @@ fn parse_directive(raw: &str) -> Option<Directive<'_>> {
         None => (false, rest.strip_prefix("ignore[")?),
     };
     let codes: Vec<&str> = rest
-        .strip_suffix(']')?
+        .split_once(']')?
+        .0
         .split(',')
         .map(str::trim)
         .filter(|code| !code.is_empty())
@@ -136,6 +138,7 @@ mod tests {
     #[case::node(" djangofmt: ignore[a, b ,c] ", Directive::Ignore(vec!["a", "b", "c"]))]
     #[case::file("djangofmt:file-ignore[invalid-syntax]", Directive::FileIgnore(vec!["invalid-syntax"]))]
     #[case::spaced_colon("djangofmt : file-ignore[invalid-syntax]", Directive::FileIgnore(vec!["invalid-syntax"]))]
+    #[case::reason("djangofmt: ignore[a]: free-text reason", Directive::Ignore(vec!["a"]))]
     fn parse_directives(#[case] comment: &str, #[case] expected: Directive) {
         assert_eq!(parse_directive(comment), Some(expected));
     }
@@ -145,9 +148,8 @@ mod tests {
         #[values(
             " djangofmt:ignore ",            // formatter directive
             "djangofmt: ignore[]",           // explicit rules only
-            "djangofmt: ignore[ , ]",        // only separators
-            "djangofmt: ignore[a] trailing", // nothing after bracket
-            "ignore[a]"                      // must start with djangofmt:
+            "djangofmt: ignore[ , ]", // only separators
+            "ignore[a]"               // must start with djangofmt:
         )]
         comment: &str,
     ) {
@@ -160,6 +162,8 @@ mod tests {
     #[case::both_codes("{# djangofmt: file-ignore[format, invalid-syntax] #}", ALL)]
     // Jinja whitespace-control markers are part of the delimiter.
     #[case::whitespace_control("{#- djangofmt: file-ignore[format] -#}", FORMAT_ONLY)]
+    // Anything after the closing bracket is a free-text reason.
+    #[case::reason("{# djangofmt: file-ignore[format]: vendored file #}", FORMAT_ONLY)]
     // A UTF-8 BOM or leading whitespace before the directive is tolerated.
     #[case::bom(
         "\u{feff}{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>",

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -15,9 +15,9 @@ enum FileIgnoreCode {
 /// A parsed suppression directive.
 #[derive(Debug, PartialEq, Eq)]
 enum Directive<'s> {
-    /// `djangofmt: ignore[...]` — suppress on the following node.
+    /// `djangofmt: ignore[...]` suppress on the following node.
     Ignore(Vec<&'s str>),
-    /// `djangofmt: file-ignore[...]` — suppress for the whole file.
+    /// `djangofmt: file-ignore[...]` suppress for the whole file.
     FileIgnore(Vec<&'s str>),
 }
 
@@ -32,9 +32,8 @@ fn directive_body(raw: &str) -> &str {
 
 /// Parse a comment body into a suppression directive.
 ///
-/// Grammar: `djangofmt:` (whitespace allowed around the colon), then
-/// `ignore[...]` or `file-ignore[...]` with a non-empty comma-separated rule
-/// list and nothing after the closing bracket.
+/// Grammar: `djangofmt:` (whitespace allowed around the colon),
+/// then `ignore[...]` or `file-ignore[...]` with a non-empty comma-separated rule list
 fn parse_directive(raw: &str) -> Option<Directive<'_>> {
     let rest = directive_body(raw)
         .strip_prefix("djangofmt")?
@@ -72,10 +71,6 @@ pub struct FileIgnores {
 
 /// Opt-outs from the file's leading comment, read straight from the raw source
 /// so they can be honored even when the file fails to parse.
-///
-/// The bare legacy `djangofmt:ignore` (in either comment style) predates rule
-/// codes and opted the file out of everything: it maps to both flags, but only
-/// at the very start of the file since it also serves as a node-level directive.
 #[must_use]
 pub fn file_ignores(source: &str) -> FileIgnores {
     // A UTF-8 BOM is not Rust whitespace, so strip it explicitly.

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -30,11 +30,8 @@ fn directive_body(raw: &str) -> &str {
         .trim()
 }
 
-/// Parse a comment body into a suppression directive.
-///
-/// Grammar: `djangofmt:` (whitespace allowed around the colon),
-/// then `ignore[...]` or `file-ignore[...]` with a non-empty comma-separated rule list.
-/// Anything after the closing bracket is a free-text reason, ignored.
+/// Parse a comment body into a suppression directive: `djangofmt:` then `ignore[...]` or
+/// `file-ignore[...]` with a non-empty code list; text after the `]` is an ignored reason.
 fn parse_directive(raw: &str) -> Option<Directive<'_>> {
     let rest = directive_body(raw)
         .strip_prefix("djangofmt")?

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -118,107 +118,78 @@ fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn parse_directives() {
-        assert_eq!(
-            parse_directive(" djangofmt: ignore[a, b ,c] "),
-            Some(Directive::Ignore(vec!["a", "b", "c"]))
-        );
-        assert_eq!(
-            parse_directive("djangofmt:file-ignore[invalid-syntax]"),
-            Some(Directive::FileIgnore(vec!["invalid-syntax"]))
-        );
-        assert_eq!(
-            parse_directive("djangofmt : file-ignore[invalid-syntax]"),
-            Some(Directive::FileIgnore(vec!["invalid-syntax"]))
-        );
+    const ALL: FileIgnores = FileIgnores {
+        format: true,
+        invalid_syntax: true,
+    };
+    const SYNTAX_ONLY: FileIgnores = FileIgnores {
+        format: false,
+        invalid_syntax: true,
+    };
+    const FORMAT_ONLY: FileIgnores = FileIgnores {
+        format: true,
+        invalid_syntax: false,
+    };
+    const NONE: FileIgnores = FileIgnores {
+        format: false,
+        invalid_syntax: false,
+    };
+
+    #[rstest]
+    #[case::node(" djangofmt: ignore[a, b ,c] ", Directive::Ignore(vec!["a", "b", "c"]))]
+    #[case::file("djangofmt:file-ignore[invalid-syntax]", Directive::FileIgnore(vec!["invalid-syntax"]))]
+    #[case::spaced_colon("djangofmt : file-ignore[invalid-syntax]", Directive::FileIgnore(vec!["invalid-syntax"]))]
+    fn parse_directives(#[case] comment: &str, #[case] expected: Directive) {
+        assert_eq!(parse_directive(comment), Some(expected));
     }
 
-    #[test]
-    fn reject_non_directives() {
-        assert_eq!(parse_directive(" djangofmt:ignore "), None); // formatter directive
-        assert_eq!(parse_directive("djangofmt: ignore[]"), None); // explicit rules only
-        assert_eq!(parse_directive("djangofmt: ignore[ , ]"), None); // only separators
-        assert_eq!(parse_directive("djangofmt: ignore[a] trailing"), None); // nothing after bracket
-        assert_eq!(parse_directive("ignore[a]"), None); // must start with djangofmt:
+    #[rstest]
+    fn reject_non_directives(
+        #[values(
+            " djangofmt:ignore ",            // formatter directive
+            "djangofmt: ignore[]",           // explicit rules only
+            "djangofmt: ignore[ , ]",        // only separators
+            "djangofmt: ignore[a] trailing", // nothing after bracket
+            "ignore[a]"                      // must start with djangofmt:
+        )]
+        comment: &str,
+    ) {
+        assert_eq!(parse_directive(comment), None);
     }
 
-    #[test]
-    fn detect_file_level_opt_outs() {
-        let all = FileIgnores {
-            format: true,
-            invalid_syntax: true,
-        };
-        let syntax_only = FileIgnores {
-            format: false,
-            invalid_syntax: true,
-        };
-        let format_only = FileIgnores {
-            format: true,
-            invalid_syntax: false,
-        };
-
-        assert_eq!(
-            file_ignores("{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"),
-            syntax_only
-        );
-        assert_eq!(
-            file_ignores("{# djangofmt: file-ignore[format] #}\n<div></div>"),
-            format_only
-        );
-        assert_eq!(
-            file_ignores("{# djangofmt: file-ignore[format, invalid-syntax] #}"),
-            all
-        );
-        // Jinja whitespace-control markers are part of the delimiter.
-        assert_eq!(
-            file_ignores("{#- djangofmt: file-ignore[format] -#}"),
-            format_only
-        );
-        // A UTF-8 BOM or leading whitespace before the directive is tolerated.
-        assert_eq!(
-            file_ignores("\u{feff}{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>"),
-            syntax_only
-        );
-        assert_eq!(
-            file_ignores("\n  {# djangofmt: file-ignore[foo, invalid-syntax] #}\n<div id=>"),
-            syntax_only
-        );
-
-        // The bare legacy directive opts out of everything, in both styles,
-        // with whitespace tolerated around the colon.
-        assert_eq!(file_ignores("{# djangofmt:ignore #}\n<div id=>"), all);
-        assert_eq!(file_ignores("<!-- djangofmt:ignore -->\n<div id=>"), all);
-        assert_eq!(file_ignores("{# djangofmt : ignore #}\n<div id=>"), all);
-        assert_eq!(
-            file_ignores("\u{feff}{# djangofmt:ignore #}\n<div id=>"),
-            all
-        );
-        // Preceded by whitespace, the bare directive is node-level, not file-level.
-        assert_eq!(
-            file_ignores("\n  {# djangofmt:ignore #}\n<div id=>"),
-            FileIgnores::default()
-        );
-        assert_eq!(
-            file_ignores(" <!-- djangofmt:ignore -->\n<div id=>"),
-            FileIgnores::default()
-        );
-
-        // Bracketed directives only count in `{# #}` comments.
-        assert_eq!(
-            file_ignores("<!-- djangofmt: file-ignore[invalid-syntax] -->\n<div id=>"),
-            FileIgnores::default()
-        );
-        // Lint codes, node-level directives and plain markup are not opt-outs.
-        assert_eq!(
-            file_ignores("{# djangofmt: file-ignore[missing-img-alt] #}\n<div id=>"),
-            FileIgnores::default()
-        );
-        assert_eq!(
-            file_ignores("{# djangofmt: ignore[invalid-syntax] #}\n<div id=>"),
-            FileIgnores::default()
-        );
-        assert_eq!(file_ignores("<div id=>"), FileIgnores::default());
+    #[rstest]
+    #[case::invalid_syntax("{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>", SYNTAX_ONLY)]
+    #[case::format("{# djangofmt: file-ignore[format] #}\n<div></div>", FORMAT_ONLY)]
+    #[case::both_codes("{# djangofmt: file-ignore[format, invalid-syntax] #}", ALL)]
+    // Jinja whitespace-control markers are part of the delimiter.
+    #[case::whitespace_control("{#- djangofmt: file-ignore[format] -#}", FORMAT_ONLY)]
+    // A UTF-8 BOM or leading whitespace before the directive is tolerated.
+    #[case::bom(
+        "\u{feff}{# djangofmt: file-ignore[invalid-syntax] #}\n<div id=>",
+        SYNTAX_ONLY
+    )]
+    #[case::leading_whitespace(
+        "\n  {# djangofmt: file-ignore[foo, invalid-syntax] #}\n<div id=>",
+        SYNTAX_ONLY
+    )]
+    // The bare legacy directive opts out of everything, in both styles,
+    // with whitespace tolerated around the colon.
+    #[case::legacy_jinja("{# djangofmt:ignore #}\n<div id=>", ALL)]
+    #[case::legacy_html("<!-- djangofmt:ignore -->\n<div id=>", ALL)]
+    #[case::legacy_spaced_colon("{# djangofmt : ignore #}\n<div id=>", ALL)]
+    #[case::legacy_bom("\u{feff}{# djangofmt:ignore #}\n<div id=>", ALL)]
+    // Preceded by whitespace, the bare directive is node-level, not file-level.
+    #[case::legacy_after_newline("\n  {# djangofmt:ignore #}\n<div id=>", NONE)]
+    #[case::legacy_after_space(" <!-- djangofmt:ignore -->\n<div id=>", NONE)]
+    // Bracketed directives only count in `{# #}` comments.
+    #[case::html_comment("<!-- djangofmt: file-ignore[invalid-syntax] -->\n<div id=>", NONE)]
+    // Lint codes, node-level directives and plain markup are not opt-outs.
+    #[case::lint_code("{# djangofmt: file-ignore[missing-img-alt] #}\n<div id=>", NONE)]
+    #[case::node_level("{# djangofmt: ignore[invalid-syntax] #}\n<div id=>", NONE)]
+    #[case::plain_markup("<div id=>", NONE)]
+    fn detect_file_level_opt_outs(#[case] source: &str, #[case] expected: FileIgnores) {
+        assert_eq!(file_ignores(source), expected);
     }
 }

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -71,16 +71,18 @@ pub struct FileIgnores {
 /// so they can be honored even when the file fails to parse.
 ///
 /// The bare legacy `djangofmt:ignore` (in either comment style) predates rule
-/// codes and opted the file out of everything: it maps to both flags.
+/// codes and opted the file out of everything: it maps to both flags, but only
+/// at the very start of the file since it also serves as a node-level directive.
 #[must_use]
 pub fn file_ignores(source: &str) -> FileIgnores {
     // A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
-    let trimmed = source
-        .strip_prefix('\u{feff}')
-        .unwrap_or(source)
-        .trim_start();
-    let jinja_body = leading_comment(trimmed, "{#", "#}");
-    if let Some(body) = jinja_body.or_else(|| leading_comment(trimmed, "<!--", "-->"))
+    let source = source.strip_prefix('\u{feff}').unwrap_or(source);
+
+    // The bare legacy directive doubles as a node-level formatter directive,
+    // so it is only file-level when nothing (not even whitespace) precedes it.
+    let legacy_body =
+        leading_comment(source, "{#", "#}").or_else(|| leading_comment(source, "<!--", "-->"));
+    if let Some(body) = legacy_body
         && markup_fmt::starts_with_directive(directive_body(body), "djangofmt:ignore")
     {
         return FileIgnores {
@@ -88,7 +90,8 @@ pub fn file_ignores(source: &str) -> FileIgnores {
             invalid_syntax: true,
         };
     }
-    match jinja_body.map(parse_directive) {
+    // `file-ignore[...]` is unambiguously file-level: leading whitespace is fine.
+    match leading_comment(source.trim_start(), "{#", "#}").map(parse_directive) {
         Some(Some(Directive::FileIgnore(codes))) => FileIgnores {
             format: codes.contains(&FORMAT),
             invalid_syntax: codes.contains(&INVALID_SYNTAX),
@@ -179,6 +182,19 @@ mod tests {
         assert_eq!(file_ignores("{# djangofmt:ignore #}\n<div id=>"), all);
         assert_eq!(file_ignores("<!-- djangofmt:ignore -->\n<div id=>"), all);
         assert_eq!(file_ignores("{# djangofmt : ignore #}\n<div id=>"), all);
+        assert_eq!(
+            file_ignores("\u{feff}{# djangofmt:ignore #}\n<div id=>"),
+            all
+        );
+        // Preceded by whitespace, the bare directive is node-level, not file-level.
+        assert_eq!(
+            file_ignores("\n  {# djangofmt:ignore #}\n<div id=>"),
+            FileIgnores::default()
+        );
+        assert_eq!(
+            file_ignores(" <!-- djangofmt:ignore -->\n<div id=>"),
+            FileIgnores::default()
+        );
 
         // Bracketed directives only count in `{# #}` comments.
         assert_eq!(

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,7 +2,7 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, Settings, graphical_handler, lint_source};
+use djangofmt_lint::{FileDiagnostics, Settings, file_ignores, graphical_handler, lint_source};
 use miette::GraphicalTheme;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -189,6 +189,10 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
     let diagnostics = match lint_source(source, profile.into(), &[], &Settings::all(), None) {
         Ok(diagnostics) => diagnostics,
         Err(e) => {
+            // Match the CLI: `file-ignore[invalid-syntax]` skips the file.
+            if file_ignores(source).invalid_syntax {
+                return Ok(LintResult::new(0, String::new()));
+            }
             let err = markup_fmt::FormatError::Syntax(e);
             return Ok(LintResult::new(1, render_parse_error(source, &err)));
         }

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,7 +2,7 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, Settings, file_ignores, graphical_handler, lint_source};
+use djangofmt_lint::{FileDiagnostics, FileIgnores, Settings, graphical_handler, lint_source};
 use miette::GraphicalTheme;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -190,7 +190,7 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
         Ok(diagnostics) => diagnostics,
         Err(e) => {
             // Match the CLI: `file-ignore[invalid-syntax]` skips the file.
-            if file_ignores(source).invalid_syntax {
+            if FileIgnores::parse(source).invalid_syntax {
                 return Ok(LintResult::new(0, String::new()));
             }
             let err = markup_fmt::FormatError::Syntax(e);

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -70,10 +70,10 @@ To disable formatting for an entire file, add `{# djangofmt: file-ignore[format]
 <div   class="keep-this-unformatted"   >Content</div>
 ```
 
-To disable formatting for a specific node, prefix it with a `{# djangofmt: ignore #}` comment:
+To disable formatting for a specific node, prefix it with a `{# djangofmt: ignore[format] #}` comment:
 
 ```html
-{# djangofmt: ignore #}
+{# djangofmt: ignore[format] #}
 <div   class="keep-this-unformatted"   >Content</div>
 <div class="this-will-be-formatted">Content</div>
 ```
@@ -88,4 +88,5 @@ Anything after the closing bracket is a free-text reason:
 ```
 
 A bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the very top still skips the whole file, parse errors included, for backward compatibility.
+
 Prefer `file-ignore[...]`: it states what is opted out of, and `{# #}` comments aren't rendered to the client.

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -87,6 +87,5 @@ Anything after the closing bracket is a free-text reason:
 {# djangofmt: file-ignore[format]: generated file, do not touch #}
 ```
 
-A bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the very top still skips the
-whole file, parse errors included, for backward compatibility. Prefer `file-ignore[...]`: it states
-what is opted out of, and `{# #}` comments aren't rendered to the client.
+A bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the very top still skips the whole file, parse errors included, for backward compatibility.
+Prefer `file-ignore[...]`: it states what is opted out of, and `{# #}` comments aren't rendered to the client.

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -78,8 +78,14 @@ To disable formatting for a specific node, prefix it with a `{# djangofmt: ignor
 <div class="this-will-be-formatted">Content</div>
 ```
 
-A file djangofmt cannot parse at all can be quarantined with `{# djangofmt: file-ignore[invalid-syntax] #}`
+A file that djangofmt cannot parse at all can be skipped with `{# djangofmt: file-ignore[invalid-syntax] #}`
 at the very top: both `format` and `check` skip it instead of reporting a parse error.
+
+Anything after the closing bracket is a free-text reason:
+
+```html
+{# djangofmt: file-ignore[format]: generated file, do not touch #}
+```
 
 A bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the very top still skips the
 whole file, parse errors included, for backward compatibility. Prefer `file-ignore[...]`: it states

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -63,23 +63,24 @@ attribute values to pass non-string types (booleans, numbers, template variables
 
 ## Disabling formatting
 
-To disable formatting for an entire file, add `<!-- djangofmt: ignore -->` at the very top of the file.
-
-A file ignored this way is also skipped by `djangofmt check` when it cannot be parsed,
-so templates that break the parser can be quarantined from both commands.
-
-To disable formatting for a specific node, prefix it with the same comment:
+To disable formatting for an entire file, add `{# djangofmt: file-ignore[format] #}` at the very top of the file:
 
 ```html
-<!-- djangofmt: ignore -->
+{# djangofmt: file-ignore[format] #}
 <div   class="keep-this-unformatted"   >Content</div>
-<div class="this-will-be-formatted">Content</div>
 ```
 
-A Django/Jinja comment works the same way, both inline and at the top of a file.
-Unlike an HTML comment, it isn't rendered to the client:
+To disable formatting for a specific node, prefix it with a `{# djangofmt: ignore #}` comment:
 
 ```html
 {# djangofmt: ignore #}
 <div   class="keep-this-unformatted"   >Content</div>
+<div class="this-will-be-formatted">Content</div>
 ```
+
+A file djangofmt cannot parse at all can be quarantined with `{# djangofmt: file-ignore[invalid-syntax] #}`
+at the very top: both `format` and `check` skip it instead of reporting a parse error.
+
+A bare `{# djangofmt:ignore #}` (or `<!-- djangofmt:ignore -->`) at the very top still skips the
+whole file, parse errors included, for backward compatibility. Prefer `file-ignore[...]`: it states
+what is opted out of, and `{# #}` comments aren't rendered to the client.


### PR DESCRIPTION
A `{# djangofmt: file-ignore[...] #}` comment at the top of a file declares what the file opts out of. 
Two codes are supported: `format` skips the formatter, `invalid-syntax` quarantines a file neither command can parse. 
This reads straight from the raw source, so it works on files that do not parse.

```jinja
{# djangofmt: file-ignore[invalid-syntax] #}
<div id=>
```

The bare `{# djangofmt:ignore #}` keeps working as an alias for both. Parse errors now hint at this escape hatch.

Part 1/4 of #436.