### PR TITLE
feat(lint): Add `invalid-ignore-comment` and `invalid-ignore-code` lint rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Conventions
 
-- Use comments sparingly — only when they explain hidden behavior — and keep them to 1-2 lines.
+- Use comments sparingly — only when they explain hidden behavior — and keep them to 1-2 lines. Rule doc comments (`## What it does` …) are the generated docs and exempt.
 - Every new CLI flag must also be readable from `pyproject.toml`: add it to `PyprojectSettings`/`LintSettings` in `pyproject.rs` and resolve it with CLI args taking precedence.
 - Keep tests lean: cover the highest-value cases and refactor them to a high standard.
 - Only the final commit of a branch needs a conventional-commit `type(scope):` prefix, e.g. `feat(lint):`, `fix(format):`, `chore(deps):` — branches are squash-merged and that title becomes the changelog entry. Earlier commits are for review only: give them plain descriptive titles.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "rustywind_core",
  "serde",
  "smallvec",
+ "strsim",
  "strum",
  "textwrap",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=3d4a8bec4cbdf2875a8f64b4c8ab648e3bcbb4e6#3d4a8bec4cbdf2875a8f64b4c8ab648e3bcbb4e6"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=857ceb19c5b31ab44568ed533f3da9076c1d69d1#857ceb19c5b31ab44568ed533f3da9076c1d69d1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6.5" }
 similar-asserts = { version = "2.0.0" }
 smallvec = { version = "1.15.1", features = ["const_new"] }
+strsim = { version = "0.11.1" }
 strum = { version = "0.28.0", features = ["derive"] }
 syn = { version = "3.0" }
 tempfile = { version = "3.27.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ malva = {
 }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "3d4a8bec4cbdf2875a8f64b4c8ab648e3bcbb4e6"
+  rev = "857ceb19c5b31ab44568ed533f3da9076c1d69d1"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -1,4 +1,4 @@
-use djangofmt_lint::{FORMAT_CODE, FileIgnores, IGNORE_DIRECTIVE};
+use djangofmt_lint::{FileIgnores, IGNORE_DIRECTIVE, ReservedCode};
 use rayon::iter::Either::{Left, Right};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::borrow::Cow;
@@ -167,7 +167,7 @@ pub fn build_markup_options(
             // <div>unformatted</div>
             ignore_comment_directive: vec![
                 IGNORE_DIRECTIVE.into(),
-                format!("{IGNORE_DIRECTIVE}[{FORMAT_CODE}]"),
+                format!("{IGNORE_DIRECTIVE}[{}]", ReservedCode::Format),
             ],
             ignore_file_comment_directive: vec![IGNORE_DIRECTIVE.into()],
             // Indent style tags content:

--- a/crates/djangofmt_dev/docs/lint-rules-intro.md
+++ b/crates/djangofmt_dev/docs/lint-rules-intro.md
@@ -45,3 +45,7 @@ A `{# djangofmt: file-ignore[...] #}` comment as the **first comment of the file
 ```jinja
 {# djangofmt: file-ignore[invalid-syntax] #}
 ```
+
+A directive djangofmt cannot honor is reported rather than skipped silently:
+- [`invalid-ignore-comment`](rules/invalid-ignore-comment.md) for a malformed or misplaced one
+- [`invalid-ignore-code`](rules/invalid-ignore-code.md) for a code naming no rule.

--- a/crates/djangofmt_dev/docs/lint-rules-intro.md
+++ b/crates/djangofmt_dev/docs/lint-rules-intro.md
@@ -37,7 +37,7 @@ A `{# djangofmt: ignore[...] #}` comment silences the listed rules on the next n
 <form method="yes" id=""></form>
 ```
 
-A `{# djangofmt: file-ignore[...] #}` comment as the **first comment of the file** covers the whole file. It also accepts two codes that are not rules:
+A `{# djangofmt: file-ignore[...] #}` comment at the **very top of the file**, before any markup, covers the whole file. It also accepts two codes that are not rules:
 
 - `invalid-syntax` skips a file neither command can parse
 - `format` skips the formatter (see [Disabling formatting](formatting.md#disabling-formatting) for more details)

--- a/crates/djangofmt_lint/Cargo.toml
+++ b/crates/djangofmt_lint/Cargo.toml
@@ -14,6 +14,7 @@ rustc-hash = { workspace = true }
 rustywind_core = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 smallvec = { workspace = true }
+strsim = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 textwrap = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -136,13 +136,11 @@ impl<'a> Checker<'a> {
 
     /// Visit the suppression comments, once the suppression they ask for has been applied.
     pub fn visit_directives(&self, directives: &[DirectiveComment<'_>]) {
-        for comment in directives {
-            if self.is_rule_enabled(Rule::InvalidIgnoreComment) {
-                rules::suspicious::invalid_ignore_comment::check(comment, self);
-            }
-            if self.is_rule_enabled(Rule::InvalidIgnoreCode) {
-                rules::suspicious::invalid_ignore_code::check(comment, self);
-            }
+        if self.is_rule_enabled(Rule::InvalidIgnoreComment) {
+            rules::suspicious::invalid_ignore_comment::check(directives, self);
+        }
+        if self.is_rule_enabled(Rule::InvalidIgnoreCode) {
+            rules::suspicious::invalid_ignore_code::check(directives, self);
         }
     }
 

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -12,6 +12,7 @@ use crate::Settings;
 use crate::lint_context::{DiagnosticGuard, LintContext};
 use crate::registry::Rule;
 use crate::rules;
+use crate::suppression::DirectiveComment;
 use crate::violation::Violation;
 
 /// AST visitor that collects lint diagnostics.
@@ -130,6 +131,18 @@ impl<'a> Checker<'a> {
         // Cross-node finalize: now that every `{% block %}` has been recorded, flag duplicates.
         if self.is_rule_enabled(Rule::DuplicateBlockName) {
             rules::correctness::duplicate_block_name::check(self);
+        }
+    }
+
+    /// Visit the suppression comments, once the suppression they ask for has been applied.
+    pub fn visit_directives(&self, directives: &[DirectiveComment<'_>]) {
+        for comment in directives {
+            if self.is_rule_enabled(Rule::InvalidIgnoreComment) {
+                rules::suspicious::invalid_ignore_comment::check(comment, self);
+            }
+            if self.is_rule_enabled(Rule::InvalidIgnoreCode) {
+                rules::suspicious::invalid_ignore_code::check(comment, self);
+            }
         }
     }
 

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -12,7 +12,7 @@ use crate::Settings;
 use crate::lint_context::{DiagnosticGuard, LintContext};
 use crate::registry::Rule;
 use crate::rules;
-use crate::suppression::DirectiveComment;
+use crate::suppression::IgnoreComment;
 use crate::violation::Violation;
 
 /// AST visitor that collects lint diagnostics.
@@ -134,13 +134,13 @@ impl<'a> Checker<'a> {
         }
     }
 
-    /// Visit the suppression comments, once the suppression they ask for has been applied.
-    pub fn visit_directives(&self, directives: &[DirectiveComment<'_>]) {
+    /// Lint the ignore comments themselves, once the suppression they ask for has been applied.
+    pub fn visit_ignore_comments(&self, comments: &[IgnoreComment<'_>]) {
         if self.is_rule_enabled(Rule::InvalidIgnoreComment) {
-            rules::suspicious::invalid_ignore_comment::check(directives, self);
+            rules::suspicious::invalid_ignore_comment::check(comments, self);
         }
         if self.is_rule_enabled(Rule::InvalidIgnoreCode) {
-            rules::suspicious::invalid_ignore_code::check(directives, self);
+            rules::suspicious::invalid_ignore_code::check(comments, self);
         }
     }
 

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -51,15 +51,27 @@ pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
     Edit::deletion(span(delete_start, delete_end - delete_start))
 }
 
-/// The span to report and the edit dropping `remove` from a directive's `codes`: one code is
-/// cut out with its separator, several are rewritten, and the comment goes once none is left.
+/// Drops `remove` from a directive's `codes`, returning the span to report and the edit.
 ///
-/// ```text
+/// When one code is dropped, only that entry and its comma are removed:
+///
+/// ```diff
 /// -{# djangofmt: ignore[not-a-rule, invalid-attr-value] #}
 /// +{# djangofmt: ignore[invalid-attr-value] #}
+/// ```
+///
+/// When several codes go but some stay, the list is rewritten:
+///
+/// ```diff
 /// -{# djangofmt: ignore[not-a-rule, invalid-attr-value, nor-this, empty-attr-value] #}
 /// +{# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
+/// ```
+///
+/// When nothing remains, the whole comment goes:
+///
+/// ```diff
 /// -{# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
+///  <form method="yes"></form>
 /// ```
 pub fn delete_codes_or_comment(
     ctx: &LintContext<'_>,

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -64,7 +64,16 @@ pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
     Edit::deletion(span(delete_start, delete_end - delete_start))
 }
 
-/// Drops `remove` from a directive's `codes`, returning the span to report and the edit.
+/// The outcome of [`delete_codes_or_comment`].
+pub struct CodesDeletion {
+    /// The span to report the violation on.
+    pub span: SourceSpan,
+    pub edit: Edit,
+    /// Nothing would remain, so the whole comment goes.
+    pub whole_comment: bool,
+}
+
+/// Drops `remove` from a directive's `codes`.
 ///
 /// When one code is dropped, only that entry and its comma are removed:
 ///
@@ -91,13 +100,27 @@ pub fn delete_codes_or_comment(
     comment: &str,
     codes: &[&str],
     remove: &[&str],
-) -> (SourceSpan, Edit) {
+) -> CodesDeletion {
     debug_assert!(
         !remove.is_empty() && remove.iter().all(|code| codes.contains(code)),
         "`remove` must be a non-empty subset of `codes`"
     );
-    if let [only] = codes {
-        return (ctx.source_span(only), delete_comment(ctx, comment));
+    let remaining: Vec<&str> = codes
+        .iter()
+        .copied()
+        .filter(|code| !remove.contains(code))
+        .collect();
+    if remaining.is_empty() {
+        // A lone code is reported on the code itself, a list on the whole comment.
+        let span = match codes {
+            [only] => ctx.source_span(only),
+            _ => ctx.source_span(comment),
+        };
+        return CodesDeletion {
+            span,
+            edit: delete_comment(ctx, comment),
+            whole_comment: true,
+        };
     }
     let mut listed = codes
         .iter()
@@ -108,24 +131,19 @@ pub fn delete_codes_or_comment(
             || (ctx.source_end(codes[index - 1]), ctx.source_end(code)),
             |next| (ctx.source_offset(code), ctx.source_offset(next)),
         );
-        return (
-            ctx.source_span(code),
-            Edit::deletion(span(start, end - start)),
-        );
+        return CodesDeletion {
+            span: ctx.source_span(code),
+            edit: Edit::deletion(span(start, end - start)),
+            whole_comment: false,
+        };
     }
-    let remaining: Vec<&str> = codes
-        .iter()
-        .copied()
-        .filter(|code| !remove.contains(code))
-        .collect();
-    let edit = if remaining.is_empty() {
-        delete_comment(ctx, comment)
-    } else {
-        let (start, end) = (
-            ctx.source_offset(codes[0]),
-            ctx.source_end(codes[codes.len() - 1]),
-        );
-        Edit::replacement(remaining.join(", "), span(start, end - start))
-    };
-    (ctx.source_span(comment), edit)
+    let (start, end) = (
+        ctx.source_offset(codes[0]),
+        ctx.source_end(codes[codes.len() - 1]),
+    );
+    CodesDeletion {
+        span: ctx.source_span(comment),
+        edit: Edit::replacement(remaining.join(", "), span(start, end - start)),
+        whole_comment: false,
+    }
 }

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -3,6 +3,7 @@ use miette::SourceSpan;
 use crate::fix::{Edit, Fix};
 use crate::lint_context::LintContext;
 use crate::span;
+use crate::suppression::strip_bom;
 
 /// Builds a safe fix that deletes a whole native attribute (e.g. `type="text/javascript"`).
 ///
@@ -51,10 +52,13 @@ pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
         .find('\n')
         .map_or(source.len(), |i| end + i + 1);
 
-    let standalone = source[line_start..start].trim_ascii().is_empty()
-        && source[end..line_end].trim_ascii().is_empty();
+    // A BOM belongs to the file rather than to the line: it neither keeps the comment from
+    // being standalone, nor goes away with the line.
+    let before = strip_bom(&source[line_start..start]);
+    let standalone =
+        before.trim_ascii().is_empty() && source[end..line_end].trim_ascii().is_empty();
     let (delete_start, delete_end) = if standalone {
-        (line_start, line_end)
+        (start - before.len(), line_end)
     } else {
         (start, end)
     };

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -1,3 +1,5 @@
+use miette::SourceSpan;
+
 use crate::fix::{Edit, Fix};
 use crate::lint_context::LintContext;
 use crate::span;
@@ -12,16 +14,74 @@ use crate::span;
 pub fn delete_attr_fix(ctx: &LintContext<'_>, name: &str, value_str: &str, quoted: bool) -> Fix {
     let name_start = ctx.source_offset(name);
     let attr_end = ctx.source_end(value_str) + usize::from(quoted);
-    let fix_start = reverse_consume_ws(ctx.source().as_bytes(), name_start);
+    let fix_start = ctx.source()[..name_start].trim_ascii_end().len();
     Fix::safe_edit(Edit::deletion(span(fix_start, attr_end - fix_start)))
 }
 
-/// Walk backwards from `offset` over ASCII whitespace bytes in `source`,
-/// returning the offset of the first non-whitespace byte.
-#[inline]
-fn reverse_consume_ws(source: &[u8], offset: usize) -> usize {
-    source[..offset]
-        .iter()
-        .rposition(|b| !b.is_ascii_whitespace())
-        .map_or(0, |i| i + 1)
+/// An edit deleting a whole comment, taking the line with it when the comment has it to
+/// itself, so no blank line is left behind.
+pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
+    let source = ctx.source();
+    let start = ctx.source_offset(comment);
+    let end = start + comment.len();
+    let line_start = source[..start].rfind('\n').map_or(0, |i| i + 1);
+    let line_end = source[end..]
+        .find('\n')
+        .map_or(source.len(), |i| end + i + 1);
+    let (before, after) = (&source[line_start..start], &source[end..line_end]);
+    let (start, end) = if before.trim_ascii().is_empty() && after.trim_ascii().is_empty() {
+        (line_start, line_end)
+    } else {
+        // Whitespace is absorbed within the line only, so the fix never joins two lines.
+        (line_start + before.trim_ascii_end().len(), end)
+    };
+    Edit::deletion(span(start, end - start))
+}
+
+/// The span to report and the edit dropping `remove` from a directive's `codes`.
+///
+/// A single code is spanned and taken out with its separator; the comment goes once no code
+/// would be left; several codes among others rewrite the list in place and span the comment.
+///
+/// # Panics
+///
+/// Panics if a code in `remove` is not listed in `codes`.
+pub fn delete_codes_or_comment(
+    ctx: &LintContext<'_>,
+    comment: &str,
+    codes: &[&str],
+    remove: &[&str],
+) -> (SourceSpan, Edit) {
+    let start_of = |slice: &str| ctx.source_offset(slice);
+    let end_of = |slice: &str| ctx.source_offset(slice) + slice.len();
+    let span_of = |slice: &str| span(start_of(slice), slice.len());
+    if let [only] = codes {
+        return (span_of(only), delete_comment(ctx, comment));
+    }
+    if let [code] = remove {
+        // Offsets come from the listed slice: `remove` may hold an equal string from elsewhere.
+        let index = codes
+            .iter()
+            .position(|listed| listed == code)
+            .expect("a code to remove is listed");
+        let code = codes[index];
+        let (start, end) = codes.get(index + 1).map_or_else(
+            || (end_of(codes[index - 1]), end_of(code)),
+            |next| (start_of(code), start_of(next)),
+        );
+        return (span_of(code), Edit::deletion(span(start, end - start)));
+    }
+    let mut remaining: Vec<&str> = Vec::new();
+    for code in codes {
+        if !remove.contains(code) && !remaining.contains(code) {
+            remaining.push(code);
+        }
+    }
+    let edit = if remaining.is_empty() {
+        delete_comment(ctx, comment)
+    } else {
+        let (start, end) = (start_of(codes[0]), end_of(codes[codes.len() - 1]));
+        Edit::replacement(remaining.join(", "), span(start, end - start))
+    };
+    (span_of(comment), edit)
 }

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -2,8 +2,7 @@ use miette::SourceSpan;
 
 use crate::fix::{Edit, Fix};
 use crate::lint_context::LintContext;
-use crate::span;
-use crate::suppression::strip_bom;
+use crate::{span, strip_bom};
 
 /// Builds a safe fix that deletes a whole native attribute (e.g. `type="text/javascript"`).
 ///

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -34,7 +34,7 @@ pub fn delete_attr_fix(ctx: &LintContext<'_>, name: &str, value_str: &str, quote
 pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
     let source = ctx.source();
     let start = ctx.source_offset(comment);
-    let end = start + comment.len();
+    let end = ctx.source_end(comment);
 
     let line_start = source[..start].rfind('\n').map_or(0, |i| i + 1);
     let line_end = source[end..]
@@ -79,11 +79,8 @@ pub fn delete_codes_or_comment(
     codes: &[&str],
     remove: &[&str],
 ) -> (SourceSpan, Edit) {
-    let start_of = |slice: &str| ctx.source_offset(slice);
-    let end_of = |slice: &str| ctx.source_offset(slice) + slice.len();
-    let span_of = |slice: &str| span(start_of(slice), slice.len());
     if let [only] = codes {
-        return (span_of(only), delete_comment(ctx, comment));
+        return (ctx.source_span(only), delete_comment(ctx, comment));
     }
     let mut listed = codes
         .iter()
@@ -91,10 +88,13 @@ pub fn delete_codes_or_comment(
         .filter(|(_, listed)| remove.contains(listed));
     if let (Some((index, code)), None) = (listed.next(), listed.next()) {
         let (start, end) = codes.get(index + 1).map_or_else(
-            || (end_of(codes[index - 1]), end_of(code)),
-            |next| (start_of(code), start_of(next)),
+            || (ctx.source_end(codes[index - 1]), ctx.source_end(code)),
+            |next| (ctx.source_offset(code), ctx.source_offset(next)),
         );
-        return (span_of(code), Edit::deletion(span(start, end - start)));
+        return (
+            ctx.source_span(code),
+            Edit::deletion(span(start, end - start)),
+        );
     }
     let remaining: Vec<&str> = codes
         .iter()
@@ -104,8 +104,11 @@ pub fn delete_codes_or_comment(
     let edit = if remaining.is_empty() {
         delete_comment(ctx, comment)
     } else {
-        let (start, end) = (start_of(codes[0]), end_of(codes[codes.len() - 1]));
+        let (start, end) = (
+            ctx.source_offset(codes[0]),
+            ctx.source_end(codes[codes.len() - 1]),
+        );
         Edit::replacement(remaining.join(", "), span(start, end - start))
     };
-    (span_of(comment), edit)
+    (ctx.source_span(comment), edit)
 }

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -71,12 +71,11 @@ pub fn delete_codes_or_comment(
         );
         return (span_of(code), Edit::deletion(span(start, end - start)));
     }
-    let mut remaining: Vec<&str> = Vec::new();
-    for code in codes {
-        if !remove.contains(code) && !remaining.contains(code) {
-            remaining.push(code);
-        }
-    }
+    let remaining: Vec<&str> = codes
+        .iter()
+        .copied()
+        .filter(|code| !remove.contains(code))
+        .collect();
     let edit = if remaining.is_empty() {
         delete_comment(ctx, comment)
     } else {

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -18,8 +18,8 @@ pub fn delete_attr_fix(ctx: &LintContext<'_>, name: &str, value_str: &str, quote
     Fix::safe_edit(Edit::deletion(span(fix_start, attr_end - fix_start)))
 }
 
-/// An edit deleting a whole comment, taking the line with it when the comment has it to
-/// itself, so no blank line is left behind.
+/// An edit deleting a comment, and its line when it has the line to itself. Sharing a line,
+/// only the comment goes: `{# #}` renders to nothing, but the whitespace around it is kept.
 pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
     let source = ctx.source();
     let start = ctx.source_offset(comment);
@@ -32,20 +32,13 @@ pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
     let (start, end) = if before.trim_ascii().is_empty() && after.trim_ascii().is_empty() {
         (line_start, line_end)
     } else {
-        // Whitespace is absorbed within the line only, so the fix never joins two lines.
-        (line_start + before.trim_ascii_end().len(), end)
+        (start, end)
     };
     Edit::deletion(span(start, end - start))
 }
 
-/// The span to report and the edit dropping `remove` from a directive's `codes`.
-///
-/// A single code is spanned and taken out with its separator; the comment goes once no code
-/// would be left; several codes among others rewrite the list in place and span the comment.
-///
-/// # Panics
-///
-/// Panics if a code in `remove` is not listed in `codes`.
+/// The span to report and the edit dropping `remove` from a directive's `codes`: one code is
+/// cut out with its separator, several are rewritten, and the comment goes once none is left.
 pub fn delete_codes_or_comment(
     ctx: &LintContext<'_>,
     comment: &str,
@@ -58,13 +51,11 @@ pub fn delete_codes_or_comment(
     if let [only] = codes {
         return (span_of(only), delete_comment(ctx, comment));
     }
-    if let [code] = remove {
-        // Offsets come from the listed slice: `remove` may hold an equal string from elsewhere.
-        let index = codes
-            .iter()
-            .position(|listed| listed == code)
-            .expect("a code to remove is listed");
-        let code = codes[index];
+    let mut listed = codes
+        .iter()
+        .enumerate()
+        .filter(|(_, listed)| remove.contains(listed));
+    if let (Some((index, code)), None) = (listed.next(), listed.next()) {
         let (start, end) = codes.get(index + 1).map_or_else(
             || (end_of(codes[index - 1]), end_of(code)),
             |next| (start_of(code), start_of(next)),

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -87,12 +87,21 @@ pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
 /// -{# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
 ///  <form method="yes"></form>
 /// ```
+///
+/// # Panics
+///
+/// In debug builds, unless `remove` is a non-empty subset of `codes`, which both fast paths
+/// assume: a lone code is taken to be a removed one, and `codes` is indexed unchecked.
 pub fn delete_codes_or_comment(
     ctx: &LintContext<'_>,
     comment: &str,
     codes: &[&str],
     remove: &[&str],
 ) -> (SourceSpan, Edit) {
+    debug_assert!(
+        !remove.is_empty() && remove.iter().all(|code| codes.contains(code)),
+        "`remove` must be a non-empty subset of `codes`"
+    );
     if let [only] = codes {
         return (ctx.source_span(only), delete_comment(ctx, comment));
     }

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -18,27 +18,49 @@ pub fn delete_attr_fix(ctx: &LintContext<'_>, name: &str, value_str: &str, quote
     Fix::safe_edit(Edit::deletion(span(fix_start, attr_end - fix_start)))
 }
 
-/// An edit deleting a comment, and its line when it has the line to itself. Sharing a line,
-/// only the comment goes: `{# #}` renders to nothing, but the whitespace around it is kept.
+/// An edit deleting a comment, and its line when it has the line to itself.
+///
+/// ```diff
+/// -{# djangofmt: ignore[gone-rule] #}
+///  <form method="yes"></form>
+/// ```
+///
+/// When sharing a line, only the comment goes. Surrounding whitespaces are kept.
+///
+/// ```diff
+/// -<div> {# djangofmt: ignore[gone-rule] #} <p>hi</p></div>
+/// +<div>  <p>hi</p></div>
+/// ```
 pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
     let source = ctx.source();
     let start = ctx.source_offset(comment);
     let end = start + comment.len();
+
     let line_start = source[..start].rfind('\n').map_or(0, |i| i + 1);
     let line_end = source[end..]
         .find('\n')
         .map_or(source.len(), |i| end + i + 1);
-    let (before, after) = (&source[line_start..start], &source[end..line_end]);
-    let (start, end) = if before.trim_ascii().is_empty() && after.trim_ascii().is_empty() {
+
+    let standalone = source[line_start..start].trim_ascii().is_empty()
+        && source[end..line_end].trim_ascii().is_empty();
+    let (delete_start, delete_end) = if standalone {
         (line_start, line_end)
     } else {
         (start, end)
     };
-    Edit::deletion(span(start, end - start))
+    Edit::deletion(span(delete_start, delete_end - delete_start))
 }
 
 /// The span to report and the edit dropping `remove` from a directive's `codes`: one code is
 /// cut out with its separator, several are rewritten, and the comment goes once none is left.
+///
+/// ```text
+/// -{# djangofmt: ignore[not-a-rule, invalid-attr-value] #}
+/// +{# djangofmt: ignore[invalid-attr-value] #}
+/// -{# djangofmt: ignore[not-a-rule, invalid-attr-value, nor-this, empty-attr-value] #}
+/// +{# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
+/// -{# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
+/// ```
 pub fn delete_codes_or_comment(
     ctx: &LintContext<'_>,
     comment: &str,

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -6,16 +6,26 @@ use crate::span;
 
 /// Builds a safe fix that deletes a whole native attribute (e.g. `type="text/javascript"`).
 ///
-/// Removes the full attribute name, `=` and value, absorbing the leading whitespace that
-/// separates it from the previous token to avoid leaving `<div >` for solo attribute and have `<div>` instead.
+/// Removes the full attribute name, `=` and value, absorbing the whitespace that separates it
+/// from the previous token, and the blanks up to a closing `>`, so that deleting the last
+/// attribute leaves `<div>` rather than `<div >`.
+///
+/// Line breaks before the `>` are kept, so a multi-line tag keeps its shape, and so is the
+/// space before a self-closing `/>`, which is idiomatic.
 ///
 /// `name` and `value_str` are the attribute's name and value slices.
 /// `quoted` indicates whether the value is wrapped in quotes (to include it in the deletion).
 pub fn delete_attr_fix(ctx: &LintContext<'_>, name: &str, value_str: &str, quoted: bool) -> Fix {
+    let source = ctx.source();
     let name_start = ctx.source_offset(name);
     let attr_end = ctx.source_end(value_str) + usize::from(quoted);
-    let fix_start = ctx.source()[..name_start].trim_ascii_end().len();
-    Fix::safe_edit(Edit::deletion(span(fix_start, attr_end - fix_start)))
+
+    let fix_start = source[..name_start].trim_ascii_end().len();
+    let fix_end = match source[attr_end..].trim_start_matches([' ', '\t']) {
+        rest if rest.starts_with('>') => source.len() - rest.len(),
+        _ => attr_end,
+    };
+    Fix::safe_edit(Edit::deletion(span(fix_start, fix_end - fix_start)))
 }
 
 /// An edit deleting a comment, and its line when it has the line to itself.

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -52,8 +52,8 @@ pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
         .find('\n')
         .map_or(source.len(), |i| end + i + 1);
 
-    // A BOM belongs to the file rather than to the line: it neither keeps the comment from
-    // being standalone, nor goes away with the line.
+    // A BOM belongs to the file rather than to the line.
+    // It neither keeps the comment from being standalone, nor goes away with the line.
     let before = strip_bom(&source[line_start..start]);
     let standalone =
         before.trim_ascii().is_empty() && source[end..line_end].trim_ascii().is_empty();
@@ -87,11 +87,6 @@ pub fn delete_comment(ctx: &LintContext<'_>, comment: &str) -> Edit {
 /// -{# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
 ///  <form method="yes"></form>
 /// ```
-///
-/// # Panics
-///
-/// In debug builds, unless `remove` is a non-empty subset of `codes`, which both fast paths
-/// assume: a lone code is taken to be a removed one, and `codes` is indexed unchecked.
 pub fn delete_codes_or_comment(
     ctx: &LintContext<'_>,
     comment: &str,

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -36,7 +36,7 @@ pub use registry::{Rule, RuleCategory, RuleGroup};
 pub use rule_selector::{RuleSelector, SelectionWarning, SelectorParseError};
 pub use rule_set::RuleSet;
 pub use settings::{LintConfiguration, Settings};
-pub use suppression::{FORMAT_CODE, FileIgnores, IGNORE_DIRECTIVE};
+pub use suppression::{FileIgnores, IGNORE_DIRECTIVE, ReservedCode};
 pub use violation::{Violation, ViolationMetadata};
 
 use std::borrow::Cow;

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -181,8 +181,10 @@ pub fn check_ast<'a>(
 ) -> Vec<LintDiagnostic> {
     let mut checker = Checker::new(source, settings, path);
     checker.visit_root(ast);
-    let suppressions = suppression::collect(ast, &checker);
-    suppression::filter(&suppressions, checker.into_diagnostics())
+    let directives = suppression::collect(ast, &checker);
+    suppression::apply(&directives, &checker);
+    checker.visit_directives(&directives);
+    checker.into_diagnostics()
 }
 
 /// Parse `source`, treating each of `custom_blocks` as a `{% tag %}...{% endtag %}` block.

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -57,6 +57,12 @@ pub fn clamp_offset(value: usize) -> u32 {
     u32::try_from(value).unwrap_or(u32::MAX)
 }
 
+/// A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
+#[must_use]
+pub(crate) fn strip_bom(source: &str) -> &str {
+    source.strip_prefix('\u{feff}').unwrap_or(source)
+}
+
 /// Wrap help and note text without splitting URLs.
 /// `textwrap` treats `/` and `-` as break opportunities, so a URL is not one word.
 #[must_use]

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -180,10 +180,15 @@ pub fn check_ast<'a>(
     path: Option<&'a Path>,
 ) -> Vec<LintDiagnostic> {
     let mut checker = Checker::new(source, settings, path);
+    // Walk the ast and collect diagnostics.
     checker.visit_root(ast);
-    let directives = suppression::collect(ast, &checker);
-    suppression::apply(&directives, &checker);
-    checker.visit_directives(&directives);
+
+    // Collect ignore comments and drop the ignored diagnostics.
+    let ignore_comments = suppression::collect_ignore_comments(ast, &checker);
+    suppression::drop_ignored_diagnostics(&checker, &ignore_comments);
+
+    // Run linter rules on the ignore comments.
+    checker.visit_ignore_comments(&ignore_comments);
     checker.into_diagnostics()
 }
 

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -149,6 +149,11 @@ impl<'a> LintContext<'a> {
         }
     }
 
+    /// Drop every diagnostic `keep` rejects: suppression applies once all rules have run.
+    pub fn retain_diagnostics(&self, keep: impl FnMut(&LintDiagnostic) -> bool) {
+        self.diagnostics.borrow_mut().retain(keep);
+    }
+
     /// Consume the context and return the collected diagnostics.
     #[must_use]
     pub fn into_diagnostics(self) -> Vec<LintDiagnostic> {

--- a/crates/djangofmt_lint/src/registry.rs
+++ b/crates/djangofmt_lint/src/registry.rs
@@ -264,4 +264,6 @@ define_rules! {
     (TableHeaderMissingScope, rules::accessibility::table_header_missing_scope::TableHeaderMissingScope),
     (SameFilePartialInclude, rules::style::same_file_partial_include::SameFilePartialInclude),
     (UnsortedTailwindClasses, rules::style::unsorted_tailwind_classes::UnsortedTailwindClasses),
+    (InvalidIgnoreComment, rules::suspicious::invalid_ignore_comment::InvalidIgnoreComment),
+    (InvalidIgnoreCode, rules::suspicious::invalid_ignore_code::InvalidIgnoreCode),
 }

--- a/crates/djangofmt_lint/src/rule_selector.rs
+++ b/crates/djangofmt_lint/src/rule_selector.rs
@@ -18,6 +18,9 @@ use crate::registry::{Rule, RuleCategory};
 /// Prefix that marks a group (a category, or `all`) selector.
 const CATEGORY_PREFIX: &str = "category:";
 
+/// The group name that selects every rule (`category:all`).
+pub(crate) const ALL_GROUP: &str = "all";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RuleSelector {
     /// Select all rules (includes rules in preview if enabled)
@@ -76,7 +79,7 @@ impl RuleSelector {
 impl fmt::Display for RuleSelector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::All => write!(f, "{CATEGORY_PREFIX}all"),
+            Self::All => write!(f, "{CATEGORY_PREFIX}{ALL_GROUP}"),
             Self::Category(category) => write!(f, "{CATEGORY_PREFIX}{category}"),
             Self::Rule(rule) => write!(f, "{rule}"),
         }
@@ -89,7 +92,7 @@ impl FromStr for RuleSelector {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         if let Some(group) = value.strip_prefix(CATEGORY_PREFIX) {
             return match group {
-                "all" => Ok(Self::All),
+                ALL_GROUP => Ok(Self::All),
                 _ => RuleCategory::from_str(group)
                     .map(Self::Category)
                     .map_err(|_| SelectorParseError::unknown_category(group)),
@@ -97,7 +100,7 @@ impl FromStr for RuleSelector {
         }
         // A bare token is a rule name.
         Rule::from_str(value).map(Self::Rule).map_err(|_| {
-            if value == "all" || RuleCategory::from_str(value).is_ok() {
+            if value == ALL_GROUP || RuleCategory::from_str(value).is_ok() {
                 // The common mistake is forgetting the `category:` prefix,
                 // so detect a bare category name and suggest the fix.
                 SelectorParseError::missing_category_prefix(value)
@@ -162,7 +165,7 @@ impl std::error::Error for SelectorParseError {}
 /// Comma-joined list of valid group names (`all` plus the categories), for error messages.
 #[must_use]
 pub fn category_list() -> String {
-    std::iter::once("all")
+    std::iter::once(ALL_GROUP)
         .chain(RuleCategory::VARIANTS.iter().copied())
         .collect::<Vec<_>>()
         .join(", ")

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -1,0 +1,60 @@
+use std::borrow::Cow;
+use std::str::FromStr;
+
+use crate::registry::{Rule, RuleCategory};
+use crate::suppression::FileIgnoreCode;
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+use crate::{Checker, span};
+
+/// ## What it does
+/// Checks for `ignore[...]` / `file-ignore[...]` suppression comments listing an invalid code.
+///
+/// ## Why is this bad?
+/// An unknown code suppresses nothing, so the diagnostic the comment was meant to silence keeps firing.
+/// It is usually a typo, or a leftover from a rule that was renamed.
+///
+/// ## Example
+/// ```html
+/// {# djangofmt: ignore[not-a-rule] #}
+/// <form method="yes">Submit</form>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {# djangofmt: ignore[invalid-attr-value] #}
+/// <form method="yes">Submit</form>
+/// ```
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct InvalidIgnoreCode {
+    pub code: String,
+}
+
+impl Violation for InvalidIgnoreCode {
+    const RULE: Rule = Rule::InvalidIgnoreCode;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+
+    #[derive_message_formats]
+    fn message(&self) -> Cow<'static, str> {
+        format!("Invalid rule code in suppression: `{}`", self.code).into()
+    }
+
+    fn help(&self) -> Option<Cow<'static, str>> {
+        Some("Remove unused suppression".into())
+    }
+}
+
+/// Report every code naming neither a rule nor a reserved code.
+pub fn check(codes: &[&str], checker: &Checker<'_>) {
+    for code in codes {
+        if Rule::from_str(code).is_ok() || FileIgnoreCode::from_str(code).is_ok() {
+            continue;
+        }
+        checker.report_diagnostic(
+            &InvalidIgnoreCode {
+                code: (*code).to_string(),
+            },
+            span(checker.source_offset(code), code.len()),
+        );
+    }
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
+use strum::{IntoEnumIterator, VariantNames};
+
 use crate::Checker;
 use crate::fix::edits::delete_codes_or_comment;
 use crate::fix::{Fix, FixAvailability};
@@ -28,13 +30,16 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// ```
 ///
 /// ## Fix safety
-/// Removing a malformed or misplaced comment is marked as unsafe because it deletes
-/// the whole comment, so any trailing free text is deleted too.
+/// The fix is marked as unsafe when every listed code is invalid, because the whole comment is
+/// then deleted, taking any free-text reason with it. Dropping an invalid code from a list that
+/// keeps a valid one is safe.
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
 #[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct InvalidIgnoreCode {
     /// The invalid codes, comma-separated.
     pub codes: String,
+    /// The known code a lone invalid one is close enough to be a typo for.
+    pub suggestion: Option<&'static str>,
     /// Whether every listed code is invalid, so the fix removes the whole comment.
     pub whole_comment: bool,
 }
@@ -47,6 +52,11 @@ impl Violation for InvalidIgnoreCode {
     #[derive_message_formats]
     fn message(&self) -> Cow<'static, str> {
         format!("Invalid rule code in suppression: {}", self.codes).into()
+    }
+
+    fn help(&self) -> Option<Cow<'static, str>> {
+        self.suggestion
+            .map(|code| format!("Did you mean `{code}`?").into())
     }
 
     fn fix_title(&self) -> Option<&'static str> {
@@ -67,11 +77,14 @@ pub fn check(comments: &[IgnoreComment<'_>], checker: &Checker<'_>) {
 
 fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
     let codes = comment.directive.codes();
-    let invalid: Vec<&str> = codes
-        .iter()
-        .copied()
-        .filter(|code| Rule::from_str(code).is_err() && ReservedCode::from_str(code).is_err())
-        .collect();
+    let mut invalid: Vec<&str> = Vec::new();
+    for &code in codes {
+        let unknown = Rule::from_str(code).is_err() && ReservedCode::from_str(code).is_err();
+        // The same code twice is one mistake, and the fix drops every occurrence of it.
+        if unknown && !invalid.contains(&code) {
+            invalid.push(code);
+        }
+    }
     if invalid.is_empty() {
         return;
     }
@@ -82,8 +95,30 @@ fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
             .map(|code| format!("`{code}`"))
             .collect::<Vec<_>>()
             .join(", "),
+        // With several invalid codes the diagnostic spans the comment, so a lone suggestion
+        // would not say which code it is about.
+        suggestion: match invalid.as_slice() {
+            [code] => closest_known_code(code),
+            _ => None,
+        },
         whole_comment: deletion.whole_comment,
     };
     let mut guard = checker.report_diagnostic(&violation, deletion.span);
-    guard.set_fix(Fix::safe_edit(deletion.edit));
+    guard.set_fix(if deletion.whole_comment {
+        Fix::unsafe_edit(deletion.edit)
+    } else {
+        Fix::safe_edit(deletion.edit)
+    });
+}
+
+/// The known code `code` was likely meant to be, when one is close enough to name.
+fn closest_known_code(code: &str) -> Option<&'static str> {
+    Rule::iter()
+        .map(<&'static str>::from)
+        .chain(ReservedCode::VARIANTS.iter().copied())
+        .map(|known| (strsim::levenshtein(code, known), known))
+        // A third of the longer spelling, so a suggestion stays a plausible misspelling.
+        .filter(|&(distance, known)| distance <= (code.len().max(known.len()) / 3).max(1))
+        .min_by_key(|&(distance, _)| distance)
+        .map(|(_, known)| known)
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -26,6 +26,10 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// {# djangofmt: ignore[invalid-attr-value] #}
 /// <form method="yes">Submit</form>
 /// ```
+///
+/// ## Fix safety
+/// Removing a malformed or misplaced comment is marked as unsafe because it deletes
+/// the whole comment, so any trailing free text is deleted too.
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
 #[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct InvalidIgnoreCode {

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -75,15 +75,15 @@ fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
     if invalid.is_empty() {
         return;
     }
-    let (span, edit) = delete_codes_or_comment(checker.context(), comment.raw, codes, &invalid);
+    let deletion = delete_codes_or_comment(checker.context(), comment.raw, codes, &invalid);
     let violation = InvalidIgnoreCode {
         codes: invalid
             .iter()
             .map(|code| format!("`{code}`"))
             .collect::<Vec<_>>()
             .join(", "),
-        whole_comment: invalid.len() == codes.len(),
+        whole_comment: deletion.whole_comment,
     };
-    let mut guard = checker.report_diagnostic(&violation, span);
-    guard.set_fix(Fix::safe_edit(edit));
+    let mut guard = checker.report_diagnostic(&violation, deletion.span);
+    guard.set_fix(Fix::safe_edit(deletion.edit));
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -5,7 +5,7 @@ use crate::Checker;
 use crate::fix::edits::delete_codes_or_comment;
 use crate::fix::{Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
-use crate::suppression::{FORMAT_CODE, INVALID_SYNTAX_CODE, IgnoreComment};
+use crate::suppression::{IgnoreComment, ReservedCode};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 
 /// ## What it does
@@ -56,7 +56,7 @@ impl Violation for InvalidIgnoreCode {
 
 /// Whether `code` names a rule or one of the reserved codes.
 fn is_known(code: &str) -> bool {
-    Rule::from_str(code).is_ok() || matches!(code, FORMAT_CODE | INVALID_SYNTAX_CODE)
+    Rule::from_str(code).is_ok() || ReservedCode::from_str(code).is_ok()
 }
 
 /// Report the codes naming neither a rule nor a reserved code, once per comment.

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -1,10 +1,12 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
+use crate::Checker;
+use crate::fix::edits::delete_codes_or_comment;
+use crate::fix::{Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
-use crate::suppression::FileIgnoreCode;
+use crate::suppression::{DirectiveComment, FORMAT_CODE, INVALID_SYNTAX_CODE};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `ignore[...]` / `file-ignore[...]` suppression comments listing an invalid code.
@@ -24,37 +26,63 @@ use crate::{Checker, span};
 /// {# djangofmt: ignore[invalid-attr-value] #}
 /// <form method="yes">Submit</form>
 /// ```
+///
+/// ## Fix safety
+/// The fix is marked as safe: a code naming no rule suppresses nothing, so dropping it cannot
+/// change which diagnostics are reported. A comment left with no code at all goes with it.
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
 #[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct InvalidIgnoreCode {
-    pub code: String,
+    /// The invalid codes, comma-separated.
+    pub codes: String,
+    /// Whether every listed code is invalid, so the fix removes the whole comment.
+    pub whole_comment: bool,
 }
 
 impl Violation for InvalidIgnoreCode {
     const RULE: Rule = Rule::InvalidIgnoreCode;
     const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> Cow<'static, str> {
-        format!("Invalid rule code in suppression: `{}`", self.code).into()
+        format!("Invalid rule code in suppression: {}", self.codes).into()
     }
 
-    fn help(&self) -> Option<Cow<'static, str>> {
-        Some("Remove unused suppression".into())
+    fn fix_title(&self) -> Option<&'static str> {
+        Some(if self.whole_comment {
+            "Remove suppression comment"
+        } else {
+            "Remove invalid rule code"
+        })
     }
 }
 
-/// Report every code naming neither a rule nor a reserved code.
-pub fn check(codes: &[&str], checker: &Checker<'_>) {
-    for code in codes {
-        if Rule::from_str(code).is_ok() || FileIgnoreCode::from_str(code).is_ok() {
-            continue;
-        }
-        checker.report_diagnostic(
-            &InvalidIgnoreCode {
-                code: (*code).to_string(),
-            },
-            span(checker.source_offset(code), code.len()),
-        );
+/// Whether `code` names a rule or one of the reserved codes.
+fn is_known(code: &str) -> bool {
+    Rule::from_str(code).is_ok() || matches!(code, FORMAT_CODE | INVALID_SYNTAX_CODE)
+}
+
+/// Report the codes naming neither a rule nor a reserved code, once per comment.
+pub fn check(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
+    let codes = comment.directive.codes();
+    let invalid: Vec<&str> = codes
+        .iter()
+        .copied()
+        .filter(|code| !is_known(code))
+        .collect();
+    if invalid.is_empty() {
+        return;
     }
+    let (span, edit) = delete_codes_or_comment(checker.context(), comment.raw, codes, &invalid);
+    let violation = InvalidIgnoreCode {
+        codes: invalid
+            .iter()
+            .map(|code| format!("`{code}`"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        whole_comment: invalid.len() == codes.len(),
+    };
+    let mut guard = checker.report_diagnostic(&violation, span);
+    guard.set_fix(Fix::safe_edit(edit));
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -26,10 +26,6 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// {# djangofmt: ignore[invalid-attr-value] #}
 /// <form method="yes">Submit</form>
 /// ```
-///
-/// ## Fix safety
-/// The fix is marked as safe: a code naming no rule suppresses nothing, so dropping it cannot
-/// change which diagnostics are reported. A comment left with no code at all goes with it.
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
 #[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct InvalidIgnoreCode {

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -64,7 +64,13 @@ fn is_known(code: &str) -> bool {
 }
 
 /// Report the codes naming neither a rule nor a reserved code, once per comment.
-pub fn check(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
+pub fn check(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
+    for comment in directives {
+        check_comment(comment, checker);
+    }
+}
+
+fn check_comment(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
     let codes = comment.directive.codes();
     let invalid: Vec<&str> = codes
         .iter()

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -5,7 +5,7 @@ use crate::Checker;
 use crate::fix::edits::delete_codes_or_comment;
 use crate::fix::{Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
-use crate::suppression::{DirectiveComment, FORMAT_CODE, INVALID_SYNTAX_CODE};
+use crate::suppression::{FORMAT_CODE, INVALID_SYNTAX_CODE, IgnoreComment};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 
 /// ## What it does
@@ -60,13 +60,13 @@ fn is_known(code: &str) -> bool {
 }
 
 /// Report the codes naming neither a rule nor a reserved code, once per comment.
-pub fn check(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
-    for comment in directives {
+pub fn check(comments: &[IgnoreComment<'_>], checker: &Checker<'_>) {
+    for comment in comments {
         check_comment(comment, checker);
     }
 }
 
-fn check_comment(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
+fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
     let codes = comment.directive.codes();
     let invalid: Vec<&str> = codes
         .iter()

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_code.rs
@@ -54,11 +54,6 @@ impl Violation for InvalidIgnoreCode {
     }
 }
 
-/// Whether `code` names a rule or one of the reserved codes.
-fn is_known(code: &str) -> bool {
-    Rule::from_str(code).is_ok() || ReservedCode::from_str(code).is_ok()
-}
-
 /// Report the codes naming neither a rule nor a reserved code, once per comment.
 pub fn check(comments: &[IgnoreComment<'_>], checker: &Checker<'_>) {
     for comment in comments {
@@ -71,7 +66,7 @@ fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
     let invalid: Vec<&str> = codes
         .iter()
         .copied()
-        .filter(|code| !is_known(code))
+        .filter(|code| Rule::from_str(code).is_err() && ReservedCode::from_str(code).is_err())
         .collect();
     if invalid.is_empty() {
         return;

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -37,6 +37,10 @@ pub enum IgnoreCommentViolation {
 /// ```
 ///
 /// Or delete the invalid suppression comment.
+///
+/// ## Fix safety
+/// Removing a malformed or misplaced comment is marked as unsafe because it deletes
+/// the whole comment, so any trailing free text is deleted too.
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
 #[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct InvalidIgnoreComment {

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -4,7 +4,7 @@ use crate::Checker;
 use crate::fix::edits::{delete_codes_or_comment, delete_comment};
 use crate::fix::{Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
-use crate::suppression::{INVALID_SYNTAX_CODE, IgnoreComment, IgnoreDirective, ParseErrorKind};
+use crate::suppression::{IgnoreComment, IgnoreDirective, ParseErrorKind, ReservedCode};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -114,11 +114,11 @@ fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
         }
         IgnoreDirective::FileIgnore(_) => return,
         IgnoreDirective::Ignore(codes) => {
-            if !codes.contains(&INVALID_SYNTAX_CODE) {
+            let invalid_syntax = ReservedCode::InvalidSyntax.as_str();
+            if !codes.contains(&invalid_syntax) {
                 return;
             }
-            let (span, edit) =
-                delete_codes_or_comment(ctx, comment.raw, codes, &[INVALID_SYNTAX_CODE]);
+            let (span, edit) = delete_codes_or_comment(ctx, comment.raw, codes, &[invalid_syntax]);
             (
                 IgnoreCommentViolation::InvalidSyntaxOnNode,
                 span,

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 
+use crate::Checker;
 use crate::fix::edits::{delete_codes_or_comment, delete_comment};
 use crate::fix::{Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
 use crate::suppression::{Directive, DirectiveComment, INVALID_SYNTAX_CODE, ParseErrorKind};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum IgnoreCommentViolation {
@@ -99,10 +99,9 @@ pub fn check(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
 fn check_comment(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
     let ctx = checker.context();
     let remove_comment = |kind| {
-        let span = span(ctx.source_offset(comment.raw), comment.raw.len());
         (
             kind,
-            span,
+            ctx.source_span(comment.raw),
             Fix::unsafe_edit(delete_comment(ctx, comment.raw)),
         )
     };

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -1,0 +1,129 @@
+use std::borrow::Cow;
+
+use crate::fix::edits::{delete_codes_or_comment, delete_comment};
+use crate::fix::{Fix, FixAvailability};
+use crate::registry::{Rule, RuleCategory};
+use crate::suppression::{Directive, DirectiveComment, INVALID_SYNTAX_CODE, ParseErrorKind};
+use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
+use crate::{Checker, span};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum IgnoreCommentViolation {
+    /// The comment starts with `djangofmt:` but does not parse as a directive.
+    Malformed(ParseErrorKind),
+    /// A `file-ignore[...]` directive that does not lead the file.
+    MisplacedFileIgnore,
+    /// `invalid-syntax` listed in a node-level `ignore[...]`.
+    InvalidSyntaxOnNode,
+}
+
+/// ## What it does
+/// Checks for `djangofmt:` suppression comments that are malformed or misplaced.
+///
+/// ## Why is this bad?
+/// Invalid suppression comments are ignored by djangofmt, and should either be fixed or removed to avoid confusion.
+///
+/// ## Example
+/// ```html
+/// {# djangofmt: ignore[] #}
+/// <form method="yes">Submit</form>
+/// ```
+///
+/// Use instead:
+/// ```html
+/// {# djangofmt: ignore[invalid-attr-value] #}
+/// <form method="yes">Submit</form>
+/// ```
+///
+/// Or delete the invalid suppression comment.
+///
+/// ## Fix safety
+/// Dropping a node-level `invalid-syntax` code is a safe fix: the code suppresses nothing where
+/// it stands. Removing a malformed or misplaced comment is an unsafe fix: the rules its author
+/// meant to silence cannot be recovered, so the comment is deleted rather than repaired.
+#[derive(Debug, PartialEq, Eq, ViolationMetadata)]
+#[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
+pub struct InvalidIgnoreComment {
+    pub kind: IgnoreCommentViolation,
+}
+
+impl Violation for InvalidIgnoreComment {
+    const RULE: Rule = Rule::InvalidIgnoreComment;
+    const CATEGORY: RuleCategory = RuleCategory::Suspicious;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> Cow<'static, str> {
+        match self.kind {
+            IgnoreCommentViolation::Malformed(error) => {
+                format!("Invalid suppression comment: {error}").into()
+            }
+            IgnoreCommentViolation::MisplacedFileIgnore => {
+                "Invalid suppression comment: file-level suppressions must be at the top of the file"
+                    .into()
+            }
+            IgnoreCommentViolation::InvalidSyntaxOnNode => {
+                "Invalid suppression comment: `invalid-syntax` cannot be scoped to a node".into()
+            }
+        }
+    }
+
+    fn help(&self) -> Option<Cow<'static, str>> {
+        Some(match self.kind {
+            IgnoreCommentViolation::Malformed(_) => {
+                "Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`"
+                    .into()
+            }
+            IgnoreCommentViolation::MisplacedFileIgnore => {
+                "Move the comment to the top of the file, or use `ignore[...]`".into()
+            }
+            IgnoreCommentViolation::InvalidSyntaxOnNode => {
+                "Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead"
+                    .into()
+            }
+        })
+    }
+
+    fn fix_title(&self) -> Option<&'static str> {
+        Some(match self.kind {
+            IgnoreCommentViolation::InvalidSyntaxOnNode => "Remove `invalid-syntax` code",
+            IgnoreCommentViolation::Malformed(_) | IgnoreCommentViolation::MisplacedFileIgnore => {
+                "Remove suppression comment"
+            }
+        })
+    }
+}
+
+/// Lint one directive comment.
+pub fn check(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
+    let ctx = checker.context();
+    let remove_comment = |kind| {
+        let span = span(ctx.source_offset(comment.raw), comment.raw.len());
+        (
+            kind,
+            span,
+            Fix::unsafe_edit(delete_comment(ctx, comment.raw)),
+        )
+    };
+    let (kind, span, fix) = match &comment.directive {
+        Directive::Malformed(error) => remove_comment(IgnoreCommentViolation::Malformed(*error)),
+        Directive::FileIgnore(_) if !comment.is_leading => {
+            remove_comment(IgnoreCommentViolation::MisplacedFileIgnore)
+        }
+        Directive::FileIgnore(_) => return,
+        Directive::Ignore(codes) => {
+            if !codes.contains(&INVALID_SYNTAX_CODE) {
+                return;
+            }
+            let (span, edit) =
+                delete_codes_or_comment(ctx, comment.raw, codes, &[INVALID_SYNTAX_CODE]);
+            (
+                IgnoreCommentViolation::InvalidSyntaxOnNode,
+                span,
+                Fix::safe_edit(edit),
+            )
+        }
+    };
+    let mut guard = checker.report_diagnostic(&InvalidIgnoreComment { kind }, span);
+    guard.set_fix(fix);
+}

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -125,13 +125,13 @@ fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
             if !codes.contains(&invalid_syntax) {
                 return;
             }
-            let (span, edit) = delete_codes_or_comment(ctx, comment.raw, codes, &[invalid_syntax]);
+            let deletion = delete_codes_or_comment(ctx, comment.raw, codes, &[invalid_syntax]);
             (
                 IgnoreCommentViolation::InvalidSyntaxOnNode {
-                    whole_comment: codes.iter().all(|code| *code == invalid_syntax),
+                    whole_comment: deletion.whole_comment,
                 },
-                span,
-                Fix::safe_edit(edit),
+                deletion.span,
+                Fix::safe_edit(deletion.edit),
             )
         }
     };

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -14,7 +14,8 @@ pub enum IgnoreCommentViolation {
     /// A `file-ignore[...]` directive that does not lead the file.
     MisplacedFileIgnore,
     /// `invalid-syntax` listed in a node-level `ignore[...]`.
-    InvalidSyntaxOnNode,
+    /// `whole_comment` tells whether dropping it leaves no code behind.
+    InvalidSyntaxOnNode { whole_comment: bool },
 }
 
 /// ## What it does
@@ -57,7 +58,7 @@ impl Violation for InvalidIgnoreComment {
                 "Invalid suppression comment: file-level suppressions must be at the top of the file"
                     .into()
             }
-            IgnoreCommentViolation::InvalidSyntaxOnNode => {
+            IgnoreCommentViolation::InvalidSyntaxOnNode { .. } => {
                 "Invalid suppression comment: `invalid-syntax` cannot be scoped to a node".into()
             }
         }
@@ -72,7 +73,7 @@ impl Violation for InvalidIgnoreComment {
             IgnoreCommentViolation::MisplacedFileIgnore => {
                 "Move the comment to the top of the file, or use `ignore[...]`".into()
             }
-            IgnoreCommentViolation::InvalidSyntaxOnNode => {
+            IgnoreCommentViolation::InvalidSyntaxOnNode { .. } => {
                 "Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead"
                     .into()
             }
@@ -81,10 +82,12 @@ impl Violation for InvalidIgnoreComment {
 
     fn fix_title(&self) -> Option<&'static str> {
         Some(match self.kind {
-            IgnoreCommentViolation::InvalidSyntaxOnNode => "Remove `invalid-syntax` code",
-            IgnoreCommentViolation::Malformed(_) | IgnoreCommentViolation::MisplacedFileIgnore => {
-                "Remove suppression comment"
-            }
+            IgnoreCommentViolation::InvalidSyntaxOnNode {
+                whole_comment: false,
+            } => "Remove `invalid-syntax` code",
+            IgnoreCommentViolation::InvalidSyntaxOnNode { .. }
+            | IgnoreCommentViolation::Malformed(_)
+            | IgnoreCommentViolation::MisplacedFileIgnore => "Remove suppression comment",
         })
     }
 }
@@ -120,7 +123,9 @@ fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
             }
             let (span, edit) = delete_codes_or_comment(ctx, comment.raw, codes, &[invalid_syntax]);
             (
-                IgnoreCommentViolation::InvalidSyntaxOnNode,
+                IgnoreCommentViolation::InvalidSyntaxOnNode {
+                    whole_comment: codes.iter().all(|code| *code == invalid_syntax),
+                },
                 span,
                 Fix::safe_edit(edit),
             )

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -131,7 +131,11 @@ fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
                     whole_comment: deletion.whole_comment,
                 },
                 deletion.span,
-                Fix::safe_edit(deletion.edit),
+                if deletion.whole_comment {
+                    Fix::unsafe_edit(deletion.edit)
+                } else {
+                    Fix::safe_edit(deletion.edit)
+                },
             )
         }
     };

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -94,8 +94,14 @@ impl Violation for InvalidIgnoreComment {
     }
 }
 
-/// Lint one directive comment.
-pub fn check(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
+/// Lint every directive comment of the file.
+pub fn check(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
+    for comment in directives {
+        check_comment(comment, checker);
+    }
+}
+
+fn check_comment(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
     let ctx = checker.context();
     let remove_comment = |kind| {
         let span = span(ctx.source_offset(comment.raw), comment.raw.len());

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -4,7 +4,7 @@ use crate::Checker;
 use crate::fix::edits::{delete_codes_or_comment, delete_comment};
 use crate::fix::{Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
-use crate::suppression::{Directive, DirectiveComment, INVALID_SYNTAX_CODE, ParseErrorKind};
+use crate::suppression::{INVALID_SYNTAX_CODE, IgnoreComment, IgnoreDirective, ParseErrorKind};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -89,14 +89,14 @@ impl Violation for InvalidIgnoreComment {
     }
 }
 
-/// Lint every directive comment of the file.
-pub fn check(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
-    for comment in directives {
+/// Lint every ignore comment of the file.
+pub fn check(comments: &[IgnoreComment<'_>], checker: &Checker<'_>) {
+    for comment in comments {
         check_comment(comment, checker);
     }
 }
 
-fn check_comment(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
+fn check_comment(comment: &IgnoreComment<'_>, checker: &Checker<'_>) {
     let ctx = checker.context();
     let remove_comment = |kind| {
         (
@@ -106,12 +106,14 @@ fn check_comment(comment: &DirectiveComment<'_>, checker: &Checker<'_>) {
         )
     };
     let (kind, span, fix) = match &comment.directive {
-        Directive::Malformed(error) => remove_comment(IgnoreCommentViolation::Malformed(*error)),
-        Directive::FileIgnore(_) if !comment.is_leading => {
+        IgnoreDirective::Malformed(error) => {
+            remove_comment(IgnoreCommentViolation::Malformed(*error))
+        }
+        IgnoreDirective::FileIgnore(_) if !comment.is_leading => {
             remove_comment(IgnoreCommentViolation::MisplacedFileIgnore)
         }
-        Directive::FileIgnore(_) => return,
-        Directive::Ignore(codes) => {
+        IgnoreDirective::FileIgnore(_) => return,
+        IgnoreDirective::Ignore(codes) => {
             if !codes.contains(&INVALID_SYNTAX_CODE) {
                 return;
             }

--- a/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/invalid_ignore_comment.rs
@@ -36,11 +36,6 @@ pub enum IgnoreCommentViolation {
 /// ```
 ///
 /// Or delete the invalid suppression comment.
-///
-/// ## Fix safety
-/// Dropping a node-level `invalid-syntax` code is a safe fix: the code suppresses nothing where
-/// it stands. Removing a malformed or misplaced comment is an unsafe fix: the rules its author
-/// meant to silence cannot be recovered, so the comment is deleted rather than repaired.
 #[derive(Debug, PartialEq, Eq, ViolationMetadata)]
 #[violation_metadata(stable_since = "NEXT_DJANGOFMT_VERSION")]
 pub struct InvalidIgnoreComment {

--- a/crates/djangofmt_lint/src/rules/suspicious/mod.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/mod.rs
@@ -2,5 +2,7 @@ pub mod django_static_url;
 pub mod django_url_pattern;
 pub mod duplicate_attr;
 pub mod empty_tag_pair;
+pub mod invalid_ignore_code;
+pub mod invalid_ignore_comment;
 pub mod javascript_url;
 pub mod use_https;

--- a/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
@@ -31,9 +31,8 @@ use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe: rewriting the scheme changes which endpoint the browser use.
-/// The host may not serve HTTPS at all, so the fix can break a link or subresource that
-/// previously worked over HTTP, and even when HTTPS is available it may serve different content .
+/// This rule's fix is marked as unsafe: rewriting the scheme changes which endpoint the browser
+/// requests. The host may not serve HTTPS at all, or may serve different content over it.
 ///
 /// ## References
 /// - [MDN: Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -131,9 +131,9 @@ mod tests {
 
     use super::{LintConfiguration, Settings, unsorted_tailwind_classes};
     use crate::registry::{Rule, RuleCategory};
-    use crate::rule_selector::{RuleSelector, SelectionWarning};
+    use crate::rule_selector::{ALL_GROUP, RuleSelector, SelectionWarning};
     use crate::rule_set::RuleSet;
-    use crate::suppression::{FORMAT_CODE, INVALID_SYNTAX_CODE};
+    use crate::suppression::ReservedCode;
 
     #[test]
     fn any_rule_enabled_reflects_membership() {
@@ -235,10 +235,8 @@ mod tests {
 
     #[test]
     fn no_rule_name_collides_with_a_reserved_word() {
-        // `format`/`invalid-syntax` are `file-ignore[...]` codes; `lint` is kept free for group suppression.
-        let reserved = ["all", "lint", FORMAT_CODE, INVALID_SYNTAX_CODE];
-        for word in reserved
-            .into_iter()
+        for word in std::iter::once(ALL_GROUP)
+            .chain(ReservedCode::VARIANTS.iter().copied())
             .chain(RuleCategory::VARIANTS.iter().copied())
         {
             assert!(

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -133,6 +133,7 @@ mod tests {
     use crate::registry::{Rule, RuleCategory};
     use crate::rule_selector::{RuleSelector, SelectionWarning};
     use crate::rule_set::RuleSet;
+    use crate::suppression::{FORMAT_CODE, INVALID_SYNTAX_CODE};
 
     #[test]
     fn any_rule_enabled_reflects_membership() {
@@ -235,7 +236,7 @@ mod tests {
     #[test]
     fn no_rule_name_collides_with_a_reserved_word() {
         // `format`/`invalid-syntax` are `file-ignore[...]` codes; `lint` is kept free for group suppression.
-        let reserved = ["all", "lint", "format", "invalid-syntax"];
+        let reserved = ["all", "lint", FORMAT_CODE, INVALID_SYNTAX_CODE];
         for word in reserved
             .into_iter()
             .chain(RuleCategory::VARIANTS.iter().copied())

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -10,63 +10,213 @@ use std::str::FromStr;
 use markup_fmt::ast::{JinjaTagOrChildren, Node, NodeKind, Root};
 use smallvec::SmallVec;
 
+use crate::Checker;
 use crate::registry::Rule;
 use crate::rule_set::RuleSet;
-use crate::{Checker, LintDiagnostic};
 
 /// The code that opts a node or file out of the formatter.
 pub const FORMAT_CODE: &str = "format";
 
-/// The node-level directive, also the formatter's own opt-out.
-pub const IGNORE_DIRECTIVE: &str = "djangofmt:ignore";
+/// The code that suppresses parse errors; only `file-ignore[...]` may carry it.
+pub const INVALID_SYNTAX_CODE: &str = "invalid-syntax";
+
+/// The namespace every directive opens with, followed by a colon and a keyword.
+const NAMESPACE: &str = "djangofmt";
+
+/// The node-level keyword, also the formatter's own opt-out.
+const IGNORE: &str = "ignore";
 
 /// Its file-wide sibling.
-const FILE_IGNORE_DIRECTIVE: &str = "djangofmt:file-ignore";
+const FILE_IGNORE: &str = "file-ignore";
 
-/// A code accepted in `file-ignore[...]`; unknown codes are ignored.
-#[derive(Debug, PartialEq, Eq, strum::EnumString)]
-#[strum(serialize_all = "kebab-case")]
-enum FileIgnoreCode {
-    /// Suppress parse errors: both commands skip the file.
-    InvalidSyntax,
-    /// Skip the formatter.
-    Format,
+/// The formatter's directive, `NAMESPACE:IGNORE` spelled out for `markup_fmt` to match.
+pub const IGNORE_DIRECTIVE: &str = "djangofmt:ignore";
+
+/// The codes a directive lists; most list one or two.
+type Codes<'s> = SmallVec<[&'s str; 2]>;
+
+/// Why a comment addressed to djangofmt is no directive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ParseErrorKind {
+    #[error("unknown djangofmt directive")]
+    UnknownKeyword,
+    #[error("missing suppression codes like `[missing-img-alt, ...]`")]
+    MissingCodes,
+    #[error("missing closing bracket")]
+    MissingBracket,
+    #[error("missing comma between codes")]
+    MissingComma,
+    #[error("invalid rule code")]
+    InvalidCode,
 }
 
-/// The codes of a `ignore[...]` / `file-ignore[...]` comment body.
-fn directive_codes<'s>(raw: &'s str, directive: &str) -> Option<Vec<&'s str>> {
-    let codes: Vec<&str> = markup_fmt::match_directive(raw, directive)?
-        .codes()
-        .collect();
-    (!codes.is_empty()).then_some(codes)
+/// What a `{# djangofmt: ... #}` comment asks for.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Directive<'s> {
+    /// `ignore[...]`, guarding the following node.
+    Ignore(Codes<'s>),
+    /// `file-ignore[...]`, covering the whole file.
+    FileIgnore(Codes<'s>),
+    /// Addressed to djangofmt, yet neither of the above nor the formatter's bare `ignore`.
+    Malformed(ParseErrorKind),
 }
 
-/// Rule codes suppressed over byte ranges of the source.
-pub struct Suppression<'s> {
+impl<'s> Directive<'s> {
+    /// The codes listed, none for a malformed directive.
+    pub fn codes(&self) -> &[&'s str] {
+        match self {
+            Self::Ignore(codes) | Self::FileIgnore(codes) => codes,
+            Self::Malformed(_) => &[],
+        }
+    }
+}
+
+/// Parse a `{# #}` comment body as a lint directive.
+///
+/// `None` is a comment the linter has no say on: one not addressed to djangofmt, or the
+/// formatter's bare `ignore`, which carries no lint codes.
+fn parse(body: &str) -> Option<Directive<'_>> {
+    // Most comments are no directive: settle that before touching the body's tail.
+    // Jinja's whitespace-control markers (`{#- ... -#}`) belong to the delimiter.
+    let rest = body
+        .trim_start()
+        .trim_start_matches(['-', '+'])
+        .trim_start()
+        .strip_prefix(NAMESPACE)?
+        .trim_start()
+        .strip_prefix(':')?
+        .trim_start()
+        .trim_end()
+        .trim_end_matches('-');
+    let keyword_end = rest
+        .find(|c: char| c == '[' || c.is_whitespace())
+        .unwrap_or(rest.len());
+    let (keyword, rest) = rest.split_at(keyword_end);
+    let directive = match keyword {
+        IGNORE => Directive::Ignore,
+        FILE_IGNORE => Directive::FileIgnore,
+        _ => return Some(Directive::Malformed(ParseErrorKind::UnknownKeyword)),
+    };
+    // The formatter's `ignore` stands bare or with a reason; only a list glued to it is ours.
+    if keyword == IGNORE && !rest.starts_with('[') {
+        return None;
+    }
+    let Some(list) = rest.trim_start().strip_prefix('[') else {
+        return Some(Directive::Malformed(ParseErrorKind::MissingCodes));
+    };
+    Some(parse_codes(list).map_or_else(Directive::Malformed, directive))
+}
+
+/// The codes of a `[...]` list, `list` starting right after the bracket; everything after the
+/// closing bracket is a free-text reason.
+fn parse_codes(list: &str) -> Result<Codes<'_>, ParseErrorKind> {
+    let mut codes = Codes::new();
+    let mut rest = list.trim_start();
+    loop {
+        if rest.is_empty() {
+            return Err(ParseErrorKind::MissingBracket);
+        }
+        if rest.starts_with(']') {
+            break;
+        }
+        let (code, after) = rest.split_at(code_len(rest));
+        if code.is_empty() {
+            return Err(ParseErrorKind::InvalidCode);
+        }
+        codes.push(code);
+        rest = after.trim_start();
+        match rest.strip_prefix(',') {
+            Some(after_comma) => rest = after_comma.trim_start(),
+            None if rest.starts_with(']') => break,
+            None if rest.is_empty() => return Err(ParseErrorKind::MissingBracket),
+            None => return Err(ParseErrorKind::MissingComma),
+        }
+    }
+    if codes.is_empty() {
+        return Err(ParseErrorKind::MissingCodes);
+    }
+    Ok(codes)
+}
+
+/// How far a rule code runs from the start of `text`: a letter, then letters, digits, `_`, `-`,
+/// or a `:` tolerated so `lint:code` still reads as one code.
+fn code_len(text: &str) -> usize {
+    let mut chars = text.char_indices();
+    if !chars.next().is_some_and(|(_, c)| c.is_alphabetic()) {
+        return 0;
+    }
+    chars
+        .find(|(_, c)| !(c.is_alphanumeric() || matches!(c, '_' | '-' | ':')))
+        .map_or(text.len(), |(index, _)| index)
+}
+
+/// A `{# djangofmt: ... #}` comment as the linter reads it.
+pub struct DirectiveComment<'s> {
+    /// The whole comment, delimiters included: what a diagnostic points at and a fix deletes.
+    pub raw: &'s str,
+    /// What the comment asks for.
+    pub directive: Directive<'s>,
+    /// Whether it is the file's leading comment, the only place `file-ignore` counts.
+    pub is_leading: bool,
+    /// Byte ranges an `ignore[...]` guards; empty when nothing follows it.
     ranges: SmallVec<[Range<usize>; 2]>,
-    codes: Vec<&'s str>,
 }
 
-/// Collect what each node-level `ignore[...]` comment suppresses.
+impl DirectiveComment<'_> {
+    /// Whether the directive silences `code` reported at `offset`.
+    fn suppresses(&self, code: &str, offset: usize) -> bool {
+        self.ranges.iter().any(|range| range.contains(&offset))
+            && self.directive.codes().contains(&code)
+    }
+}
+
+/// Every lint directive of the file, in source order.
 #[must_use]
-pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'_>) -> Vec<Suppression<'s>> {
+pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'_>) -> Vec<DirectiveComment<'s>> {
+    let source = checker.context().source();
     root.jinja_comments
         .iter()
-        .filter_map(|raw| {
-            let codes = directive_codes(raw, IGNORE_DIRECTIVE)?;
-            let rest = siblings_after(&root.children, checker.source_offset(raw), checker)?;
-            let ranges = guarded_ranges(checker, rest)?;
-            Some(Suppression { ranges, codes })
+        .filter_map(|body| {
+            let directive = parse(body)?;
+            // An attribute-position comment is no node: it neither guards nor gets linted.
+            let (node, rest) = locate(&root.children, checker.source_offset(body), checker)?;
+            let ranges = match directive {
+                Directive::Ignore(_) => guarded_ranges(checker, rest),
+                Directive::FileIgnore(_) | Directive::Malformed(_) => SmallVec::new(),
+            };
+            // Only `file-ignore` cares where it sits, so only it pays for the lookup.
+            let is_leading = matches!(directive, Directive::FileIgnore(_))
+                && leading_jinja_comment(source)
+                    .is_some_and(|leading| leading.as_ptr() == body.as_ptr());
+            Some(DirectiveComment {
+                raw: node.raw,
+                directive,
+                is_leading,
+                ranges,
+            })
         })
         .collect()
 }
 
-/// The siblings following the `{# djangofmt:ignore[rule] #}` comment at `offset`.
-fn siblings_after<'n, 's>(
+/// Drop from `checker` the diagnostics the directives silence.
+pub fn apply(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
+    if directives.is_empty() {
+        return;
+    }
+    checker.context().retain_diagnostics(|diagnostic| {
+        let offset = diagnostic.span.offset() as usize;
+        !directives
+            .iter()
+            .any(|comment| comment.suppresses(diagnostic.code, offset))
+    });
+}
+
+/// The `{# #}` comment node whose body sits at `offset`, and the siblings following it.
+fn locate<'n, 's>(
     mut nodes: &'n [Node<'s>],
     offset: usize,
     checker: &Checker<'_>,
-) -> Option<&'n [Node<'s>]> {
+) -> Option<(&'n Node<'s>, &'n [Node<'s>])> {
     let start = |node: &Node<'_>| checker.source_offset(node.raw);
     let end = |node: &Node<'_>| checker.source_end(node.raw);
     loop {
@@ -74,7 +224,7 @@ fn siblings_after<'n, 's>(
         let index = nodes.partition_point(|node| end(node) <= offset);
         let node = nodes.get(index).filter(|node| start(node) <= offset)?;
         if matches!(node.kind, NodeKind::JinjaComment(_)) {
-            return Some(&nodes[index + 1..]);
+            return Some((node, &nodes[index + 1..]));
         }
         nodes = child_slices(node).find(|children| {
             children
@@ -87,14 +237,16 @@ fn siblings_after<'n, 's>(
 
 /// Byte ranges a directive comment guards: the first node after it, minus that node's children.
 /// For an element that is its opening and closing tags; for a block, its `{% %}` tags.
-fn guarded_ranges(checker: &Checker<'_>, rest: &[Node<'_>]) -> Option<SmallVec<[Range<usize>; 2]>> {
-    let target = rest.iter().find(|node| {
+fn guarded_ranges(checker: &Checker<'_>, rest: &[Node<'_>]) -> SmallVec<[Range<usize>; 2]> {
+    let mut ranges = SmallVec::new();
+    let Some(target) = rest.iter().find(|node| {
         !is_whitespace_text(node)
             && !matches!(node.kind, NodeKind::JinjaComment(_) | NodeKind::Comment(_))
-    })?;
+    }) else {
+        return ranges;
+    };
     let start = checker.source_offset(target.raw);
     let end = checker.source_end(target.raw);
-    let mut ranges = SmallVec::new();
     let mut cursor = start;
     for child in child_slices(target).flatten() {
         let child_start = checker.source_offset(child.raw);
@@ -106,7 +258,7 @@ fn guarded_ranges(checker: &Checker<'_>, rest: &[Node<'_>]) -> Option<SmallVec<[
     if cursor < end {
         ranges.push(cursor..end);
     }
-    Some(ranges)
+    ranges
 }
 
 /// The child slices of a node: an element's children, or each branch of a block.
@@ -127,28 +279,6 @@ fn child_slices<'n, 's>(node: &'n Node<'s>) -> impl Iterator<Item = &'n [Node<'s
 /// Whitespace between a directive and its target does not displace the target.
 fn is_whitespace_text(node: &Node<'_>) -> bool {
     matches!(node.kind, NodeKind::Text(_)) && node.raw.trim().is_empty()
-}
-
-/// Drop the diagnostics silenced by `suppressions`.
-#[must_use]
-pub fn filter(
-    suppressions: &[Suppression<'_>],
-    mut diagnostics: Vec<LintDiagnostic>,
-) -> Vec<LintDiagnostic> {
-    if suppressions.is_empty() {
-        return diagnostics;
-    }
-    diagnostics.retain(|diagnostic| {
-        let offset = diagnostic.span.offset() as usize;
-        !suppressions.iter().any(|suppression| {
-            suppression.codes.contains(&diagnostic.code)
-                && suppression
-                    .ranges
-                    .iter()
-                    .any(|range| range.contains(&offset))
-        })
-    });
-    diagnostics
 }
 
 /// File-wide opt-outs declared by the leading comment of a file.
@@ -182,22 +312,23 @@ impl FileIgnores {
         leading_file_ignore_codes(source)
             .unwrap_or_default()
             .iter()
-            .filter_map(|code| FileIgnoreCode::from_str(code).ok())
             .fold(Self::default(), |mut ignores, code| {
-                match code {
-                    FileIgnoreCode::Format => ignores.format = true,
-                    FileIgnoreCode::InvalidSyntax => ignores.invalid_syntax = true,
+                match *code {
+                    FORMAT_CODE => ignores.format = true,
+                    INVALID_SYNTAX_CODE => ignores.invalid_syntax = true,
+                    _ => {}
                 }
                 ignores
             })
     }
 }
 
-/// The codes of the file's leading `{# djangofmt: file-ignore[...] #}` comment,
-/// BOM and leading whitespace tolerated.
-fn leading_file_ignore_codes(source: &str) -> Option<Vec<&str>> {
-    leading_comment(strip_bom(source).trim_start(), "{#", "#}")
-        .and_then(|body| directive_codes(body, FILE_IGNORE_DIRECTIVE))
+/// The codes of the file's leading `{# djangofmt: file-ignore[...] #}` comment.
+fn leading_file_ignore_codes(source: &str) -> Option<Codes<'_>> {
+    match parse(leading_jinja_comment(source)?)? {
+        Directive::FileIgnore(codes) => Some(codes),
+        Directive::Ignore(_) | Directive::Malformed(_) => None,
+    }
 }
 
 /// Rules the file's leading `file-ignore[...]` comment turns off, so they never run at all.
@@ -210,6 +341,11 @@ pub fn file_ignored_rules(source: &str) -> RuleSet {
         }
     }
     rules
+}
+
+/// The body of the file's leading `{# #}` comment, BOM and whitespace before it tolerated.
+fn leading_jinja_comment(source: &str) -> Option<&str> {
+    leading_comment(strip_bom(source).trim_start(), "{#", "#}")
 }
 
 /// A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
@@ -226,9 +362,10 @@ fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Settings, lint_source};
+    use crate::{LintDiagnostic, Settings, lint_source};
     use markup_fmt::Language;
     use rstest::rstest;
+    use smallvec::smallvec;
 
     const ALL: FileIgnores = FileIgnores {
         format: true,
@@ -247,43 +384,65 @@ mod tests {
         invalid_syntax: false,
     };
 
-    /// The CLI builds the formatter's `ignore[format]` entry from `FORMAT_CODE`.
+    /// The formatter matches the spelled-out directive; the linter parses namespace and keyword.
     #[test]
-    fn format_code_matches_the_enum() {
-        assert_eq!(
-            FileIgnoreCode::from_str(FORMAT_CODE),
-            Ok(FileIgnoreCode::Format)
-        );
+    fn ignore_directive_spells_the_namespace_and_keyword() {
+        assert_eq!(IGNORE_DIRECTIVE, format!("{NAMESPACE}:{IGNORE}"));
     }
 
     #[rstest]
-    #[case::node(" djangofmt: ignore[a, b ,c] ", IGNORE_DIRECTIVE, &["a", "b", "c"])]
-    #[case::file("djangofmt:file-ignore[invalid-syntax]", FILE_IGNORE_DIRECTIVE, &["invalid-syntax"])]
-    #[case::spaced_colon("djangofmt : file-ignore[invalid-syntax]", FILE_IGNORE_DIRECTIVE, &["invalid-syntax"])]
-    #[case::reason("djangofmt: ignore[a]: free-text reason", IGNORE_DIRECTIVE, &["a"])]
-    fn parse_directive_codes(
-        #[case] comment: &str,
-        #[case] directive: &str,
-        #[case] expected: &[&str],
-    ) {
-        assert_eq!(
-            directive_codes(comment, directive).as_deref(),
-            Some(expected)
-        );
+    #[case::node(" djangofmt: ignore[a, b ,c] ", Directive::Ignore(smallvec!["a", "b", "c"]))]
+    #[case::file("djangofmt:file-ignore[invalid-syntax]", Directive::FileIgnore(smallvec!["invalid-syntax"]))]
+    #[case::spaced_colon("djangofmt : file-ignore[a]", Directive::FileIgnore(smallvec!["a"]))]
+    #[case::spaced_list("djangofmt: file-ignore [a]", Directive::FileIgnore(smallvec!["a"]))]
+    #[case::trailing_comma("djangofmt: ignore[a,]", Directive::Ignore(smallvec!["a"]))]
+    #[case::reason("djangofmt: ignore[a]: free-text reason", Directive::Ignore(smallvec!["a"]))]
+    #[case::whitespace_control("- djangofmt: ignore[a] -", Directive::Ignore(smallvec!["a"]))]
+    #[case::unknown_keyword(
+        "djangofmt: silence[a]",
+        Directive::Malformed(ParseErrorKind::UnknownKeyword)
+    )]
+    #[case::bare_file_ignore(
+        "djangofmt: file-ignore",
+        Directive::Malformed(ParseErrorKind::MissingCodes)
+    )]
+    #[case::empty_list(
+        "djangofmt: ignore[]",
+        Directive::Malformed(ParseErrorKind::MissingCodes)
+    )]
+    #[case::unclosed_list(
+        "djangofmt: ignore[a",
+        Directive::Malformed(ParseErrorKind::MissingBracket)
+    )]
+    #[case::missing_comma(
+        "djangofmt: ignore[a b]",
+        Directive::Malformed(ParseErrorKind::MissingComma)
+    )]
+    #[case::only_separators(
+        "djangofmt: ignore[ , ]",
+        Directive::Malformed(ParseErrorKind::InvalidCode)
+    )]
+    #[case::numeric_code(
+        "djangofmt: ignore[1x]",
+        Directive::Malformed(ParseErrorKind::InvalidCode)
+    )]
+    fn parse_directives(#[case] comment: &'static str, #[case] expected: Directive<'static>) {
+        assert_eq!(parse(comment), Some(expected));
     }
 
     #[rstest]
-    fn reject_non_directives(
+    fn skip_comments_the_linter_has_no_say_on(
         #[values(
-            " djangofmt:ignore ",       // formatter directive
-            "djangofmt: ignore[]",      // explicit rules only
-            "djangofmt: ignore[ , ]",   // only separators
-            "ignore[a]",                // must start with djangofmt:
-            "djangofmt: file-ignore[a]" // the file-level sibling is not `ignore`
+            " djangofmt:ignore ",                // the formatter's directive
+            "djangofmt:ignore this is generated", // with a reason
+            "djangofmt: ignore [a]",             // a space before the list makes it bare
+            "djangofmt ignore[a]",               // missing colon
+            "ignore[a]",                         // not addressed to djangofmt
+            "See djangofmt: https://example.com" // merely mentioning it
         )]
         comment: &str,
     ) {
-        assert_eq!(directive_codes(comment, IGNORE_DIRECTIVE), None);
+        assert_eq!(parse(comment), None);
     }
 
     #[rstest]

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -11,9 +11,9 @@ pub use markup_fmt::ParseErrorKind;
 use markup_fmt::ast::{JinjaTagOrChildren, Node, NodeKind, Root};
 use smallvec::SmallVec;
 
-use crate::Checker;
 use crate::registry::Rule;
 use crate::rule_set::RuleSet;
+use crate::{Checker, strip_bom};
 
 /// An ignore code naming no rule: it opts out of a whole stage rather than one lint.
 #[derive(
@@ -305,11 +305,6 @@ pub fn file_ignored_rules(source: &str) -> RuleSet {
         }
     }
     rules
-}
-
-/// A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
-pub fn strip_bom(source: &str) -> &str {
-    source.strip_prefix('\u{feff}').unwrap_or(source)
 }
 
 /// The body of a leading `{# #}` comment, if `text` starts with one.

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -21,13 +21,8 @@ pub const FORMAT_CODE: &str = "format";
 /// The code that suppresses parse errors; only `file-ignore[...]` may carry it.
 pub const INVALID_SYNTAX_CODE: &str = "invalid-syntax";
 
-/// The namespace every directive opens with, followed by a colon and a keyword.
 const NAMESPACE: &str = "djangofmt";
-
-/// The node-level keyword, also the formatter's own opt-out.
 const IGNORE: &str = "ignore";
-
-/// Its file-wide sibling.
 const FILE_IGNORE: &str = "file-ignore";
 
 /// The formatter's directive, `NAMESPACE:IGNORE` spelled out for `markup_fmt` to match.

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -308,7 +308,7 @@ pub fn file_ignored_rules(source: &str) -> RuleSet {
 }
 
 /// A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
-fn strip_bom(source: &str) -> &str {
+pub fn strip_bom(source: &str) -> &str {
     source.strip_prefix('\u{feff}').unwrap_or(source)
 }
 

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -7,6 +7,7 @@
 use std::ops::Range;
 use std::str::FromStr;
 
+pub use markup_fmt::ParseErrorKind;
 use markup_fmt::ast::{JinjaTagOrChildren, Node, NodeKind, Root};
 use smallvec::SmallVec;
 
@@ -32,31 +33,13 @@ const FILE_IGNORE: &str = "file-ignore";
 /// The formatter's directive, `NAMESPACE:IGNORE` spelled out for `markup_fmt` to match.
 pub const IGNORE_DIRECTIVE: &str = "djangofmt:ignore";
 
-/// The codes a directive lists; most list one or two.
-type Codes<'s> = SmallVec<[&'s str; 2]>;
-
-/// Why a comment addressed to djangofmt is no directive.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum ParseErrorKind {
-    #[error("unknown djangofmt directive")]
-    UnknownKeyword,
-    #[error("missing suppression codes like `[missing-img-alt, ...]`")]
-    MissingCodes,
-    #[error("missing closing bracket")]
-    MissingBracket,
-    #[error("missing comma between codes")]
-    MissingComma,
-    #[error("invalid rule code")]
-    InvalidCode,
-}
-
 /// What a `{# djangofmt: ... #}` comment asks for.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Directive<'s> {
     /// `ignore[...]`, guarding the following node.
-    Ignore(Codes<'s>),
+    Ignore(Vec<&'s str>),
     /// `file-ignore[...]`, covering the whole file.
-    FileIgnore(Codes<'s>),
+    FileIgnore(Vec<&'s str>),
     /// Addressed to djangofmt, yet neither of the above nor the formatter's bare `ignore`.
     Malformed(ParseErrorKind),
 }
@@ -71,83 +54,21 @@ impl<'s> Directive<'s> {
     }
 }
 
-/// Parse a `{# #}` comment body as a lint directive.
+/// Parse a `{# #}` comment body as a lint directive, with the grammar the formatter uses.
 ///
 /// `None` is a comment the linter has no say on: one not addressed to djangofmt, or the
 /// formatter's bare `ignore`, which carries no lint codes.
 fn parse(body: &str) -> Option<Directive<'_>> {
-    // Most comments are no directive: settle that before touching the body's tail.
-    // Jinja's whitespace-control markers (`{#- ... -#}`) belong to the delimiter.
-    let rest = body
-        .trim_start()
-        .trim_start_matches(['-', '+'])
-        .trim_start()
-        .strip_prefix(NAMESPACE)?
-        .trim_start()
-        .strip_prefix(':')?
-        .trim_start()
-        .trim_end()
-        .trim_end_matches('-');
-    let keyword_end = rest
-        .find(|c: char| c == '[' || c.is_whitespace())
-        .unwrap_or(rest.len());
-    let (keyword, rest) = rest.split_at(keyword_end);
-    let directive = match keyword {
-        IGNORE => Directive::Ignore,
-        FILE_IGNORE => Directive::FileIgnore,
-        _ => return Some(Directive::Malformed(ParseErrorKind::UnknownKeyword)),
+    let directive = match markup_fmt::parse_directive(body, NAMESPACE, &[IGNORE, FILE_IGNORE])? {
+        Ok(directive) => directive,
+        Err(error) => return Some(Directive::Malformed(error)),
     };
-    // The formatter's `ignore` stands bare or with a reason; only a list glued to it is ours.
-    if keyword == IGNORE && !rest.starts_with('[') {
-        return None;
-    }
-    let Some(list) = rest.trim_start().strip_prefix('[') else {
-        return Some(Directive::Malformed(ParseErrorKind::MissingCodes));
-    };
-    Some(parse_codes(list).map_or_else(Directive::Malformed, directive))
-}
-
-/// The codes of a `[...]` list, `list` starting right after the bracket; everything after the
-/// closing bracket is a free-text reason.
-fn parse_codes(list: &str) -> Result<Codes<'_>, ParseErrorKind> {
-    let mut codes = Codes::new();
-    let mut rest = list.trim_start();
-    loop {
-        if rest.is_empty() {
-            return Err(ParseErrorKind::MissingBracket);
-        }
-        if rest.starts_with(']') {
-            break;
-        }
-        let (code, after) = rest.split_at(code_len(rest));
-        if code.is_empty() {
-            return Err(ParseErrorKind::InvalidCode);
-        }
-        codes.push(code);
-        rest = after.trim_start();
-        match rest.strip_prefix(',') {
-            Some(after_comma) => rest = after_comma.trim_start(),
-            None if rest.starts_with(']') => break,
-            None if rest.is_empty() => return Err(ParseErrorKind::MissingBracket),
-            None => return Err(ParseErrorKind::MissingComma),
-        }
-    }
-    if codes.is_empty() {
-        return Err(ParseErrorKind::MissingCodes);
-    }
-    Ok(codes)
-}
-
-/// How far a rule code runs from the start of `text`: a letter, then letters, digits, `_`, `-`,
-/// or a `:` tolerated so `lint:code` still reads as one code.
-fn code_len(text: &str) -> usize {
-    let mut chars = text.char_indices();
-    if !chars.next().is_some_and(|(_, c)| c.is_alphabetic()) {
-        return 0;
-    }
-    chars
-        .find(|(_, c)| !(c.is_alphanumeric() || matches!(c, '_' | '-' | ':')))
-        .map_or(text.len(), |(index, _)| index)
+    Some(match (directive.keyword, directive.codes) {
+        (IGNORE, codes) if codes.is_empty() => return None,
+        (IGNORE, codes) => Directive::Ignore(codes),
+        (_, codes) if codes.is_empty() => Directive::Malformed(ParseErrorKind::MissingCodes),
+        (_, codes) => Directive::FileIgnore(codes),
+    })
 }
 
 /// A `{# djangofmt: ... #}` comment as the linter reads it.
@@ -172,26 +93,29 @@ impl DirectiveComment<'_> {
 
 /// Every lint directive of the file, in source order.
 #[must_use]
-pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'_>) -> Vec<DirectiveComment<'s>> {
+pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'s>) -> Vec<DirectiveComment<'s>> {
     let source = checker.context().source();
     root.jinja_comments
         .iter()
         .filter_map(|body| {
             let directive = parse(body)?;
-            // An attribute-position comment is no node: it neither guards nor gets linted.
-            let (node, rest) = locate(&root.children, checker.source_offset(body), checker)?;
+            let offset = checker.source_offset(body);
+            // The body sits between `{#` and `#}`; an unterminated comment runs to the end.
+            let start = offset - "{#".len();
+            let end = (offset + body.len() + "#}".len()).min(source.len());
             let ranges = match directive {
-                Directive::Ignore(_) => guarded_ranges(checker, rest),
+                // At attribute position the comment is no node, so it guards nothing.
+                Directive::Ignore(_) => siblings_after(&root.children, offset, checker)
+                    .map_or_else(SmallVec::new, |rest| guarded_ranges(checker, rest)),
                 Directive::FileIgnore(_) | Directive::Malformed(_) => SmallVec::new(),
             };
-            // Only `file-ignore` cares where it sits, so only it pays for the lookup.
-            let is_leading = matches!(directive, Directive::FileIgnore(_))
-                && leading_jinja_comment(source)
-                    .is_some_and(|leading| leading.as_ptr() == body.as_ptr());
             Some(DirectiveComment {
-                raw: node.raw,
+                raw: &source[start..end],
                 directive,
-                is_leading,
+                is_leading: source[..start]
+                    .trim_start_matches('\u{feff}')
+                    .trim_start()
+                    .is_empty(),
                 ranges,
             })
         })
@@ -211,12 +135,12 @@ pub fn apply(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
     });
 }
 
-/// The `{# #}` comment node whose body sits at `offset`, and the siblings following it.
-fn locate<'n, 's>(
+/// The siblings following the `{# #}` comment node whose body sits at `offset`.
+fn siblings_after<'n, 's>(
     mut nodes: &'n [Node<'s>],
     offset: usize,
     checker: &Checker<'_>,
-) -> Option<(&'n Node<'s>, &'n [Node<'s>])> {
+) -> Option<&'n [Node<'s>]> {
     let start = |node: &Node<'_>| checker.source_offset(node.raw);
     let end = |node: &Node<'_>| checker.source_end(node.raw);
     loop {
@@ -224,7 +148,7 @@ fn locate<'n, 's>(
         let index = nodes.partition_point(|node| end(node) <= offset);
         let node = nodes.get(index).filter(|node| start(node) <= offset)?;
         if matches!(node.kind, NodeKind::JinjaComment(_)) {
-            return Some((node, &nodes[index + 1..]));
+            return Some(&nodes[index + 1..]);
         }
         nodes = child_slices(node).find(|children| {
             children
@@ -302,7 +226,7 @@ impl FileIgnores {
         let legacy_body =
             leading_comment(source, "{#", "#}").or_else(|| leading_comment(source, "<!--", "-->"));
         if let Some(body) = legacy_body
-            && markup_fmt::starts_with_directive(body, IGNORE_DIRECTIVE)
+            && markup_fmt::matches_directive(body, IGNORE_DIRECTIVE)
         {
             return Self {
                 format: true,
@@ -324,7 +248,7 @@ impl FileIgnores {
 }
 
 /// The codes of the file's leading `{# djangofmt: file-ignore[...] #}` comment.
-fn leading_file_ignore_codes(source: &str) -> Option<Codes<'_>> {
+fn leading_file_ignore_codes(source: &str) -> Option<Vec<&str>> {
     match parse(leading_jinja_comment(source)?)? {
         Directive::FileIgnore(codes) => Some(codes),
         Directive::Ignore(_) | Directive::Malformed(_) => None,
@@ -365,7 +289,6 @@ mod tests {
     use crate::{LintDiagnostic, Settings, lint_source};
     use markup_fmt::Language;
     use rstest::rstest;
-    use smallvec::smallvec;
 
     const ALL: FileIgnores = FileIgnores {
         format: true,
@@ -391,13 +314,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case::node(" djangofmt: ignore[a, b ,c] ", Directive::Ignore(smallvec!["a", "b", "c"]))]
-    #[case::file("djangofmt:file-ignore[invalid-syntax]", Directive::FileIgnore(smallvec!["invalid-syntax"]))]
-    #[case::spaced_colon("djangofmt : file-ignore[a]", Directive::FileIgnore(smallvec!["a"]))]
-    #[case::spaced_list("djangofmt: file-ignore [a]", Directive::FileIgnore(smallvec!["a"]))]
-    #[case::trailing_comma("djangofmt: ignore[a,]", Directive::Ignore(smallvec!["a"]))]
-    #[case::reason("djangofmt: ignore[a]: free-text reason", Directive::Ignore(smallvec!["a"]))]
-    #[case::whitespace_control("- djangofmt: ignore[a] -", Directive::Ignore(smallvec!["a"]))]
+    #[case::node(" djangofmt: ignore[a, b ,c] ", Directive::Ignore(vec!["a", "b", "c"]))]
+    #[case::file("djangofmt:file-ignore[invalid-syntax]", Directive::FileIgnore(vec!["invalid-syntax"]))]
+    #[case::spaced_colon("djangofmt : file-ignore[a]", Directive::FileIgnore(vec!["a"]))]
+    #[case::spaced_list("djangofmt: file-ignore [a]", Directive::FileIgnore(vec!["a"]))]
+    #[case::spaced_node_list("djangofmt: ignore [a]", Directive::Ignore(vec!["a"]))]
+    #[case::trailing_comma("djangofmt: ignore[a,]", Directive::Ignore(vec!["a"]))]
+    #[case::reason("djangofmt: ignore[a]: free-text reason", Directive::Ignore(vec!["a"]))]
+    #[case::whitespace_control("- djangofmt: ignore[a] -", Directive::Ignore(vec!["a"]))]
     #[case::unknown_keyword(
         "djangofmt: silence[a]",
         Directive::Malformed(ParseErrorKind::UnknownKeyword)
@@ -435,7 +359,6 @@ mod tests {
         #[values(
             " djangofmt:ignore ",                // the formatter's directive
             "djangofmt:ignore this is generated", // with a reason
-            "djangofmt: ignore [a]",             // a space before the list makes it bare
             "djangofmt ignore[a]",               // missing colon
             "ignore[a]",                         // not addressed to djangofmt
             "See djangofmt: https://example.com" // merely mentioning it

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -30,7 +30,7 @@ pub const IGNORE_DIRECTIVE: &str = "djangofmt:ignore";
 
 /// What a `{# djangofmt: ... #}` comment asks for.
 #[derive(Debug, PartialEq, Eq)]
-pub enum Directive<'s> {
+pub enum IgnoreDirective<'s> {
     /// `ignore[...]`, guarding the following node.
     Ignore(Vec<&'s str>),
     /// `file-ignore[...]`, covering the whole file.
@@ -39,7 +39,7 @@ pub enum Directive<'s> {
     Malformed(ParseErrorKind),
 }
 
-impl<'s> Directive<'s> {
+impl<'s> IgnoreDirective<'s> {
     /// The codes listed, none for a malformed directive.
     pub fn codes(&self) -> &[&'s str] {
         match self {
@@ -53,32 +53,32 @@ impl<'s> Directive<'s> {
 ///
 /// `None` is a comment the linter has no say on: one not addressed to djangofmt, or the
 /// formatter's bare `ignore`, which carries no lint codes.
-fn parse(body: &str) -> Option<Directive<'_>> {
+fn parse(body: &str) -> Option<IgnoreDirective<'_>> {
     let directive = match markup_fmt::parse_directive(body, NAMESPACE, &[IGNORE, FILE_IGNORE])? {
         Ok(directive) => directive,
-        Err(error) => return Some(Directive::Malformed(error)),
+        Err(error) => return Some(IgnoreDirective::Malformed(error)),
     };
     Some(match (directive.keyword, directive.codes) {
         (IGNORE, codes) if codes.is_empty() => return None,
-        (IGNORE, codes) => Directive::Ignore(codes),
-        (_, codes) if codes.is_empty() => Directive::Malformed(ParseErrorKind::MissingCodes),
-        (_, codes) => Directive::FileIgnore(codes),
+        (IGNORE, codes) => IgnoreDirective::Ignore(codes),
+        (_, codes) if codes.is_empty() => IgnoreDirective::Malformed(ParseErrorKind::MissingCodes),
+        (_, codes) => IgnoreDirective::FileIgnore(codes),
     })
 }
 
 /// A `{# djangofmt: ... #}` comment as the linter reads it.
-pub struct DirectiveComment<'s> {
+pub struct IgnoreComment<'s> {
     /// The whole comment, delimiters included: what a diagnostic points at and a fix deletes.
     pub raw: &'s str,
     /// What the comment asks for.
-    pub directive: Directive<'s>,
+    pub directive: IgnoreDirective<'s>,
     /// Whether it is the file's leading comment, the only place `file-ignore` counts.
     pub is_leading: bool,
     /// Byte ranges an `ignore[...]` guards; empty when nothing follows it.
     ranges: SmallVec<[Range<usize>; 2]>,
 }
 
-impl DirectiveComment<'_> {
+impl IgnoreComment<'_> {
     /// Whether the directive silences `code` reported at `offset`.
     fn suppresses(&self, code: &str, offset: usize) -> bool {
         self.ranges.iter().any(|range| range.contains(&offset))
@@ -86,9 +86,12 @@ impl DirectiveComment<'_> {
     }
 }
 
-/// Every lint directive of the file, in source order.
+/// Every `{# djangofmt: ... #}` comment of the file, in source order.
 #[must_use]
-pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'s>) -> Vec<DirectiveComment<'s>> {
+pub fn collect_ignore_comments<'s>(
+    root: &Root<'s>,
+    checker: &Checker<'s>,
+) -> Vec<IgnoreComment<'s>> {
     let source = checker.context().source();
     root.jinja_comments
         .iter()
@@ -100,11 +103,11 @@ pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'s>) -> Vec<DirectiveComme
             let end = (checker.source_end(body) + "#}".len()).min(source.len());
             let ranges = match directive {
                 // At attribute position the comment is no node, so it guards nothing.
-                Directive::Ignore(_) => siblings_after(&root.children, offset, checker)
+                IgnoreDirective::Ignore(_) => siblings_after(&root.children, offset, checker)
                     .map_or_else(SmallVec::new, |rest| guarded_ranges(checker, rest)),
-                Directive::FileIgnore(_) | Directive::Malformed(_) => SmallVec::new(),
+                IgnoreDirective::FileIgnore(_) | IgnoreDirective::Malformed(_) => SmallVec::new(),
             };
-            Some(DirectiveComment {
+            Some(IgnoreComment {
                 raw: &source[start..end],
                 directive,
                 is_leading: source[..start]
@@ -117,14 +120,14 @@ pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'s>) -> Vec<DirectiveComme
         .collect()
 }
 
-/// Drop from `checker` the diagnostics the directives silence.
-pub fn apply(directives: &[DirectiveComment<'_>], checker: &Checker<'_>) {
-    if directives.is_empty() {
+/// Drop from `checker` the diagnostics an `ignore[...]` comment silences.
+pub fn drop_ignored_diagnostics(checker: &Checker<'_>, comments: &[IgnoreComment<'_>]) {
+    if comments.is_empty() {
         return;
     }
     checker.context().retain_diagnostics(|diagnostic| {
         let offset = diagnostic.span.offset() as usize;
-        !directives
+        !comments
             .iter()
             .any(|comment| comment.suppresses(diagnostic.code, offset))
     });
@@ -245,8 +248,8 @@ impl FileIgnores {
 /// The codes of the file's leading `{# djangofmt: file-ignore[...] #}` comment.
 fn leading_file_ignore_codes(source: &str) -> Option<Vec<&str>> {
     match parse(leading_jinja_comment(source)?)? {
-        Directive::FileIgnore(codes) => Some(codes),
-        Directive::Ignore(_) | Directive::Malformed(_) => None,
+        IgnoreDirective::FileIgnore(codes) => Some(codes),
+        IgnoreDirective::Ignore(_) | IgnoreDirective::Malformed(_) => None,
     }
 }
 
@@ -309,43 +312,43 @@ mod tests {
     }
 
     #[rstest]
-    #[case::node(" djangofmt: ignore[a, b ,c] ", Directive::Ignore(vec!["a", "b", "c"]))]
-    #[case::file("djangofmt:file-ignore[invalid-syntax]", Directive::FileIgnore(vec!["invalid-syntax"]))]
-    #[case::spaced_colon("djangofmt : file-ignore[a]", Directive::FileIgnore(vec!["a"]))]
-    #[case::spaced_list("djangofmt: file-ignore [a]", Directive::FileIgnore(vec!["a"]))]
-    #[case::spaced_node_list("djangofmt: ignore [a]", Directive::Ignore(vec!["a"]))]
-    #[case::trailing_comma("djangofmt: ignore[a,]", Directive::Ignore(vec!["a"]))]
-    #[case::reason("djangofmt: ignore[a]: free-text reason", Directive::Ignore(vec!["a"]))]
-    #[case::whitespace_control("- djangofmt: ignore[a] -", Directive::Ignore(vec!["a"]))]
+    #[case::node(" djangofmt: ignore[a, b ,c] ", IgnoreDirective::Ignore(vec!["a", "b", "c"]))]
+    #[case::file("djangofmt:file-ignore[invalid-syntax]", IgnoreDirective::FileIgnore(vec!["invalid-syntax"]))]
+    #[case::spaced_colon("djangofmt : file-ignore[a]", IgnoreDirective::FileIgnore(vec!["a"]))]
+    #[case::spaced_list("djangofmt: file-ignore [a]", IgnoreDirective::FileIgnore(vec!["a"]))]
+    #[case::spaced_node_list("djangofmt: ignore [a]", IgnoreDirective::Ignore(vec!["a"]))]
+    #[case::trailing_comma("djangofmt: ignore[a,]", IgnoreDirective::Ignore(vec!["a"]))]
+    #[case::reason("djangofmt: ignore[a]: free-text reason", IgnoreDirective::Ignore(vec!["a"]))]
+    #[case::whitespace_control("- djangofmt: ignore[a] -", IgnoreDirective::Ignore(vec!["a"]))]
     #[case::unknown_keyword(
         "djangofmt: silence[a]",
-        Directive::Malformed(ParseErrorKind::UnknownKeyword)
+        IgnoreDirective::Malformed(ParseErrorKind::UnknownKeyword)
     )]
     #[case::bare_file_ignore(
         "djangofmt: file-ignore",
-        Directive::Malformed(ParseErrorKind::MissingCodes)
+        IgnoreDirective::Malformed(ParseErrorKind::MissingCodes)
     )]
     #[case::empty_list(
         "djangofmt: ignore[]",
-        Directive::Malformed(ParseErrorKind::MissingCodes)
+        IgnoreDirective::Malformed(ParseErrorKind::MissingCodes)
     )]
     #[case::unclosed_list(
         "djangofmt: ignore[a",
-        Directive::Malformed(ParseErrorKind::MissingBracket)
+        IgnoreDirective::Malformed(ParseErrorKind::MissingBracket)
     )]
     #[case::missing_comma(
         "djangofmt: ignore[a b]",
-        Directive::Malformed(ParseErrorKind::MissingComma)
+        IgnoreDirective::Malformed(ParseErrorKind::MissingComma)
     )]
     #[case::only_separators(
         "djangofmt: ignore[ , ]",
-        Directive::Malformed(ParseErrorKind::InvalidCode)
+        IgnoreDirective::Malformed(ParseErrorKind::InvalidCode)
     )]
     #[case::numeric_code(
         "djangofmt: ignore[1x]",
-        Directive::Malformed(ParseErrorKind::InvalidCode)
+        IgnoreDirective::Malformed(ParseErrorKind::InvalidCode)
     )]
-    fn parse_directives(#[case] comment: &'static str, #[case] expected: Directive<'static>) {
+    fn parse_directives(#[case] comment: &'static str, #[case] expected: IgnoreDirective<'static>) {
         assert_eq!(parse(comment), Some(expected));
     }
 

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -97,7 +97,7 @@ pub fn collect<'s>(root: &Root<'s>, checker: &Checker<'s>) -> Vec<DirectiveComme
             let offset = checker.source_offset(body);
             // The body sits between `{#` and `#}`; an unterminated comment runs to the end.
             let start = offset - "{#".len();
-            let end = (offset + body.len() + "#}".len()).min(source.len());
+            let end = (checker.source_end(body) + "#}".len()).min(source.len());
             let ranges = match directive {
                 // At attribute position the comment is no node, so it guards nothing.
                 Directive::Ignore(_) => siblings_after(&root.children, offset, checker)

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -61,6 +61,11 @@ pub enum IgnoreDirective<'s> {
 }
 
 impl<'s> IgnoreDirective<'s> {
+    /// Whether the directive scopes to the node that follows it, rather than to the whole file.
+    const fn guards_next_node(&self) -> bool {
+        matches!(self, Self::Ignore(_))
+    }
+
     /// The codes listed, none for a malformed directive.
     pub fn codes(&self) -> &[&'s str] {
         match self {
@@ -96,13 +101,15 @@ pub struct IgnoreComment<'s> {
     /// Whether it is the file's leading comment, the only place `file-ignore` counts.
     pub is_leading: bool,
     /// Byte ranges an `ignore[...]` guards; empty when nothing follows it.
-    ranges: SmallVec<[Range<usize>; 2]>,
+    guarded_ranges: SmallVec<[Range<usize>; 2]>,
 }
 
 impl IgnoreComment<'_> {
     /// Whether the directive silences `code` reported at `offset`.
     fn suppresses(&self, code: &str, offset: usize) -> bool {
-        self.ranges.iter().any(|range| range.contains(&offset))
+        self.guarded_ranges
+            .iter()
+            .any(|range| range.contains(&offset))
             && self.directive.codes().contains(&code)
     }
 }
@@ -119,15 +126,16 @@ pub fn collect_ignore_comments<'s>(
         .filter_map(|body| {
             let directive = parse(body)?;
             let offset = checker.source_offset(body);
+
+            let ranges = if directive.guards_next_node() {
+                guarded_ranges(root, offset, checker)
+            } else {
+                SmallVec::new()
+            };
+
             // The body sits between `{#` and `#}`; an unterminated comment runs to the end.
             let start = offset - "{#".len();
             let end = (checker.source_end(body) + "#}".len()).min(source.len());
-            let ranges = match directive {
-                // At attribute position the comment is no node, so it guards nothing.
-                IgnoreDirective::Ignore(_) => siblings_after(&root.children, offset, checker)
-                    .map_or_else(SmallVec::new, |rest| guarded_ranges(checker, rest)),
-                IgnoreDirective::FileIgnore(_) | IgnoreDirective::Malformed(_) => SmallVec::new(),
-            };
             Some(IgnoreComment {
                 raw: &source[start..end],
                 directive,
@@ -135,7 +143,7 @@ pub fn collect_ignore_comments<'s>(
                     .trim_start_matches('\u{feff}')
                     .trim_start()
                     .is_empty(),
-                ranges,
+                guarded_ranges: ranges,
             })
         })
         .collect()
@@ -178,11 +186,19 @@ fn siblings_after<'n, 's>(
     }
 }
 
-/// Byte ranges a directive comment guards: the first node after it, minus that node's children.
+/// Byte ranges the comment at `offset` guards: the first node after it, minus that node's children.
 /// For an element that is its opening and closing tags; for a block, its `{% %}` tags.
-fn guarded_ranges(checker: &Checker<'_>, rest: &[Node<'_>]) -> SmallVec<[Range<usize>; 2]> {
+fn guarded_ranges(
+    root: &Root<'_>,
+    offset: usize,
+    checker: &Checker<'_>,
+) -> SmallVec<[Range<usize>; 2]> {
     let mut ranges = SmallVec::new();
-    let Some(target) = rest.iter().find(|node| {
+    // At attribute position the comment is no node, so it has no siblings and guards nothing.
+    let Some(siblings) = siblings_after(&root.children, offset, checker) else {
+        return ranges;
+    };
+    let Some(target) = siblings.iter().find(|node| {
         !is_whitespace_text(node)
             && !matches!(node.kind, NodeKind::JinjaComment(_) | NodeKind::Comment(_))
     }) else {

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -15,11 +15,32 @@ use crate::Checker;
 use crate::registry::Rule;
 use crate::rule_set::RuleSet;
 
-/// The code that opts a node or file out of the formatter.
-pub const FORMAT_CODE: &str = "format";
+/// An ignore code naming no rule: it opts out of a whole stage rather than one lint.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    strum::EnumString,
+    strum::Display,
+    strum::IntoStaticStr,
+    strum::VariantNames,
+)]
+#[strum(serialize_all = "kebab-case")]
+pub enum ReservedCode {
+    /// Opts the node or file out of the formatter.
+    Format,
+    /// Suppresses parse errors; only `file-ignore[...]` may carry it.
+    InvalidSyntax,
+}
 
-/// The code that suppresses parse errors; only `file-ignore[...]` may carry it.
-pub const INVALID_SYNTAX_CODE: &str = "invalid-syntax";
+impl ReservedCode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
 
 const NAMESPACE: &str = "djangofmt";
 const IGNORE: &str = "ignore";
@@ -235,10 +256,10 @@ impl FileIgnores {
             .unwrap_or_default()
             .iter()
             .fold(Self::default(), |mut ignores, code| {
-                match *code {
-                    FORMAT_CODE => ignores.format = true,
-                    INVALID_SYNTAX_CODE => ignores.invalid_syntax = true,
-                    _ => {}
+                match ReservedCode::from_str(code) {
+                    Ok(ReservedCode::Format) => ignores.format = true,
+                    Ok(ReservedCode::InvalidSyntax) => ignores.invalid_syntax = true,
+                    Err(_) => {}
                 }
                 ignores
             })

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -367,6 +367,10 @@ mod tests {
     #[case::trailing_comma("djangofmt: ignore[a,]", IgnoreDirective::Ignore(vec!["a"]))]
     #[case::reason("djangofmt: ignore[a]: free-text reason", IgnoreDirective::Ignore(vec!["a"]))]
     #[case::whitespace_control("- djangofmt: ignore[a] -", IgnoreDirective::Ignore(vec!["a"]))]
+    #[case::plus_whitespace_control("+ djangofmt: ignore[a]", IgnoreDirective::Ignore(vec!["a"]))]
+    // A comment may wrap over lines, and a code may carry a `:` so `lint:code` reads as one.
+    #[case::multiline("\n  djangofmt: ignore[a,\n  b]\n", IgnoreDirective::Ignore(vec!["a", "b"]))]
+    #[case::namespaced_code("djangofmt: ignore[lint:a]", IgnoreDirective::Ignore(vec!["lint:a"]))]
     #[case::unknown_keyword(
         "djangofmt: silence[a]",
         IgnoreDirective::Malformed(ParseErrorKind::UnknownKeyword)
@@ -402,9 +406,10 @@ mod tests {
     #[rstest]
     fn skip_comments_the_linter_has_no_say_on(
         #[values(
-            " djangofmt:ignore ",                // the formatter's directive
+            " djangofmt:ignore ",                // the formatter's old directive
             "djangofmt:ignore this is generated", // with a reason
             "djangofmt ignore[a]",               // missing colon
+            "djangofmt-lint: ignore[a]",         // a namespace that merely starts the same
             "ignore[a]",                         // not addressed to djangofmt
             "See djangofmt: https://example.com" // merely mentioning it
         )]

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -139,10 +139,7 @@ pub fn collect_ignore_comments<'s>(
             Some(IgnoreComment {
                 raw: &source[start..end],
                 directive,
-                is_leading: source[..start]
-                    .trim_start_matches('\u{feff}')
-                    .trim_start()
-                    .is_empty(),
+                is_leading: strip_bom(&source[..start]).trim_start().is_empty(),
                 guarded_ranges: ranges,
             })
         })

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -42,6 +42,14 @@ impl ReservedCode {
     }
 }
 
+/// Delimiters of a template comment, the only kind that carries a directive.
+const TEMPLATE_COMMENT_OPEN: &str = "{#";
+const TEMPLATE_COMMENT_CLOSE: &str = "#}";
+
+/// Delimiters of an HTML comment, which only the legacy bare directive is read from.
+const HTML_COMMENT_OPEN: &str = "<!--";
+const HTML_COMMENT_CLOSE: &str = "-->";
+
 const NAMESPACE: &str = "djangofmt";
 const IGNORE: &str = "ignore";
 const FILE_IGNORE: &str = "file-ignore";
@@ -133,9 +141,9 @@ pub fn collect_ignore_comments<'s>(
                 SmallVec::new()
             };
 
-            // The body sits between `{#` and `#}`; an unterminated comment runs to the end.
-            let start = offset - "{#".len();
-            let end = (checker.source_end(body) + "#}".len()).min(source.len());
+            // The body sits between the delimiters; an unterminated comment runs to the end.
+            let start = offset - TEMPLATE_COMMENT_OPEN.len();
+            let end = (checker.source_end(body) + TEMPLATE_COMMENT_CLOSE.len()).min(source.len());
             Some(IgnoreComment {
                 raw: &source[start..end],
                 directive,
@@ -255,8 +263,7 @@ impl FileIgnores {
 
         // The bare legacy directive doubles as a node-level formatter directive,
         // so it is only file-level when nothing (not even whitespace) precedes it.
-        let legacy_body =
-            leading_comment(source, "{#", "#}").or_else(|| leading_comment(source, "<!--", "-->"));
+        let legacy_body = leading_template_comment(source).or_else(|| leading_html_comment(source));
         if let Some(body) = legacy_body
             && markup_fmt::matches_directive(body, IGNORE_DIRECTIVE)
         {
@@ -279,9 +286,10 @@ impl FileIgnores {
     }
 }
 
-/// The codes of the file's leading `{# djangofmt: file-ignore[...] #}` comment.
+/// The codes of the file's leading `{# djangofmt: file-ignore[...] #}` comment,
+/// a BOM and whitespace before it tolerated.
 fn leading_file_ignore_codes(source: &str) -> Option<Vec<&str>> {
-    match parse(leading_jinja_comment(source)?)? {
+    match parse(leading_template_comment(strip_bom(source).trim_start())?)? {
         IgnoreDirective::FileIgnore(codes) => Some(codes),
         IgnoreDirective::Ignore(_) | IgnoreDirective::Malformed(_) => None,
     }
@@ -299,17 +307,22 @@ pub fn file_ignored_rules(source: &str) -> RuleSet {
     rules
 }
 
-/// The body of the file's leading `{# #}` comment, BOM and whitespace before it tolerated.
-fn leading_jinja_comment(source: &str) -> Option<&str> {
-    leading_comment(strip_bom(source).trim_start(), "{#", "#}")
-}
-
 /// A UTF-8 BOM is not Rust whitespace, so strip it explicitly.
 fn strip_bom(source: &str) -> &str {
     source.strip_prefix('\u{feff}').unwrap_or(source)
 }
 
-/// The body of a leading `open`..`close` comment, if the text starts with one.
+/// The body of a leading `{# #}` comment, if `text` starts with one.
+fn leading_template_comment(text: &str) -> Option<&str> {
+    leading_comment(text, TEMPLATE_COMMENT_OPEN, TEMPLATE_COMMENT_CLOSE)
+}
+
+/// The body of a leading `<!-- -->` comment, if `text` starts with one.
+fn leading_html_comment(text: &str) -> Option<&str> {
+    leading_comment(text, HTML_COMMENT_OPEN, HTML_COMMENT_CLOSE)
+}
+
+/// The body of a leading comment with the given delimiters, if `text` starts with one.
 fn leading_comment<'s>(text: &'s str, open: &str, close: &str) -> Option<&'s str> {
     let body = text.strip_prefix(open)?;
     Some(&body[..body.find(close)?])

--- a/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.invalid.fixed.snap
@@ -31,8 +31,14 @@ source: crates/djangofmt_lint/tests/check/main.rs
     role="banner"
 ></div>
 
+<!-- Solo attribute: the space before `>` goes with it -->
+<div></div>
+
 <!-- Self-closing void element -->
 <input name="email" />
+
+<!-- Solo attribute on a self-closing element: the space before `/>` stays -->
+<input />
 
 <!-- Nested in Jinja block -->
 {% if show %}

--- a/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.invalid.html
+++ b/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.invalid.html
@@ -30,8 +30,14 @@
     role="banner"
 ></div>
 
+<!-- Solo attribute: the space before `>` goes with it -->
+<div id="" ></div>
+
 <!-- Self-closing void element -->
 <input id="" name="email" />
+
+<!-- Solo attribute on a self-closing element: the space before `/>` stays -->
+<input class="" />
 
 <!-- Nested in Jinja block -->
 {% if show %}

--- a/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/empty_attr_value/empty_attr_value.invalid.snap
@@ -93,19 +93,37 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ╰────
 
   × Empty `id` attribute
-    ╭─[tests/check/empty_attr_value/empty_attr_value.invalid.html:34:12]
- 33 │ <!-- Self-closing void element -->
- 34 │ <input id="" name="email" />
-    ·            ▲
-    ·            ╰── here
+    ╭─[tests/check/empty_attr_value/empty_attr_value.invalid.html:34:10]
+ 33 │ <!-- Solo attribute: the space before `>` goes with it -->
+ 34 │ <div id="" ></div>
+    ·          ▲
+    ·          ╰── here
  35 │ 
     ╰────
 
   × Empty `id` attribute
-    ╭─[tests/check/empty_attr_value/empty_attr_value.invalid.html:38:15]
- 37 │ {% if show %}
- 38 │     <span id=""></span>
+    ╭─[tests/check/empty_attr_value/empty_attr_value.invalid.html:37:12]
+ 36 │ <!-- Self-closing void element -->
+ 37 │ <input id="" name="email" />
+    ·            ▲
+    ·            ╰── here
+ 38 │ 
+    ╰────
+
+  × Empty `class` attribute
+    ╭─[tests/check/empty_attr_value/empty_attr_value.invalid.html:40:15]
+ 39 │ <!-- Solo attribute on a self-closing element: the space before `/>` stays -->
+ 40 │ <input class="" />
     ·               ▲
     ·               ╰── here
- 39 │ {% endif %}
+ 41 │ 
+    ╰────
+
+  × Empty `id` attribute
+    ╭─[tests/check/empty_attr_value/empty_attr_value.invalid.html:44:15]
+ 43 │ {% if show %}
+ 44 │     <span id=""></span>
+    ·               ▲
+    ·               ╰── here
+ 45 │ {% endif %}
     ╰────

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.fixed.snap
@@ -21,3 +21,6 @@ source: crates/djangofmt_lint/tests/check/main.rs
 
 <!-- A comment sharing its line keeps the line -->
 <div><p>hi</p></div>
+
+<!-- Selector words are no ignore codes: neither `all` nor a rule category names a rule -->
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.fixed.snap
@@ -1,22 +1,23 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
 <!-- Typo in a rule name -->
-{# djangofmt: ignore[invalid-attr-values] #}
 <form method="yes"></form>
 
 <!-- Unknown code hiding among valid ones -->
-{# djangofmt: ignore[invalid-attr-value, not-a-rule] #}
+{# djangofmt: ignore[invalid-attr-value] #}
 <div></div>
 
 <!-- All codes unknown: one diagnostic for the comment, which goes as a whole -->
-{# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
 <div></div>
 
 <!-- Unknown code first: the separator that follows it goes too -->
-{# djangofmt: ignore[not-a-rule-either, invalid-attr-value] #}
+{# djangofmt: ignore[invalid-attr-value] #}
 <form method="yes"></form>
 
 <!-- Several unknown codes among valid ones: the list is rewritten -->
-{# djangofmt: ignore[not-a-rule, invalid-attr-value, nor-this, empty-attr-value] #}
+{# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
 <form method="yes"></form>
 
 <!-- A comment sharing its line keeps the line -->
-<div>{# djangofmt: ignore[gone-rule] #}<p>hi</p></div>
+<div><p>hi</p></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html
@@ -20,3 +20,7 @@
 
 <!-- A comment sharing its line keeps the line -->
 <div>{# djangofmt: ignore[gone-rule] #}<p>hi</p></div>
+
+<!-- Selector words are no ignore codes: neither `all` nor a rule category names a rule -->
+{# djangofmt: ignore[all, correctness] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html
@@ -24,3 +24,11 @@
 <!-- Selector words are no ignore codes: neither `all` nor a rule category names a rule -->
 {# djangofmt: ignore[all, correctness] #}
 <div></div>
+
+<!-- The same code listed twice is one mistake -->
+{# djangofmt: ignore[not-a-rule, not-a-rule] #}
+<div></div>
+
+<!-- Deleting the comment takes its free-text reason along, so that fix is unsafe -->
+{# djangofmt: ignore[stale-rule]: kept until someone checks what replaced it #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html
@@ -1,0 +1,11 @@
+<!-- Typo in a rule name -->
+{# djangofmt: ignore[invalid-attr-values] #}
+<form method="yes"></form>
+
+<!-- Unknown code hiding among valid ones -->
+{# djangofmt: ignore[invalid-attr-value, not-a-rule] #}
+<div></div>
+
+<!-- file-ignore codes are checked too, every one of them -->
+{# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
@@ -1,0 +1,43 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+
+  × Invalid rule code in suppression: `invalid-attr-values`
+   ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:2:22]
+ 1 │ <!-- Typo in a rule name -->
+ 2 │ {# djangofmt: ignore[invalid-attr-values] #}
+   ·                      ─────────┬─────────
+   ·                               ╰── here
+ 3 │ <form method="yes"></form>
+   ╰────
+  help: Remove unused suppression
+
+  × Invalid rule code in suppression: `not-a-rule`
+   ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:6:42]
+ 5 │ <!-- Unknown code hiding among valid ones -->
+ 6 │ {# djangofmt: ignore[invalid-attr-value, not-a-rule] #}
+   ·                                          ─────┬────
+   ·                                               ╰── here
+ 7 │ <div></div>
+   ╰────
+  help: Remove unused suppression
+
+  × Invalid rule code in suppression: `nonexistent-rule`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:10:27]
+  9 │ <!-- file-ignore codes are checked too, every one of them -->
+ 10 │ {# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
+    ·                           ────────┬───────
+    ·                                   ╰── here
+ 11 │ <div></div>
+    ╰────
+  help: Remove unused suppression
+
+  × Invalid rule code in suppression: `also-not-a-rule`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:10:45]
+  9 │ <!-- file-ignore codes are checked too, every one of them -->
+ 10 │ {# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
+    ·                                             ───────┬───────
+    ·                                                    ╰── here
+ 11 │ <div></div>
+    ╰────
+  help: Remove unused suppression

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
@@ -53,4 +53,14 @@ source: crates/djangofmt_lint/tests/check/main.rs
  22 │ <div>{# djangofmt: ignore[gone-rule] #}<p>hi</p></div>
     ·                           ────┬────
     ·                               ╰── here
+ 23 │ 
+    ╰────
+
+  × Invalid rule code in suppression: `all`, `correctness`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:25:1]
+ 24 │ <!-- Selector words are no ignore codes: neither `all` nor a rule category names a rule -->
+ 25 │ {# djangofmt: ignore[all, correctness] #}
+    · ────────────────────┬────────────────────
+    ·                     ╰── here
+ 26 │ <div></div>
     ╰────

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
@@ -10,6 +10,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                               ╰── here
  3 │ <form method="yes"></form>
    ╰────
+  help: Did you mean `invalid-attr-value`?
 
   × Invalid rule code in suppression: `not-a-rule`
    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:6:42]
@@ -63,4 +64,22 @@ source: crates/djangofmt_lint/tests/check/main.rs
     · ────────────────────┬────────────────────
     ·                     ╰── here
  26 │ <div></div>
+    ╰────
+
+  × Invalid rule code in suppression: `not-a-rule`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:29:1]
+ 28 │ <!-- The same code listed twice is one mistake -->
+ 29 │ {# djangofmt: ignore[not-a-rule, not-a-rule] #}
+    · ───────────────────────┬───────────────────────
+    ·                        ╰── here
+ 30 │ <div></div>
+    ╰────
+
+  × Invalid rule code in suppression: `stale-rule`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:33:22]
+ 32 │ <!-- Deleting the comment takes its free-text reason along, so that fix is unsafe -->
+ 33 │ {# djangofmt: ignore[stale-rule]: kept until someone checks what replaced it #}
+    ·                      ─────┬────
+    ·                           ╰── here
+ 34 │ <div></div>
     ╰────

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.snap
@@ -10,7 +10,6 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                               ╰── here
  3 │ <form method="yes"></form>
    ╰────
-  help: Remove unused suppression
 
   × Invalid rule code in suppression: `not-a-rule`
    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:6:42]
@@ -20,24 +19,38 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                                               ╰── here
  7 │ <div></div>
    ╰────
-  help: Remove unused suppression
 
-  × Invalid rule code in suppression: `nonexistent-rule`
-    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:10:27]
-  9 │ <!-- file-ignore codes are checked too, every one of them -->
+  × Invalid rule code in suppression: `nonexistent-rule`, `also-not-a-rule`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:10:1]
+  9 │ <!-- All codes unknown: one diagnostic for the comment, which goes as a whole -->
  10 │ {# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
-    ·                           ────────┬───────
-    ·                                   ╰── here
+    · ───────────────────────────────┬───────────────────────────────
+    ·                                ╰── here
  11 │ <div></div>
     ╰────
-  help: Remove unused suppression
 
-  × Invalid rule code in suppression: `also-not-a-rule`
-    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:10:45]
-  9 │ <!-- file-ignore codes are checked too, every one of them -->
- 10 │ {# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
-    ·                                             ───────┬───────
-    ·                                                    ╰── here
- 11 │ <div></div>
+  × Invalid rule code in suppression: `not-a-rule-either`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:14:22]
+ 13 │ <!-- Unknown code first: the separator that follows it goes too -->
+ 14 │ {# djangofmt: ignore[not-a-rule-either, invalid-attr-value] #}
+    ·                      ────────┬────────
+    ·                              ╰── here
+ 15 │ <form method="yes"></form>
     ╰────
-  help: Remove unused suppression
+
+  × Invalid rule code in suppression: `not-a-rule`, `nor-this`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:18:1]
+ 17 │ <!-- Several unknown codes among valid ones: the list is rewritten -->
+ 18 │ {# djangofmt: ignore[not-a-rule, invalid-attr-value, nor-this, empty-attr-value] #}
+    · ─────────────────────────────────────────┬─────────────────────────────────────────
+    ·                                          ╰── here
+ 19 │ <form method="yes"></form>
+    ╰────
+
+  × Invalid rule code in suppression: `gone-rule`
+    ╭─[tests/check/invalid_ignore_code/invalid_ignore_code.invalid.html:22:27]
+ 21 │ <!-- A comment sharing its line keeps the line -->
+ 22 │ <div>{# djangofmt: ignore[gone-rule] #}<p>hi</p></div>
+    ·                           ────┬────
+    ·                               ╰── here
+    ╰────

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.invalid.unsafe-fixed.snap
@@ -2,7 +2,6 @@
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
 <!-- Typo in a rule name -->
-{# djangofmt: ignore[invalid-attr-values] #}
 <form method="yes"></form>
 
 <!-- Unknown code hiding among valid ones -->
@@ -10,7 +9,6 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <div></div>
 
 <!-- All codes unknown: one diagnostic for the comment, which goes as a whole -->
-{# djangofmt: file-ignore[nonexistent-rule, also-not-a-rule] #}
 <div></div>
 
 <!-- Unknown code first: the separator that follows it goes too -->
@@ -22,16 +20,13 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <form method="yes"></form>
 
 <!-- A comment sharing its line keeps the line -->
-<div>{# djangofmt: ignore[gone-rule] #}<p>hi</p></div>
+<div><p>hi</p></div>
 
 <!-- Selector words are no ignore codes: neither `all` nor a rule category names a rule -->
-{# djangofmt: ignore[all, correctness] #}
 <div></div>
 
 <!-- The same code listed twice is one mistake -->
-{# djangofmt: ignore[not-a-rule, not-a-rule] #}
 <div></div>
 
 <!-- Deleting the comment takes its free-text reason along, so that fix is unsafe -->
-{# djangofmt: ignore[stale-rule]: kept until someone checks what replaced it #}
 <div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.valid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_code/invalid_ignore_code.valid.html
@@ -1,0 +1,13 @@
+{# djangofmt: file-ignore[format, invalid-syntax] #}
+{# The reserved codes above are known, and so are real rule names #}
+
+{# djangofmt: ignore[invalid-attr-value, empty-attr-value] #}
+<form method="yes"></form>
+
+{# Reserved codes are known on a node too: where they may appear is invalid-ignore-comment's concern #}
+{# djangofmt: ignore[format, invalid-syntax] #}
+<div></div>
+
+{# A malformed directive has no codes to check #}
+{# djangofmt: ignore[] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/bom.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/bom.invalid.html
@@ -1,0 +1,4 @@
+﻿{# djangofmt: ignore[] #}
+<div></div>
+
+{# A BOM at the top does not keep the first comment from having its line to itself #}

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/bom.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/bom.invalid.snap
@@ -1,0 +1,12 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+
+  × Invalid suppression comment: missing suppression codes like `[code, ...]`
+   ╭─[tests/check/invalid_ignore_comment/bom.invalid.html:1:4]
+ 1 │ ﻿{# djangofmt: ignore[] #}
+   · ────────────┬────────────
+   ·             ╰── here
+ 2 │ <div></div>
+   ╰────
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/bom.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/bom.invalid.unsafe-fixed.snap
@@ -1,0 +1,6 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+﻿<div></div>
+
+{# A BOM at the top does not keep the first comment from having its line to itself #}

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
@@ -44,3 +44,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Among several codes, the span points at the offending one -->
 {# djangofmt: ignore[invalid-attr-value] #}
 <div></div>
+
+<!-- Repeated, every occurrence goes -->
+{# djangofmt: ignore[invalid-attr-value] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
@@ -39,6 +39,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 </div>
 
 <!-- `invalid-syntax` cannot be scoped to a node -->
+{# djangofmt: ignore[invalid-syntax] #}
 <div></div>
 
 <!-- Among several codes, the span points at the offending one -->

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
@@ -1,3 +1,6 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
 <!-- Malformed: empty rule list -->
 {# djangofmt: ignore[] #}
 <form method="yes"></form>
@@ -33,9 +36,8 @@
 </div>
 
 <!-- `invalid-syntax` cannot be scoped to a node -->
-{# djangofmt: ignore[invalid-syntax] #}
 <div></div>
 
 <!-- Among several codes, the span points at the offending one -->
-{# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
+{# djangofmt: ignore[invalid-attr-value] #}
 <div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
@@ -48,3 +48,10 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Repeated, every occurrence goes -->
 {# djangofmt: ignore[invalid-attr-value] #}
 <div></div>
+
+<!-- Malformed, with whitespace control: the trimming markers go with the comment -->
+{#- djangofmt: ignore[] -#}
+<div></div>
+
+<!-- Malformed and unterminated at the end of the file -->
+{# djangofmt: ignore[]

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.fixed.snap
@@ -17,6 +17,9 @@ source: crates/djangofmt_lint/tests/check/main.rs
 {# djangofmt: ignore[invalid-attr-value, , 404] #}
 <div></div>
 
+<!-- Malformed, at attribute position: no node to guard, still a comment to report -->
+<form {# djangofmt: ignore[] #} method="yes"></form>
+
 <!-- Malformed: unknown keyword -->
 {# djangofmt: silence[invalid-attr-value] #}
 <div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
@@ -1,0 +1,29 @@
+<!-- Malformed: empty rule list -->
+{# djangofmt: ignore[] #}
+<form method="yes"></form>
+
+<!-- Malformed: missing closing bracket -->
+{# djangofmt: ignore[invalid-attr-value #}
+<div></div>
+
+<!-- Malformed: unknown keyword -->
+{# djangofmt: silence[invalid-attr-value] #}
+<div></div>
+
+<!-- Misplaced: `file-ignore` is only honored as the file's first comment -->
+{# djangofmt: file-ignore[invalid-attr-value] #}
+<div></div>
+
+<!-- Misplaced: nested `file-ignore` -->
+<div>
+  {# djangofmt: file-ignore[empty-attr-value] #}
+  <p>hi</p>
+</div>
+
+<!-- `invalid-syntax` cannot be scoped to a node -->
+{# djangofmt: ignore[invalid-syntax] #}
+<div></div>
+
+<!-- Among several codes, the span points at the offending one -->
+{# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
@@ -46,3 +46,10 @@
 <!-- Repeated, every occurrence goes -->
 {# djangofmt: ignore[invalid-syntax, invalid-attr-value, invalid-syntax] #}
 <div></div>
+
+<!-- Malformed, with whitespace control: the trimming markers go with the comment -->
+{#- djangofmt: ignore[] -#}
+<div></div>
+
+<!-- Malformed and unterminated at the end of the file -->
+{# djangofmt: ignore[]

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
@@ -42,3 +42,7 @@
 <!-- Among several codes, the span points at the offending one -->
 {# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
 <div></div>
+
+<!-- Repeated, every occurrence goes -->
+{# djangofmt: ignore[invalid-syntax, invalid-attr-value, invalid-syntax] #}
+<div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html
@@ -14,6 +14,9 @@
 {# djangofmt: ignore[invalid-attr-value, , 404] #}
 <div></div>
 
+<!-- Malformed, at attribute position: no node to guard, still a comment to report -->
+<form {# djangofmt: ignore[] #} method="yes"></form>
+
 <!-- Malformed: unknown keyword -->
 {# djangofmt: silence[invalid-attr-value] #}
 <div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
@@ -1,0 +1,73 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
+
+  × Malformed `djangofmt:` directive comment.
+   ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:2:1]
+ 1 │ <!-- Malformed: empty rule list -->
+ 2 │ {# djangofmt: ignore[] #}
+   · ────────────┬────────────
+   ·             ╰── here
+ 3 │ <form method="yes"></form>
+   ╰────
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
+
+  × Malformed `djangofmt:` directive comment.
+   ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:6:1]
+ 5 │ <!-- Malformed: missing closing bracket -->
+ 6 │ {# djangofmt: ignore[invalid-attr-value #}
+   · ─────────────────────┬────────────────────
+   ·                      ╰── here
+ 7 │ <div></div>
+   ╰────
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
+
+  × Malformed `djangofmt:` directive comment.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:10:1]
+  9 │ <!-- Malformed: unknown keyword -->
+ 10 │ {# djangofmt: silence[invalid-attr-value] #}
+    · ──────────────────────┬─────────────────────
+    ·                       ╰── here
+ 11 │ <div></div>
+    ╰────
+  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
+
+  × `file-ignore[...]` must be the first comment in the file.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:14:1]
+ 13 │ <!-- Misplaced: `file-ignore` is only honored as the file's first comment -->
+ 14 │ {# djangofmt: file-ignore[invalid-attr-value] #}
+    · ────────────────────────┬───────────────────────
+    ·                         ╰── here
+ 15 │ <div></div>
+    ╰────
+  help: Move the comment to the top of the file, or use `ignore[...]` to target the next node.
+
+  × `file-ignore[...]` must be the first comment in the file.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:19:3]
+ 18 │ <div>
+ 19 │   {# djangofmt: file-ignore[empty-attr-value] #}
+    ·   ───────────────────────┬──────────────────────
+    ·                          ╰── here
+ 20 │   <p>hi</p>
+    ╰────
+  help: Move the comment to the top of the file, or use `ignore[...]` to target the next node.
+
+  × `invalid-syntax` cannot be scoped to a node.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:24:22]
+ 23 │ <!-- `invalid-syntax` cannot be scoped to a node -->
+ 24 │ {# djangofmt: ignore[invalid-syntax] #}
+    ·                      ───────┬──────
+    ·                             ╰── here
+ 25 │ <div></div>
+    ╰────
+  help: An unparsable file has no nodes to attach to: use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.
+
+  × `invalid-syntax` cannot be scoped to a node.
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:28:42]
+ 27 │ <!-- Among several codes, the span points at the offending one -->
+ 28 │ {# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
+    ·                                          ───────┬──────
+    ·                                                 ╰── here
+ 29 │ <div></div>
+    ╰────
+  help: An unparsable file has no nodes to attach to: use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
@@ -111,3 +111,13 @@ source: crates/djangofmt_lint/tests/check/main.rs
  44 │ <div></div>
     ╰────
   help: Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead
+
+  × Invalid suppression comment: `invalid-syntax` cannot be scoped to a node
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:47:1]
+ 46 │ <!-- Repeated, every occurrence goes -->
+ 47 │ {# djangofmt: ignore[invalid-syntax, invalid-attr-value, invalid-syntax] #}
+    · ─────────────────────────────────────┬─────────────────────────────────────
+    ·                                      ╰── here
+ 48 │ <div></div>
+    ╰────
+  help: Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
@@ -2,7 +2,7 @@
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
 
-  × Invalid suppression comment: missing suppression codes like `[missing-img-alt, ...]`
+  × Invalid suppression comment: missing suppression codes like `[code, ...]`
    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:2:1]
  1 │ <!-- Malformed: empty rule list -->
  2 │ {# djangofmt: ignore[] #}
@@ -32,7 +32,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ╰────
   help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
-  × Invalid suppression comment: invalid rule code
+  × Invalid suppression comment: invalid code
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:14:1]
  13 │ <!-- Malformed: a code must start with a letter -->
  14 │ {# djangofmt: ignore[invalid-attr-value, , 404] #}
@@ -42,62 +42,72 @@ source: crates/djangofmt_lint/tests/check/main.rs
     ╰────
   help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
-  × Invalid suppression comment: unknown djangofmt directive
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:18:1]
- 17 │ <!-- Malformed: unknown keyword -->
- 18 │ {# djangofmt: silence[invalid-attr-value] #}
-    · ──────────────────────┬─────────────────────
-    ·                       ╰── here
- 19 │ <div></div>
+  × Invalid suppression comment: missing suppression codes like `[code, ...]`
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:18:7]
+ 17 │ <!-- Malformed, at attribute position: no node to guard, still a comment to report -->
+ 18 │ <form {# djangofmt: ignore[] #} method="yes"></form>
+    ·       ────────────┬────────────
+    ·                   ╰── here
+ 19 │ 
     ╰────
   help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
-  × Invalid suppression comment: missing suppression codes like `[missing-img-alt, ...]`
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:22:1]
- 21 │ <!-- Malformed: `file-ignore` without codes -->
- 22 │ {# djangofmt: file-ignore #}
+  × Invalid suppression comment: unknown directive
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:21:1]
+ 20 │ <!-- Malformed: unknown keyword -->
+ 21 │ {# djangofmt: silence[invalid-attr-value] #}
+    · ──────────────────────┬─────────────────────
+    ·                       ╰── here
+ 22 │ <div></div>
+    ╰────
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
+
+  × Invalid suppression comment: missing suppression codes like `[code, ...]`
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:25:1]
+ 24 │ <!-- Malformed: `file-ignore` without codes -->
+ 25 │ {# djangofmt: file-ignore #}
     · ──────────────┬─────────────
     ·               ╰── here
- 23 │ <div></div>
+ 26 │ <div></div>
     ╰────
   help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
   × Invalid suppression comment: file-level suppressions must be at the top of the file
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:26:1]
- 25 │ <!-- Misplaced: `file-ignore` is only honored at the top of the file -->
- 26 │ {# djangofmt: file-ignore[invalid-attr-value] #}
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:29:1]
+ 28 │ <!-- Misplaced: `file-ignore` is only honored at the top of the file -->
+ 29 │ {# djangofmt: file-ignore[invalid-attr-value] #}
     · ────────────────────────┬───────────────────────
     ·                         ╰── here
- 27 │ <div></div>
+ 30 │ <div></div>
     ╰────
   help: Move the comment to the top of the file, or use `ignore[...]`
 
   × Invalid suppression comment: file-level suppressions must be at the top of the file
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:31:3]
- 30 │ <div>
- 31 │   {# djangofmt: file-ignore[empty-attr-value] #}
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:34:3]
+ 33 │ <div>
+ 34 │   {# djangofmt: file-ignore[empty-attr-value] #}
     ·   ───────────────────────┬──────────────────────
     ·                          ╰── here
- 32 │   <p>hi</p>
+ 35 │   <p>hi</p>
     ╰────
   help: Move the comment to the top of the file, or use `ignore[...]`
 
   × Invalid suppression comment: `invalid-syntax` cannot be scoped to a node
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:36:22]
- 35 │ <!-- `invalid-syntax` cannot be scoped to a node -->
- 36 │ {# djangofmt: ignore[invalid-syntax] #}
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:39:22]
+ 38 │ <!-- `invalid-syntax` cannot be scoped to a node -->
+ 39 │ {# djangofmt: ignore[invalid-syntax] #}
     ·                      ───────┬──────
     ·                             ╰── here
- 37 │ <div></div>
+ 40 │ <div></div>
     ╰────
   help: Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead
 
   × Invalid suppression comment: `invalid-syntax` cannot be scoped to a node
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:40:42]
- 39 │ <!-- Among several codes, the span points at the offending one -->
- 40 │ {# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:43:42]
+ 42 │ <!-- Among several codes, the span points at the offending one -->
+ 43 │ {# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
     ·                                          ───────┬──────
     ·                                                 ╰── here
- 41 │ <div></div>
+ 44 │ <div></div>
     ╰────
   help: Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
@@ -2,7 +2,7 @@
 source: crates/djangofmt_lint/tests/check/main.rs
 ---
 
-  × Malformed `djangofmt:` directive comment.
+  × Invalid suppression comment: missing suppression codes like `[missing-img-alt, ...]`
    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:2:1]
  1 │ <!-- Malformed: empty rule list -->
  2 │ {# djangofmt: ignore[] #}
@@ -10,9 +10,9 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·             ╰── here
  3 │ <form method="yes"></form>
    ╰────
-  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
-  × Malformed `djangofmt:` directive comment.
+  × Invalid suppression comment: missing closing bracket
    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:6:1]
  5 │ <!-- Malformed: missing closing bracket -->
  6 │ {# djangofmt: ignore[invalid-attr-value #}
@@ -20,54 +20,84 @@ source: crates/djangofmt_lint/tests/check/main.rs
    ·                      ╰── here
  7 │ <div></div>
    ╰────
-  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
-  × Malformed `djangofmt:` directive comment.
+  × Invalid suppression comment: missing comma between codes
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:10:1]
-  9 │ <!-- Malformed: unknown keyword -->
- 10 │ {# djangofmt: silence[invalid-attr-value] #}
-    · ──────────────────────┬─────────────────────
-    ·                       ╰── here
+  9 │ <!-- Malformed: missing comma between codes -->
+ 10 │ {# djangofmt: ignore[invalid-attr-value empty-attr-value] #}
+    · ──────────────────────────────┬─────────────────────────────
+    ·                               ╰── here
  11 │ <div></div>
     ╰────
-  help: Write `{# djangofmt: ignore[rule] #}` before a node, or `{# djangofmt: file-ignore[rule] #}` at the top of the file.
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
-  × `file-ignore[...]` must be the first comment in the file.
+  × Invalid suppression comment: invalid rule code
     ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:14:1]
- 13 │ <!-- Misplaced: `file-ignore` is only honored as the file's first comment -->
- 14 │ {# djangofmt: file-ignore[invalid-attr-value] #}
-    · ────────────────────────┬───────────────────────
-    ·                         ╰── here
+ 13 │ <!-- Malformed: a code must start with a letter -->
+ 14 │ {# djangofmt: ignore[invalid-attr-value, , 404] #}
+    · ─────────────────────────┬────────────────────────
+    ·                          ╰── here
  15 │ <div></div>
     ╰────
-  help: Move the comment to the top of the file, or use `ignore[...]` to target the next node.
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
 
-  × `file-ignore[...]` must be the first comment in the file.
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:19:3]
- 18 │ <div>
- 19 │   {# djangofmt: file-ignore[empty-attr-value] #}
+  × Invalid suppression comment: unknown djangofmt directive
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:18:1]
+ 17 │ <!-- Malformed: unknown keyword -->
+ 18 │ {# djangofmt: silence[invalid-attr-value] #}
+    · ──────────────────────┬─────────────────────
+    ·                       ╰── here
+ 19 │ <div></div>
+    ╰────
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
+
+  × Invalid suppression comment: missing suppression codes like `[missing-img-alt, ...]`
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:22:1]
+ 21 │ <!-- Malformed: `file-ignore` without codes -->
+ 22 │ {# djangofmt: file-ignore #}
+    · ──────────────┬─────────────
+    ·               ╰── here
+ 23 │ <div></div>
+    ╰────
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
+
+  × Invalid suppression comment: file-level suppressions must be at the top of the file
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:26:1]
+ 25 │ <!-- Misplaced: `file-ignore` is only honored at the top of the file -->
+ 26 │ {# djangofmt: file-ignore[invalid-attr-value] #}
+    · ────────────────────────┬───────────────────────
+    ·                         ╰── here
+ 27 │ <div></div>
+    ╰────
+  help: Move the comment to the top of the file, or use `ignore[...]`
+
+  × Invalid suppression comment: file-level suppressions must be at the top of the file
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:31:3]
+ 30 │ <div>
+ 31 │   {# djangofmt: file-ignore[empty-attr-value] #}
     ·   ───────────────────────┬──────────────────────
     ·                          ╰── here
- 20 │   <p>hi</p>
+ 32 │   <p>hi</p>
     ╰────
-  help: Move the comment to the top of the file, or use `ignore[...]` to target the next node.
+  help: Move the comment to the top of the file, or use `ignore[...]`
 
-  × `invalid-syntax` cannot be scoped to a node.
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:24:22]
- 23 │ <!-- `invalid-syntax` cannot be scoped to a node -->
- 24 │ {# djangofmt: ignore[invalid-syntax] #}
+  × Invalid suppression comment: `invalid-syntax` cannot be scoped to a node
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:36:22]
+ 35 │ <!-- `invalid-syntax` cannot be scoped to a node -->
+ 36 │ {# djangofmt: ignore[invalid-syntax] #}
     ·                      ───────┬──────
     ·                             ╰── here
- 25 │ <div></div>
+ 37 │ <div></div>
     ╰────
-  help: An unparsable file has no nodes to attach to: use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.
+  help: Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead
 
-  × `invalid-syntax` cannot be scoped to a node.
-    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:28:42]
- 27 │ <!-- Among several codes, the span points at the offending one -->
- 28 │ {# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
+  × Invalid suppression comment: `invalid-syntax` cannot be scoped to a node
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:40:42]
+ 39 │ <!-- Among several codes, the span points at the offending one -->
+ 40 │ {# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
     ·                                          ───────┬──────
     ·                                                 ╰── here
- 29 │ <div></div>
+ 41 │ <div></div>
     ╰────
-  help: An unparsable file has no nodes to attach to: use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file.
+  help: Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.snap
@@ -121,3 +121,22 @@ source: crates/djangofmt_lint/tests/check/main.rs
  48 │ <div></div>
     ╰────
   help: Use `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of the file instead
+
+  × Invalid suppression comment: missing suppression codes like `[code, ...]`
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:51:1]
+ 50 │ <!-- Malformed, with whitespace control: the trimming markers go with the comment -->
+ 51 │ {#- djangofmt: ignore[] -#}
+    · ─────────────┬─────────────
+    ·              ╰── here
+ 52 │ <div></div>
+    ╰────
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`
+
+  × Invalid suppression comment: missing suppression codes like `[code, ...]`
+    ╭─[tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.html:55:1]
+ 54 │ <!-- Malformed and unterminated at the end of the file -->
+ 55 │ {# djangofmt: ignore[]
+    · ───────────┬───────────
+    ·            ╰── here
+    ╰────
+  help: Use `{# djangofmt: ignore[rule, ...] #}` or `{# djangofmt: file-ignore[rule, ...] #}`

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
@@ -13,6 +13,9 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Malformed: a code must start with a letter -->
 <div></div>
 
+<!-- Malformed, at attribute position: no node to guard, still a comment to report -->
+<form method="yes"></form>
+
 <!-- Malformed: unknown keyword -->
 <div></div>
 

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
@@ -14,7 +14,7 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <div></div>
 
 <!-- Malformed, at attribute position: no node to guard, still a comment to report -->
-<form method="yes"></form>
+<form  method="yes"></form>
 
 <!-- Malformed: unknown keyword -->
 <div></div>
@@ -34,5 +34,9 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <div></div>
 
 <!-- Among several codes, the span points at the offending one -->
+{# djangofmt: ignore[invalid-attr-value] #}
+<div></div>
+
+<!-- Repeated, every occurrence goes -->
 {# djangofmt: ignore[invalid-attr-value] #}
 <div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
@@ -1,41 +1,35 @@
+---
+source: crates/djangofmt_lint/tests/check/main.rs
+---
 <!-- Malformed: empty rule list -->
-{# djangofmt: ignore[] #}
 <form method="yes"></form>
 
 <!-- Malformed: missing closing bracket -->
-{# djangofmt: ignore[invalid-attr-value #}
 <div></div>
 
 <!-- Malformed: missing comma between codes -->
-{# djangofmt: ignore[invalid-attr-value empty-attr-value] #}
 <div></div>
 
 <!-- Malformed: a code must start with a letter -->
-{# djangofmt: ignore[invalid-attr-value, , 404] #}
 <div></div>
 
 <!-- Malformed: unknown keyword -->
-{# djangofmt: silence[invalid-attr-value] #}
 <div></div>
 
 <!-- Malformed: `file-ignore` without codes -->
-{# djangofmt: file-ignore #}
 <div></div>
 
 <!-- Misplaced: `file-ignore` is only honored at the top of the file -->
-{# djangofmt: file-ignore[invalid-attr-value] #}
 <div></div>
 
 <!-- Misplaced: nested `file-ignore` -->
 <div>
-  {# djangofmt: file-ignore[empty-attr-value] #}
   <p>hi</p>
 </div>
 
 <!-- `invalid-syntax` cannot be scoped to a node -->
-{# djangofmt: ignore[invalid-syntax] #}
 <div></div>
 
 <!-- Among several codes, the span points at the offending one -->
-{# djangofmt: ignore[invalid-attr-value, invalid-syntax] #}
+{# djangofmt: ignore[invalid-attr-value] #}
 <div></div>

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.invalid.unsafe-fixed.snap
@@ -40,3 +40,8 @@ source: crates/djangofmt_lint/tests/check/main.rs
 <!-- Repeated, every occurrence goes -->
 {# djangofmt: ignore[invalid-attr-value] #}
 <div></div>
+
+<!-- Malformed, with whitespace control: the trimming markers go with the comment -->
+<div></div>
+
+<!-- Malformed and unterminated at the end of the file -->

--- a/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.valid.html
+++ b/crates/djangofmt_lint/tests/check/invalid_ignore_comment/invalid_ignore_comment.valid.html
@@ -1,0 +1,35 @@
+{# djangofmt: file-ignore[format, invalid-syntax, missing-img-alt] #}
+{# The file-ignore above is the first comment, where the file-wide codes belong #}
+
+{# djangofmt: ignore[invalid-attr-value] #}
+<form method="yes"></form>
+
+{# The formatter honors `format` on a node too #}
+{# djangofmt: ignore[format] #}
+<div></div>
+
+{# Text after the closing bracket is a free-text reason #}
+{# djangofmt: ignore[invalid-attr-value]: because reasons #}
+<form method="yes"></form>
+
+{# Unknown codes are invalid-ignore-code's concern #}
+{# djangofmt: ignore[not-a-real-rule] #}
+<div></div>
+
+{# The formatter's bare directive: spaced, explained, whitespace-controlled #}
+{# djangofmt:ignore #}
+<div></div>
+{# djangofmt: ignore #}
+<div></div>
+{# djangofmt:ignore this table is generated #}
+<div></div>
+{#- djangofmt:ignore -#}
+<div></div>
+
+{# Merely mentioning djangofmt: is not a directive #}
+{# See djangofmt: https://unknownplatypus.github.io/djangofmt/ #}
+<div></div>
+
+{# A directive in an HTML comment is never honored, so never flagged #}
+<!-- djangofmt: ignore[] -->
+<div></div>


### PR DESCRIPTION
A suppression comment djangofmt does not recognize is skipped silently, so the diagnostic it was meant to silence keeps firing. These two rules make that visible: `invalid-ignore-comment` covers malformed directives, a misplaced `file-ignore[...]`, and file-wide codes used on a node; `invalid-ignore-code` covers codes naming no rule.

```jinja
{# djangofmt: ignore[invalid-attr-values] #}   ← invalid-ignore-code (typo)
{# djangofmt: ignore[] #}                      ← invalid-ignore-comment
```

The directive grammar (namespace, keyword, code list, parse errors) lives once in `markup_fmt`, so the formatter and the linter read every comment the same way. Whitespace before the code list is accepted, `{# djangofmt: ignore [rule] #}` included.

Part 3/4 of #436, stacked on #441.