### PR TITLE
fix(format): Recover from panics instead of crashing the whole run

### DIFF
--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -99,7 +99,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
     .unwrap_or_default();
 
     let start = Instant::now();
-    let (results, parse_errors): (Vec<_>, Vec<_>) = resolved
+    let (results, errors): (Vec<_>, Vec<_>) = resolved
         .files
         .par_iter()
         .map(|path| {
@@ -114,14 +114,16 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
                 resolved.pyproject.profile,
                 Some(path),
             );
-            check_path(
-                path,
-                profile,
-                settings,
-                &custom_blocks,
-                config.fix,
-                threshold,
-            )
+            super::catch_file_panic(path, || {
+                check_path(
+                    path,
+                    profile,
+                    settings,
+                    &custom_blocks,
+                    config.fix,
+                    threshold,
+                )
+            })
         })
         .partition_map(|result| match result {
             Ok(r) => Left(r),
@@ -131,7 +133,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
     let duration = start.elapsed();
     debug!("Checked {} files in {:.2?}", resolved.files.len(), duration);
 
-    let nb_parse_errors = super::report_parse_errors(parse_errors, "check", config.output_format);
+    let nb_errors = super::report_errors(errors, "check", config.output_format);
 
     let mut total_diagnostics = 0usize;
     let mut total_applied = 0usize;
@@ -167,15 +169,15 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
         total_unsafe_fixable,
         config.fix,
         config.unsafe_fixes,
-        nb_parse_errors,
+        nb_errors,
     );
 
     if config.show_fixes && total_applied > 0 {
         print_show_fixes(&results, total_applied);
     }
 
-    // I/O and parse errors take precedence over lint violations in the exit code.
-    if nb_parse_errors > 0 {
+    // I/O, parse and panic errors take precedence over lint violations in the exit code.
+    if nb_errors > 0 {
         return Ok(ExitStatus::Error);
     }
     if total_diagnostics > 0 {

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -3,16 +3,19 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::Write;
+use std::panic::UnwindSafe;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::ExitStatus;
 use crate::args::{FormatCommand, OutputFormat, Profile};
 use crate::config::{resolve_bool_arg, resolve_profile};
 use crate::editorconfig::{self, EditorconfigSettings};
 use crate::error::{CommandError, ParseError, Result};
+use crate::fs::relativize_path;
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
+use crate::panic::catch_unwind;
 use crate::pyproject::PyprojectSettings;
 use editorconfig_parser::EditorConfig;
 
@@ -285,10 +288,10 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
 
     // Format files in parallel
     let start = Instant::now();
-    let (results, parse_errors): (Vec<_>, Vec<_>) = resolved
+    let (results, errors): (Vec<_>, Vec<_>) = resolved
         .files
         .par_iter()
-        .map(|entry| format_path(entry, &context))
+        .map(|entry| super::catch_file_panic(entry, || format_path(entry, &context)))
         .partition_map(|result| match result {
             Ok(fmt_res) => Left(fmt_res),
             Err(err) => Right(*err),
@@ -300,7 +303,7 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
         start.elapsed()
     );
 
-    let nb_parse_errors = super::report_parse_errors(parse_errors, "format", OutputFormat::Full);
+    let nb_errors = super::report_errors(errors, "format", OutputFormat::Full);
 
     // Report on the formatting changes.
     let summary = build_summary(results.as_ref());
@@ -308,7 +311,7 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
         info!("{} !", summary);
     }
 
-    if nb_parse_errors == 0 {
+    if nb_errors == 0 {
         Ok(ExitStatus::Success)
     } else {
         Ok(ExitStatus::Error)
@@ -316,10 +319,13 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
 }
 
 /// Format the given source code.
+///
+/// `path` only labels diagnostics, pass `None` when the source has no file behind it.
 pub fn format_text(
     source: &str,
     config: &FormatterConfig,
     profile: Profile,
+    path: Option<&Path>,
 ) -> std::result::Result<Option<String>, markup_fmt::FormatError> {
     if is_file_ignored(source) {
         return Ok(None);
@@ -334,24 +340,26 @@ pub fn format_text(
                     let fake_filename = PathBuf::from(format!("djangofmt_fmt_stdin.{}", hints.ext));
                     let mut json_config = config.json.clone();
                     json_config.line_width = u32::try_from(hints.print_width).unwrap_or(u32::MAX);
-                    match dprint_plugin_json::format_text(&fake_filename, code, &json_config) {
-                        Ok(Some(formatted)) => Ok(formatted.into()),
-                        Ok(None) => Ok(code.into()),
-                        Err(error) => {
-                            debug!(
-                                "Failed to format JSON, falling back to original code. Error: {:?}",
-                                error
-                            );
-                            Ok(code.into())
+                    Ok(format_or_fallback(code, "JSON", path, || {
+                        match dprint_plugin_json::format_text(&fake_filename, code, &json_config) {
+                            Ok(Some(formatted)) => formatted.into(),
+                            Ok(None) => code.into(),
+                            Err(error) => {
+                                debug!(
+                                    "Failed to format JSON, falling back to original code. Error: {:?}",
+                                    error
+                                );
+                                code.into()
+                            }
                         }
-                    }
+                    }))
                 }
                 "css" | "scss" | "sass" | "less" => {
                     let mut malva_config = config.malva.clone();
                     malva_config.layout.print_width = hints.print_width;
 
-                    let formatted_css = malva::format_text(code, malva::Syntax::Css, &malva_config)
-                        .map_or_else(
+                    let formatted_css = format_or_fallback(code, "CSS", path, || {
+                        malva::format_text(code, malva::Syntax::Css, &malva_config).map_or_else(
                             |error| {
                                 debug!(
                                     "Failed to format CSS, falling back to original code. Error: {:?}",
@@ -360,7 +368,8 @@ pub fn format_text(
                                 code.into()
                             },
                             Cow::from,
-                        );
+                        )
+                    });
 
                     // Workaround a bug in malva -> https://github.com/g-plane/malva/issues/44
                     // Tries to keep on formatting style attr on a single line like expected with
@@ -383,6 +392,27 @@ pub fn format_text(
     .map(Some)
 }
 
+/// Run an embedded formatter, falling back to the original `code` if it panics.
+fn format_or_fallback<'a>(
+    code: &'a str,
+    language: &str,
+    path: Option<&Path>,
+    format: impl FnOnce() -> Cow<'a, str> + UnwindSafe,
+) -> Cow<'a, str> {
+    catch_unwind(format).unwrap_or_else(|err| {
+        let location = err
+            .location
+            .map_or_else(String::new, |location| format!(" at {location}"));
+        warn!(
+            "{}: the embedded {language} formatter panicked{location} ({}), leaving that snippet unformatted. Please report it at {}/issues",
+            path.map_or_else(|| "<unknown>".to_string(), relativize_path),
+            err.payload,
+            env!("CARGO_PKG_REPOSITORY"),
+        );
+        Cow::Borrowed(code)
+    })
+}
+
 /// Format the file at the given [`Path`].
 #[tracing::instrument(level="debug", skip_all, fields(path = %path.display()))]
 fn format_path(
@@ -394,7 +424,7 @@ fn format_path(
     let unformatted = std::fs::read_to_string(path)
         .map_err(|err| CommandError::Read(Some(path.to_path_buf()), err))?;
 
-    let formatted = match format_text(&unformatted, &config, profile) {
+    let formatted = match format_text(&unformatted, &config, profile, Some(path)) {
         Ok(f) => f,
         Err(err) => {
             return Err(Box::new(CommandError::Parse(ParseError::new(
@@ -490,6 +520,27 @@ mod tests {
         let io_err = io::Error::other("disk full");
         let err = CommandError::Write(None, io_err);
         assert_eq!(err.to_string(), "Failed to write <unknown>: disk full");
+    }
+
+    #[test]
+    fn format_or_fallback_returns_original_code_on_panic() {
+        let code = "color: red";
+        assert_eq!(
+            format_or_fallback(code, "CSS", None, || panic!("boom")),
+            code
+        );
+    }
+
+    #[test]
+    fn format_command_error_panic_display() {
+        let panic_error = catch_unwind(|| panic!("boom")).unwrap_err();
+        let err = CommandError::Panic(Some(PathBuf::from("a.html")), Box::new(panic_error));
+
+        let full = err.to_string();
+        assert!(full.contains("Panicked while processing a.html"), "{full}");
+        assert!(full.contains("boom"), "{full}");
+        assert!(full.contains("issues/new"), "{full}");
+        assert!(err.concise().contains("a.html: Panicked: boom"));
     }
 
     #[test]

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -56,7 +56,7 @@ fn format_source_code(
         .read_to_string(&mut source)
         .map_err(|err| Box::new(CommandError::Read(path.map(Path::to_path_buf), err)))?;
 
-    let formatted = match format_text(&source, config, profile) {
+    let formatted = match format_text(&source, config, profile, path) {
         Ok(f) => f,
         Err(err) => {
             return Err(Box::new(CommandError::Parse(ParseError::new(

--- a/crates/djangofmt/src/commands/mod.rs
+++ b/crates/djangofmt/src/commands/mod.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::panic::UnwindSafe;
+use std::path::{Path, PathBuf};
 
 use tracing::error;
 
@@ -33,16 +34,29 @@ pub(crate) fn resolve_command(
     })
 }
 
-/// Sort parse errors by path, log each as a report, and return the count.
+/// Run a per-file task, converting a panic into a [`CommandError::Panic`] so the run survives it.
+pub(crate) fn catch_file_panic<T>(
+    path: &Path,
+    f: impl FnOnce() -> std::result::Result<T, Box<CommandError>> + UnwindSafe,
+) -> std::result::Result<T, Box<CommandError>> {
+    crate::panic::catch_unwind(f).unwrap_or_else(|error| {
+        Err(Box::new(CommandError::Panic(
+            Some(path.to_path_buf()),
+            Box::new(error),
+        )))
+    })
+}
+
+/// Sort errors by path, log each as a report, and return the count.
 /// `verb` fills the summary line, e.g. "Couldn't format N files!".
-pub(crate) fn report_parse_errors(
-    mut parse_errors: Vec<CommandError>,
+pub(crate) fn report_errors(
+    mut errors: Vec<CommandError>,
     verb: &str,
     output_format: OutputFormat,
 ) -> usize {
-    parse_errors.sort_unstable_by(|a, b| a.path().cmp(&b.path()));
-    let count = parse_errors.len();
-    for err in parse_errors {
+    errors.sort_unstable_by(|a, b| a.path().cmp(&b.path()));
+    let count = errors.len();
+    for err in errors {
         match output_format {
             OutputFormat::Full => error!("{:?}", miette::Report::new(err)),
             OutputFormat::Concise => error!("{}", err.concise()),

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 use crate::fs::relativize_path;
+use crate::panic::PanicError;
 
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -66,6 +67,15 @@ pub enum CommandError {
     Parse(ParseError),
     #[error("Failed to write {path}: {err}", path = path_display(.0.as_ref()), err = .1)]
     Write(Option<PathBuf>, #[source] io::Error),
+    #[error(
+        "Panicked while processing {path}: This indicates a bug in djangofmt. \
+         If you could open an issue at {repo}/issues/new?title=%5BPanic%5D \
+         with the file contents and the trace below, we'd be very appreciative!\n{err}",
+        path = path_display(.0.as_ref()),
+        repo = env!("CARGO_PKG_REPOSITORY"),
+        err = .1
+    )]
+    Panic(Option<PathBuf>, Box<PanicError>),
 }
 
 impl CommandError {
@@ -73,7 +83,7 @@ impl CommandError {
     pub fn path(&self) -> Option<&Path> {
         match self {
             Self::Parse(err) => err.path.as_deref(),
-            Self::Read(path, _) | Self::Write(path, _) => path.as_deref(),
+            Self::Read(path, _) | Self::Write(path, _) | Self::Panic(path, _) => path.as_deref(),
         }
     }
 
@@ -87,6 +97,11 @@ impl CommandError {
                 format!("{path}:{line}:{column}: {}", err.message)
             }
             Self::Read(..) | Self::Write(..) => self.to_string(),
+            Self::Panic(path, err) => format!(
+                "{path}: Panicked: {payload}",
+                path = path_display(path.as_ref()),
+                payload = err.payload
+            ),
         }
     }
 }

--- a/crates/djangofmt/src/lib.rs
+++ b/crates/djangofmt/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fs;
 pub mod line_width;
 mod logging;
 pub mod options_metadata;
+pub mod panic;
 pub mod per_file_ignores;
 pub mod pyproject;
 pub mod resolver;

--- a/crates/djangofmt/src/panic.rs
+++ b/crates/djangofmt/src/panic.rs
@@ -1,0 +1,100 @@
+use std::any::Any;
+use std::backtrace::BacktraceStatus;
+use std::cell::Cell;
+use std::panic::Location;
+use std::sync::OnceLock;
+
+/// The cause of a panic caught by [`catch_unwind`], with the payload rendered to
+/// a string right away so the error stays `Send + Sync` for miette.
+#[derive(Debug)]
+pub struct PanicError {
+    pub location: Option<String>,
+    pub payload: String,
+    pub backtrace: Option<std::backtrace::Backtrace>,
+}
+
+fn payload_to_string(payload: &(dyn Any + Send)) -> String {
+    payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(ToString::to_string))
+        .unwrap_or_else(|| "Box<dyn Any>".to_string())
+}
+
+impl std::fmt::Display for PanicError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "panicked at")?;
+        if let Some(location) = &self.location {
+            write!(f, " {location}")?;
+        }
+        write!(f, ":\n{payload}", payload = self.payload)?;
+
+        if let Some(backtrace) = &self.backtrace {
+            match backtrace.status() {
+                BacktraceStatus::Disabled => {
+                    writeln!(
+                        f,
+                        "\nrun with `RUST_BACKTRACE=1` environment variable to display a backtrace"
+                    )?;
+                }
+                BacktraceStatus::Captured => {
+                    writeln!(f, "\nBacktrace: {backtrace}")?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CapturedPanicInfo {
+    backtrace: Option<std::backtrace::Backtrace>,
+    location: Option<String>,
+}
+
+thread_local! {
+    static CAPTURE_PANIC_INFO: Cell<bool> = const { Cell::new(false) };
+    static LAST_PANIC_INFO: Cell<CapturedPanicInfo> = const {
+        Cell::new(CapturedPanicInfo { backtrace: None, location: None })
+    };
+}
+
+/// Install the global hook once; threads outside a [`catch_unwind`] call keep the default one.
+fn install_hook() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if !CAPTURE_PANIC_INFO.with(Cell::get) {
+                return (*prev)(info);
+            }
+            LAST_PANIC_INFO.set(CapturedPanicInfo {
+                backtrace: Some(std::backtrace::Backtrace::capture()),
+                location: info.location().map(Location::to_string),
+            });
+        }));
+    });
+}
+
+/// Invoke a closure, capturing the cause of a panic without letting the default hook print it.
+pub fn catch_unwind<F, R>(f: F) -> Result<R, PanicError>
+where
+    F: FnOnce() -> R + std::panic::UnwindSafe,
+{
+    install_hook();
+    let prev_should_capture = CAPTURE_PANIC_INFO.replace(true);
+    let result = std::panic::catch_unwind(f).map_err(|payload| {
+        let CapturedPanicInfo {
+            location,
+            backtrace,
+        } = LAST_PANIC_INFO.take();
+        PanicError {
+            location,
+            payload: payload_to_string(payload.as_ref()),
+            backtrace,
+        }
+    });
+    CAPTURE_PANIC_INFO.set(prev_should_capture);
+    result
+}

--- a/crates/djangofmt/tests/fmt/main.rs
+++ b/crates/djangofmt/tests/fmt/main.rs
@@ -52,12 +52,12 @@ fn build_config(pyproject: &PyprojectSettings) -> FormatterConfig {
 fn run_format_test(path: &Path, input: &str, config: &FormatterConfig) -> String {
     let profile = Profile::Django;
 
-    let output = format_text(input, config, profile)
+    let output = format_text(input, config, profile, Some(path))
         .map_err(|err| format!("failed to format '{}': {:?}", path.display(), err))
         .expect("Failed to format text in test")
         .unwrap_or_else(|| input.to_string());
     // Stability test: format the output again and ensure it's the same
-    let regression_format = format_text(&output, config, profile)
+    let regression_format = format_text(&output, config, profile, Some(path))
         .map_err(|err| {
             format!(
                 "syntax error in stability test '{}': {:?}",

--- a/crates/djangofmt/tests/logging_test.rs
+++ b/crates/djangofmt/tests/logging_test.rs
@@ -22,7 +22,7 @@ invalid-css-property;
     );
     let profile = Profile::Django;
 
-    format_text(input, &config, profile).unwrap();
+    format_text(input, &config, profile, None).unwrap();
     assert!(logs_contain(
         "Failed to format CSS, falling back to original code"
     ));

--- a/crates/djangofmt_benchmark/benches/formatter.rs
+++ b/crates/djangofmt_benchmark/benches/formatter.rs
@@ -25,6 +25,7 @@ fn format_templates(bencher: divan::Bencher, template: &'static TestFile) {
                 divan::black_box(template.code),
                 divan::black_box(&config),
                 divan::black_box(template.profile),
+                None,
             )
             .expect("Formatting to succeed")
         });

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -22,7 +22,7 @@ pub fn format(source: &str, line_length: u16, indent_width: u8, profile: &str) -
         false,
     );
 
-    match format_text(source, &config, profile) {
+    match format_text(source, &config, profile, None) {
         Ok(opt) => opt.unwrap_or_else(|| source.to_string()),
         Err(err) => render_parse_error(source, &err),
     }

--- a/fuzz/fuzz_targets/fmt_idempotency.rs
+++ b/fuzz/fuzz_targets/fmt_idempotency.rs
@@ -22,7 +22,7 @@ static CONFIG: LazyLock<FormatterConfig> = LazyLock::new(|| {
 });
 
 fn do_fuzz_profile(code: &str, profile: Profile) -> Corpus {
-    let formatted = match format_text(code, &CONFIG, profile) {
+    let formatted = match format_text(code, &CONFIG, profile, None) {
         Ok(Some(formatted)) => formatted,
         // Skipped via a djangofmt:ignore directive.
         Ok(None) => return Corpus::Reject,
@@ -33,7 +33,7 @@ fn do_fuzz_profile(code: &str, profile: Profile) -> Corpus {
         }
     };
 
-    match format_text(&formatted, &CONFIG, profile) {
+    match format_text(&formatted, &CONFIG, profile, None) {
         Ok(Some(reformatted)) => {
             similar_asserts::assert_eq!(
                 formatted,


### PR DESCRIPTION
currently a panic in a batch of files fails thje whole run with cryptic messages.

Now it's not and print message pointing to the file causing issue at least