### PR TITLE
chore(deps): Bump `markup_fmt` to stop script indent growing after a template literal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=5dfcc78156b9d8266d72a200c08c8a1237a7b76c#5dfcc78156b9d8266d72a200c08c8a1237a7b76c"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=73b504ded80d22139e077103d5a8b597b600b2e6#73b504ded80d22139e077103d5a8b597b600b2e6"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=73b504ded80d22139e077103d5a8b597b600b2e6#73b504ded80d22139e077103d5a8b597b600b2e6"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=3ff7f8cfcfd78c08484a6ec09b28f348f5874538#3ff7f8cfcfd78c08484a6ec09b28f348f5874538"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ malva = {
 }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "5dfcc78156b9d8266d72a200c08c8a1237a7b76c"
+  rev = "73b504ded80d22139e077103d5a8b597b600b2e6"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ malva = {
 }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "73b504ded80d22139e077103d5a8b597b600b2e6"
+  rev = "3ff7f8cfcfd78c08484a6ec09b28f348f5874538"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }

--- a/crates/djangofmt/tests/fmt/script_template_literal_indent.html
+++ b/crates/djangofmt/tests/fmt/script_template_literal_indent.html
@@ -1,0 +1,9 @@
+<div>
+    <script>
+        const q = `
+line one
+`;
+
+        let after = 1;
+    </script>
+</div>

--- a/crates/djangofmt/tests/fmt/script_template_literal_indent.snap
+++ b/crates/djangofmt/tests/fmt/script_template_literal_indent.snap
@@ -1,0 +1,12 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<div>
+    <script>
+        const q = `
+line one
+`;
+
+        let after = 1;
+    </script>
+</div>

--- a/python/ecosystem-check/ecosystem_check/defaults.py
+++ b/python/ecosystem-check/ecosystem_check/defaults.py
@@ -360,10 +360,6 @@ DEFAULT_TARGETS = [
                 ExcludeReason.INVALID_SOURCE_HTML: (
                     "netbox/templates/extras/inc/configcontext_data.html",  # Unterminated id attribute
                 ),
-                ExcludeReason.UNSTABLE_FORMATTING: (
-                    # Code after a multiline template literal is re-indented on every pass
-                    "netbox/templates/graphql/graphiql.html",
-                ),
             },
         ),
     ),


### PR DESCRIPTION
Also fix an issue from https://github.com/UnknownPlatypus/djangofmt/pull/466