### PR TITLE
ci(lock): set UV_LOCKED in workflows that resolve dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ env:
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/uv
   UV_VERSION: 0.12.6
+  # Fail instead of silently re-resolving when `uv.lock` is out of date.
+  UV_LOCKED: 1
   # Make sure CI fails on all warnings, including Clippy lints
   RUSTFLAGS: "-Dwarnings"
   # Line-tables-only debug info: faster builds, backtraces still work.

--- a/.github/workflows/publish-playground-and-docs.yml
+++ b/.github/workflows/publish-playground-and-docs.yml
@@ -30,6 +30,10 @@ on:
 # Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions: { id-token: write, pages: write }
 
+env:
+  # Fail instead of silently re-resolving when `uv.lock` is out of date.
+  UV_LOCKED: 1
+
 # Scope the concurrency group per PR so simultaneous PR builds don't cancel each other.
 # `main` deploys (and workflow_dispatch / workflow_call runs) share a single `pages-deploy`
 # group, since GitHub Pages itself only accepts one deploy at a time.


### PR DESCRIPTION
`uv sync` and `uv run` silently re-resolve and rewrite `uv.lock` when it is out of date, so CI passed on a lockfile that was never committed.