### PR TITLE
chore(deps): Pin `malva` on raffia 0.12 to stop an OOM on an unclosed CSS `[`

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,9 @@ reviews:
   sequence_diagrams: false
   poem: false
   review_status: false
+  # Snapshots are ignored by default, which makes the reviewer flag fixtures as missing their `.snap`.
+  path_filters:
+    - "**/*.snap"
   tools:
     htmlhint:
       enabled: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd05482a95823ffe421e8a9ba24fa22a6a30d594e2c60455cbb43a41bf2d8fa"
 dependencies = [
  "divan-macros",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -827,15 +827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,10 +894,10 @@ checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 [[package]]
 name = "malva"
 version = "0.16.0"
-source = "git+https://github.com/UnknownPlatypus/malva?rev=375681ea53921df556517f5fbbfa73d5c1c3900c#375681ea53921df556517f5fbbfa73d5c1c3900c"
+source = "git+https://github.com/UnknownPlatypus/malva?rev=1d7b2e48a5cb14810a3e41bd9b9748103d48f20d#1d7b2e48a5cb14810a3e41bd9b9748103d48f20d"
 dependencies = [
  "aho-corasick",
- "itertools 0.15.0",
+ "itertools",
  "memchr",
  "raffia",
  "serde",
@@ -921,7 +912,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "css_dataset",
- "itertools 0.14.0",
+ "itertools",
  "memchr",
  "regex",
  "tiny_pretty",
@@ -1127,9 +1118,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raffia"
-version = "0.13.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a83eb5987650fcfc3f2e912d3a718f19b8e87c0d980e12e36edf79fa0221d93"
+checksum = "a589c5611a5f7713bf0c13e949c4c791a359ff517a9f27552475b470e8873229"
 dependencies = [
  "raffia_macro",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ insta = { version = "1.47.2", features = ["filters", "glob", "yaml"] }
 insta-cmd = { version = "0.7.0" }
 malva = {
   git = "https://github.com/UnknownPlatypus/malva",
-  rev = "375681ea53921df556517f5fbbfa73d5c1c3900c",
+  rev = "1d7b2e48a5cb14810a3e41bd9b9748103d48f20d",
   features = ["config_serde"]
 }
 markup_fmt = {

--- a/crates/djangofmt/tests/fmt/malva/css_unclosed_bracket.html
+++ b/crates/djangofmt/tests/fmt/malva/css_unclosed_bracket.html
@@ -1,0 +1,2 @@
+<!-- raffia 0.13 loops forever on an unclosed `[` at end of input, growing until the process is killed -->
+<div style="a:["></div>

--- a/crates/djangofmt/tests/fmt/malva/css_unclosed_bracket.snap
+++ b/crates/djangofmt/tests/fmt/malva/css_unclosed_bracket.snap
@@ -1,0 +1,5 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<!-- raffia 0.13 loops forever on an unclosed `[` at end of input, growing until the process is killed -->
+<div style="a:["></div>


### PR DESCRIPTION
```html
<!-- raffia 0.13 loops forever on an unclosed `[` at end of input, growing until the process is killed -->
<div style="a:["></div>
```