### PR TITLE
chore(deps): Bump `markup_fmt` to reject prose comments on their first byte

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=35d607085eea6a9c3a549f3a724054ca97da622b#35d607085eea6a9c3a549f3a724054ca97da622b"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=16cfde41dec2aa19645c5c60981a9ad8b274c0f3#16cfde41dec2aa19645c5c60981a9ad8b274c0f3"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ malva = {
 }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "35d607085eea6a9c3a549f3a724054ca97da622b"
+  rev = "16cfde41dec2aa19645c5c60981a9ad8b274c0f3"
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }


### PR DESCRIPTION
Should not change anything for the formater but will help keep good perf for the linter suppression machinery