### PR TITLE
fix(cli): Stop breaking help URLs across lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "serde",
  "similar-asserts",
  "tempfile",
+ "textwrap",
  "thiserror",
  "tikv-jemallocator",
  "toml",
@@ -480,6 +481,7 @@ dependencies = [
  "serde",
  "smallvec",
  "strum",
+ "textwrap",
  "thiserror",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ smallvec = { version = "1.15.1", features = ["const_new"] }
 strum = { version = "0.28.0", features = ["derive"] }
 syn = { version = "3.0" }
 tempfile = { version = "3.27.0" }
+textwrap = { version = "0.16.2" }
 thiserror = { version = "2.0.18" }
 # This has to be kept in sync with src/main.rs where the allocator for the program is set.
 tikv-jemallocator = { version = "0.7.0" }

--- a/crates/djangofmt/Cargo.toml
+++ b/crates/djangofmt/Cargo.toml
@@ -29,6 +29,7 @@ miette = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
+textwrap = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -101,7 +101,7 @@ impl ParseError {
                     markup_fmt::SyntaxErrorKind::ExpectCloseTag { tag_name, pos, .. } => (
                         format!("expected close tag for opening tag <{tag_name}>"),
                         Some(format!(
-                            "If a `</{tag_name}>` does exist, it must live in the same block as the opening tag: \
+                            "If a `</{tag_name}>` does exist, it must live in the same block as the opening tag.\n\
                              https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags"
                         )),
                         // `pos` is the `<`; the caret covers the tag name.

--- a/crates/djangofmt/src/main.rs
+++ b/crates/djangofmt/src/main.rs
@@ -25,6 +25,17 @@ use djangofmt::{ExitStatus, run};
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[must_use]
 pub fn main() -> ExitCode {
+    // Match the wrap policy of `djangofmt_lint::graphical_handler`, keeping URLs unbroken.
+    let _ = miette::set_hook(Box::new(|_| {
+        Box::new(
+            miette::MietteHandlerOpts::new()
+                .word_separator(textwrap::WordSeparator::AsciiSpace)
+                .word_splitter(textwrap::WordSplitter::NoHyphenation)
+                .break_words(false)
+                .build(),
+        )
+    }));
+
     let args = Args::parse();
 
     match run(args) {

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -107,7 +107,7 @@ fn format_quiet() {
 #[test]
 fn format_file_parse_error_exits_2() {
     let project = Project::new().file("test.html", "<div   class=\"foo\"  >");
-    assert_cmd_snapshot_tmpdir!(cli().arg(project.join("test.html")), @r###"
+    assert_cmd_snapshot_tmpdir!(cli().arg(project.join("test.html")), @r##"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -121,11 +121,11 @@ fn format_file_parse_error_exits_2() {
        ·   ╰── here
        ╰────
       help: If a `</div>` does exist, it must live in the same block as the
-            opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
-            limitations/#conditional-openclose-tags
+            opening tag.
+            https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
 
     Couldn't format 1 files!
-    "###);
+    "##);
 }
 
 // ── Format from stdin ────────────────────────────────────────────────
@@ -218,7 +218,7 @@ fn format_stdin_ignore_directive() {
 fn format_stdin_parse_error_exits_2() {
     assert_cmd_snapshot!(
         cli().arg("-").pass_stdin("<div   class=\"foo\"  >"),
-        @r###"
+        @r##"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -232,9 +232,9 @@ fn format_stdin_parse_error_exits_2() {
        ·   ╰── here
        ╰────
       help: If a `</div>` does exist, it must live in the same block as the
-            opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-
-            limitations/#conditional-openclose-tags
-    "###);
+            opening tag.
+            https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
+    "##);
 }
 
 #[test]

--- a/crates/djangofmt/tests/parse_error/invalid_closing_tag_syntax.snap
+++ b/crates/djangofmt/tests/parse_error/invalid_closing_tag_syntax.snap
@@ -9,4 +9,5 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·    ╰── here
  3 │ </html>
    ╰────
-  help: If a `</p>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
+  help: If a `</p>` does exist, it must live in the same block as the opening tag.
+        https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt/tests/parse_error/main.rs
+++ b/crates/djangofmt/tests/parse_error/main.rs
@@ -13,10 +13,11 @@ use std::{fs, path};
 use djangofmt::args::Profile;
 use djangofmt::commands::format::build_markup_options;
 use djangofmt::error::ParseError;
+use djangofmt_lint::graphical_handler;
 use insta::{assert_snapshot, glob};
 use markup_fmt::config::FormatOptions;
 use markup_fmt::{Language, format_text};
-use miette::{GraphicalReportHandler, GraphicalTheme};
+use miette::GraphicalTheme;
 
 #[test]
 fn parse_error_snapshot() {
@@ -66,7 +67,7 @@ fn format_str(
 
 fn render_miette_error(error: &dyn miette::Diagnostic) -> String {
     let mut output = String::new();
-    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+    let handler = graphical_handler(GraphicalTheme::unicode_nocolor());
     handler
         .render_report(&mut output, error)
         .expect("Failed to render report");

--- a/crates/djangofmt/tests/parse_error/nested_unclosed_tags.snap
+++ b/crates/djangofmt/tests/parse_error/nested_unclosed_tags.snap
@@ -9,4 +9,5 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·              ╰── here
  5 │         </article>
    ╰────
-  help: If a `</p>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
+  help: If a `</p>` does exist, it must live in the same block as the opening tag.
+        https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt/tests/parse_error/unclosed_body_tag.snap
+++ b/crates/djangofmt/tests/parse_error/unclosed_body_tag.snap
@@ -9,4 +9,5 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·    ╰── here
  6 │ <head>
    ╰────
-  help: If a `</html>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
+  help: If a `</html>` does exist, it must live in the same block as the opening tag.
+        https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt/tests/parse_error/unclosed_div_tag.snap
+++ b/crates/djangofmt/tests/parse_error/unclosed_div_tag.snap
@@ -9,4 +9,5 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·       ╰── here
  8 │         <h1>Unclosed div tag</h1>
    ╰────
-  help: If a `</div>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
+  help: If a `</div>` does exist, it must live in the same block as the opening tag.
+        https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt/tests/parse_error/unclosed_tag_non_ascii.snap
+++ b/crates/djangofmt/tests/parse_error/unclosed_tag_non_ascii.snap
@@ -8,4 +8,5 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·           ╰── here
  2 │     unclosed
    ╰────
-  help: If a `</div>` does exist, it must live in the same block as the opening tag: https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags
+  help: If a `</div>` does exist, it must live in the same block as the opening tag.
+        https://unknownplatypus.github.io/djangofmt/docs/known-limitations/#conditional-openclose-tags

--- a/crates/djangofmt_benchmark/benches/reporter.rs
+++ b/crates/djangofmt_benchmark/benches/reporter.rs
@@ -4,8 +4,8 @@
 use djangofmt_benchmark::{
     DJANGO_TEMPLATE_DEEPLY_NESTED, DJANGO_TEMPLATE_LARGE, JINJA_TEMPLATE_LARGE, TestFile,
 };
-use djangofmt_lint::{FileDiagnostics, Settings, lint_source};
-use miette::{GraphicalReportHandler, GraphicalTheme};
+use djangofmt_lint::{FileDiagnostics, Settings, graphical_handler, lint_source};
+use miette::GraphicalTheme;
 
 fn main() {
     divan::main();
@@ -34,7 +34,7 @@ fn render(bencher: divan::Bencher, template: &'static TestFile) {
 
     // Pinned to what an interactive `check` renders, so the terminal the
     // benchmark happens to run in can't change the result.
-    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode()).with_width(120);
+    let handler = graphical_handler(GraphicalTheme::unicode()).with_width(120);
 
     bencher.counter(file_diagnostics.len()).bench(|| {
         let mut out = String::new();

--- a/crates/djangofmt_lint/Cargo.toml
+++ b/crates/djangofmt_lint/Cargo.toml
@@ -15,6 +15,7 @@ rustywind_core = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 smallvec = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
+textwrap = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -56,9 +56,7 @@ pub fn clamp_offset(value: usize) -> u32 {
 }
 
 /// Wrap help and note text without splitting URLs.
-///
-/// `textwrap`'s Unicode line-breaking treats `/` and `-` as break opportunities,
-/// so a URL is not one word and gets a hard newline that defeats terminal linkification.
+/// `textwrap` treats `/` and `-` as break opportunities, so a URL is not one word.
 #[must_use]
 pub fn graphical_handler(theme: GraphicalTheme) -> GraphicalReportHandler {
     GraphicalReportHandler::new_themed(theme)

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -43,7 +43,7 @@ use std::path::Path;
 use markup_fmt::ast::Root;
 use markup_fmt::parser::Parser;
 use markup_fmt::{Language, SyntaxError};
-use miette::{Diagnostic, GraphicalReportHandler, NamedSource, Report, SourceSpan};
+use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme, NamedSource, Report, SourceSpan};
 use std::fmt;
 use std::sync::{Arc, LazyLock};
 
@@ -53,6 +53,18 @@ use std::sync::{Arc, LazyLock};
 #[must_use]
 pub fn clamp_offset(value: usize) -> u32 {
     u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+/// Wrap help and note text without splitting URLs.
+///
+/// `textwrap`'s Unicode line-breaking treats `/` and `-` as break opportunities,
+/// so a URL is not one word and gets a hard newline that defeats terminal linkification.
+#[must_use]
+pub fn graphical_handler(theme: GraphicalTheme) -> GraphicalReportHandler {
+    GraphicalReportHandler::new_themed(theme)
+        .with_word_separator(textwrap::WordSeparator::AsciiSpace)
+        .with_word_splitter(textwrap::WordSplitter::NoHyphenation)
+        .with_break_words(false)
 }
 
 /// Build a [`SourceSpan`] from `usize` byte offsets.

--- a/crates/djangofmt_lint/tests/check/main.rs
+++ b/crates/djangofmt_lint/tests/check/main.rs
@@ -3,13 +3,13 @@ mod common;
 
 use common::build_settings;
 use djangofmt_lint::{
-    Applicability, FileDiagnostics, LintDiagnostic, Rule, RuleSet, Settings, fix_ast, lint_source,
-    parse,
+    Applicability, FileDiagnostics, LintDiagnostic, Rule, RuleSet, Settings, fix_ast,
+    graphical_handler, lint_source, parse,
 };
 
 use insta::{assert_snapshot, glob};
 use markup_fmt::Language;
-use miette::{GraphicalReportHandler, GraphicalTheme};
+use miette::GraphicalTheme;
 use std::fs;
 use std::path::Path;
 use strum::IntoEnumIterator;
@@ -139,7 +139,7 @@ fn render_diagnostics(diagnostics: &FileDiagnostics) -> String {
     let mut output = String::new();
     diagnostics
         .render(
-            &GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor()),
+            &graphical_handler(GraphicalTheme::unicode_nocolor()),
             &mut output,
         )
         .expect("Failed to render diagnostics");

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,8 +2,8 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, Settings, lint_source};
-use miette::{GraphicalReportHandler, GraphicalTheme};
+use djangofmt_lint::{FileDiagnostics, Settings, graphical_handler, lint_source};
+use miette::GraphicalTheme;
 use serde::Serialize;
 use std::path::PathBuf;
 use tsify::Tsify;
@@ -201,7 +201,7 @@ fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
     }
 
     let file_diagnostics = FileDiagnostics::new("", source, diagnostics);
-    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode());
+    let handler = graphical_handler(GraphicalTheme::unicode());
     let mut output = String::new();
     file_diagnostics
         .render(&handler, &mut output)
@@ -228,7 +228,7 @@ fn render_parse_error(source: &str, err: &markup_fmt::FormatError) -> String {
         source.to_string(),
         err,
     );
-    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+    let handler = graphical_handler(GraphicalTheme::unicode_nocolor());
     let mut output = String::new();
     match handler.render_report(&mut output, &diagnostic) {
         Ok(()) => output,


### PR DESCRIPTION
`textwrap`'s Unicode line-breaking treats `/` and `-` as break opportunities, so a URL is not one word: 

miette wrapped the known-limitations link mid-path at any terminal under 200 columns (80 in CI, where there is no tty), leaving a hard newline that defeats linkification and copy-paste.

Share one wrap policy across every renderer and put the URL on its own line so the prose still wraps normally.