### PR TITLE
test(ecosystem): Exclude django-unfold `avatar.html` (dynamic tag name)

### DIFF
--- a/python/ecosystem-check/ecosystem_check/defaults.py
+++ b/python/ecosystem-check/ecosystem_check/defaults.py
@@ -201,6 +201,7 @@ DEFAULT_TARGETS = [
                 ExcludeReason.DYNAMIC_TAG_NAME: (
                     "src/unfold/templates/unfold/components/button.html",
                     "src/unfold/templates/unfold/components/card.html",
+                    "src/unfold/templates/unfold/helpers/avatar.html",
                     "src/unfold/templates/unfold/helpers/change_list_filter_vertical.html",
                     "src/unfold/templates/unfold/helpers/display_dropdown.html",
                     "src/unfold/templates/unfold/helpers/edit_inline/inline_delete.html",


### PR DESCRIPTION
They have a new dynamic tag name

```
× expected close tag for opening tag <{>
    ╭─[src/unfold/templates/unfold/helpers/avatar.html:19:14]
 18 │         {% if badge_count or badge_variant %}
 19 │             <{% if badge_url %}a{% else %}div{% endif %} href="{{ badge_url }}" class="absolute border-2 border-base-100 block top-0 right-0 rounded-full text-[10px] font-semibold text-white w-[20px] h-[20px] flex items-center text-shadow translate-x-1/3 -translate-y-1/3 justify-center dark:border-base-800 z-100
    ·              ┬
    ·              ╰── here
 20 │             {% if badge_variant == "primary" %}
    ╰────
  help: If a `</{>` does exist, it must live in the same block as the
        opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
        limitations/#conditional-openclose-tags

Couldn't format 1 files!
155 files reformatted, 70 files left unchanged !
```