### PR TITLE
ci(ecosystem): Stop rebuilding `djangofmt` a third time in the ecosystem check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           echo "$PWD/python/benchmarks/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Run `djangofmt` ecosystem check
+        env:
+          # djangofmt was built above, don't rebuild it via project install and maturin
+          UV_NO_PROJECT: 1
         run: |
           # Set pipefail to avoid hiding errors with tee
           set -eo pipefail


### PR DESCRIPTION
See https://github.com/UnknownPlatypus/djangofmt/actions/runs/33261077072/job/99123027664?pr=454

It was doing extra unnecessary work