### PR TITLE
feat(format): accept whitespace around `:` in the ignore directive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=2f7e5c1fc609c6dd90339d85dc823e5b12a78cae#2f7e5c1fc609c6dd90339d85dc823e5b12a78cae"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=981fb745b583109226d85bff17ac49d46a60cf07#981fb745b583109226d85bff17ac49d46a60cf07"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ insta-cmd = { version = "0.7.0" }
 malva = { version = "0.16.0", features = ["config_serde"] }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "2f7e5c1fc609c6dd90339d85dc823e5b12a78cae"
+  rev = "981fb745b583109226d85bff17ac49d46a60cf07"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -109,20 +109,17 @@ pub(crate) fn merge_custom_blocks(
     }
 }
 
-macro_rules! ignore_directive {
-    () => {
-        "djangofmt:ignore"
-    };
-}
-const DJANGOFMT_IGNORE_COMMENT_DIRECTIVE: &str = ignore_directive!();
-const DJANGOFMT_IGNORE_COMMENT: &str = concat!("<!-- ", ignore_directive!(), " -->");
-const DJANGOFMT_IGNORE_COMMENT_JINJA: &str = concat!("{# ", ignore_directive!(), " #}");
+const DJANGOFMT_IGNORE_COMMENT_DIRECTIVE: &str = "djangofmt:ignore";
 
 /// Whether the file opts out of djangofmt entirely with a leading ignore comment.
 #[must_use]
 pub(crate) fn is_file_ignored(source: &str) -> bool {
-    source.starts_with(DJANGOFMT_IGNORE_COMMENT)
-        || source.starts_with(DJANGOFMT_IGNORE_COMMENT_JINJA)
+    source
+        .strip_prefix("<!--")
+        .or_else(|| source.strip_prefix("{#"))
+        .is_some_and(|comment| {
+            markup_fmt::starts_with_directive(comment, DJANGOFMT_IGNORE_COMMENT_DIRECTIVE)
+        })
 }
 
 /// Build default `markup_fmt` options for HTML/Jinja formatting.

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -53,7 +53,7 @@ fn format_file_with_ignore_directive() {
 
 #[test]
 fn check_unparsable_file_with_ignore_directive() {
-    let project = Project::new().file("test.html", "{# djangofmt:ignore #}\n<div>\n");
+    let project = Project::new().file("test.html", "{# djangofmt:   ignore #}\n<div>\n");
     assert_cmd_snapshot!(cli().arg("check").arg(project.join("test.html")), @r"
     success: true
     exit_code: 0

--- a/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive.html
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive.html
@@ -1,5 +1,5 @@
 <div>
-    <!-- djangofmt:ignore -->
+    <!-- djangofmt: ignore -->
     <p     class="unformatted"      >This should not be formatted</p>
     <!-- end djangofmt:ignore -->
 </div>

--- a/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive.snap
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_comment_directive.snap
@@ -1,8 +1,8 @@
 ---
-source: tests/fmt.rs
+source: crates/djangofmt/tests/fmt/main.rs
 ---
 <div>
-    <!-- djangofmt:ignore -->
+    <!-- djangofmt: ignore -->
     <p     class="unformatted"      >This should not be formatted</p>
     <!-- end djangofmt:ignore -->
 </div>

--- a/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.html
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.html
@@ -1,4 +1,4 @@
-{# djangofmt:ignore #}
+{# djangofmt: ignore #}
 <div>
     <p     class="unformatted"      >This entire file should not be formatted</p>
 </div>

--- a/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.snap
+++ b/crates/djangofmt/tests/fmt/ignore/ignore_file_comment_directive_jinja.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/djangofmt/tests/fmt/main.rs
 ---
-{# djangofmt:ignore #}
+{# djangofmt: ignore #}
 <div>
     <p     class="unformatted"      >This entire file should not be formatted</p>
 </div>

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -63,7 +63,7 @@ attribute values to pass non-string types (booleans, numbers, template variables
 
 ## Disabling formatting
 
-To disable formatting for an entire file, add `<!-- djangofmt:ignore -->` at the very top of the file.
+To disable formatting for an entire file, add `<!-- djangofmt: ignore -->` at the very top of the file.
 
 A file ignored this way is also skipped by `djangofmt check` when it cannot be parsed,
 so templates that break the parser can be quarantined from both commands.
@@ -71,7 +71,7 @@ so templates that break the parser can be quarantined from both commands.
 To disable formatting for a specific node, prefix it with the same comment:
 
 ```html
-<!-- djangofmt:ignore -->
+<!-- djangofmt: ignore -->
 <div   class="keep-this-unformatted"   >Content</div>
 <div class="this-will-be-formatted">Content</div>
 ```
@@ -80,6 +80,6 @@ A Django/Jinja comment works the same way, both inline and at the top of a file.
 Unlike an HTML comment, it isn't rendered to the client:
 
 ```html
-{# djangofmt:ignore #}
+{# djangofmt: ignore #}
 <div   class="keep-this-unformatted"   >Content</div>
 ```


### PR DESCRIPTION
`{# djangofmt: ignore #}` (a space after the colon, the way it reads naturally) was silently
ignored — only the exact `djangofmt:ignore` matched. Matching now allows whitespace around the
`:`, like ruff's `# ruff: noqa`.

The matching lives in markup_fmt, so this bumps the pinned rev to
[`981fb74`](https://github.com/UnknownPlatypus/markup_fmt/commit/981fb745b583109226d85bff17ac49d46a60cf07),
which adds a `starts_with_directive` helper (no allocation, plain prefix compare in the common case)
used by both the per-node and the whole-file directive checks. `is_file_ignored` here reuses it, so
the unparsable-file path accepts the same spellings as the parsed one — it previously also required
exactly one space inside the comment markers.

Docs now show the blessed `djangofmt: ignore` form.