### PR TITLE
ci(lock): build and test with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           ref: main
           persist-credentials: false
       - name: Build main version
-        run: cargo build -p djangofmt --release --verbose && mv target/release/djangofmt ./main_djangofmt
+        run: cargo build --locked -p djangofmt --release --verbose && mv target/release/djangofmt ./main_djangofmt
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -71,7 +71,7 @@ jobs:
           clean: false
 
       - name: Build PR version
-        run: cargo build -p djangofmt --release --verbose && mv target/release/djangofmt ./pr_djangofmt
+        run: cargo build --locked -p djangofmt --release --verbose && mv target/release/djangofmt ./pr_djangofmt
 
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -165,7 +165,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup component add clippy
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --locked --all-targets --all-features
 
   cargo-shear:
     name: "cargo shear"
@@ -196,7 +196,7 @@ jobs:
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
           tool: cargo-llvm-cov
-      - run: cargo llvm-cov --workspace --exclude djangofmt_dev --all-targets --all-features --fail-under-lines 85
+      - run: cargo llvm-cov --locked --workspace --exclude djangofmt_dev --all-targets --all-features --fail-under-lines 85
 
   msrv_check:
     name: "cargo build (msrv)"
@@ -221,7 +221,7 @@ jobs:
       - name: Build tests with MSRV
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
-        run: cargo "+${MSRV}" test --no-run --workspace --all-targets --all-features
+        run: cargo "+${MSRV}" test --locked --no-run --workspace --all-targets --all-features
 
   docs_check:
     name: "rule docs up to date"
@@ -232,7 +232,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - run: cargo run -p djangofmt_dev -- generate-all
+      - run: cargo run --locked -p djangofmt_dev -- generate-all
       - name: Verify rule docs are up to date
         run: |
           git add --intent-to-add docs/

--- a/.github/workflows/publish-playground-and-docs.yml
+++ b/.github/workflows/publish-playground-and-docs.yml
@@ -71,7 +71,7 @@ jobs:
           # Release runs deploy this build, so they must not read a cache PRs can write.
           enable-cache: ${{ github.event_name == 'pull_request' }}
       - name: Regenerate rule docs and synced pages
-        run: cargo run -p djangofmt_dev -- generate-all
+        run: cargo run --locked -p djangofmt_dev -- generate-all
       - name: Sync docs dependencies
         run: uv sync --group docs --no-install-project
       - name: Build docs site


### PR DESCRIPTION
Only the release builds passed --locked, so a stale Cargo.lock went unnoticed in CI: cargo silently resolved and rewrote it in the runner.