### PR TITLE
chore(deps): Pin `malva` to stop glued CSS numbers growing on every format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd05482a95823ffe421e8a9ba24fa22a6a30d594e2c60455cbb43a41bf2d8fa"
 dependencies = [
  "divan-macros",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -825,6 +825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,11 +901,10 @@ checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 [[package]]
 name = "malva"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed54a855fc80dddeb3518c03d04a2bb06954955297ee514429935149e58eaa75"
+source = "git+https://github.com/UnknownPlatypus/malva?rev=375681ea53921df556517f5fbbfa73d5c1c3900c#375681ea53921df556517f5fbbfa73d5c1c3900c"
 dependencies = [
  "aho-corasick",
- "itertools",
+ "itertools 0.15.0",
  "memchr",
  "raffia",
  "serde",
@@ -911,7 +919,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "css_dataset",
- "itertools",
+ "itertools 0.14.0",
  "memchr",
  "regex",
  "tiny_pretty",
@@ -1117,9 +1125,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raffia"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a589c5611a5f7713bf0c13e949c4c791a359ff517a9f27552475b470e8873229"
+checksum = "0a83eb5987650fcfc3f2e912d3a718f19b8e87c0d980e12e36edf79fa0221d93"
 dependencies = [
  "raffia_macro",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,11 @@ globset = { version = "0.4.18" }
 ignore = { version = "0.4.25" }
 insta = { version = "1.47.2", features = ["filters", "glob", "yaml"] }
 insta-cmd = { version = "0.7.0" }
-malva = { version = "0.16.0", features = ["config_serde"] }
+malva = {
+  git = "https://github.com/UnknownPlatypus/malva",
+  rev = "375681ea53921df556517f5fbbfa73d5c1c3900c",
+  features = ["config_serde"]
+}
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
   rev = "16e8390dbafea9e3ffc74c8a3704a2f019efa77c"

--- a/crates/djangofmt/tests/fmt/malva/css_number_leading_zero.html
+++ b/crates/djangofmt/tests/fmt/malva/css_number_leading_zero.html
@@ -1,0 +1,8 @@
+<style>
+  a {
+    opacity: 0.5;
+    /* a glued typo must survive round-trips instead of growing (c0.1, c00.1, ...) */
+    top: c.1;
+  }
+</style>
+<div style="margin: 0 .5em; scale: c.1">x</div>

--- a/crates/djangofmt/tests/fmt/malva/css_number_leading_zero.snap
+++ b/crates/djangofmt/tests/fmt/malva/css_number_leading_zero.snap
@@ -1,0 +1,11 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<style>
+    a {
+        /* a glued typo must survive round-trips instead of growing (c0.1, c00.1, ...) */
+        top: c.1;
+        opacity: 0.5;
+    }
+</style>
+<div style="margin: 0 0.5em; scale: c.1">x</div>


### PR DESCRIPTION
Fixes this fuzzer found stability issue:

```html
<style>
  a {
    /* a glued typo must survive round-trips instead of growing (c0.1, c00.1, ...) */
    top: c.1;
  }
</style>
```