### PR TITLE
fix(format): Stop reordering CSS shorthands past the longhands they override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 [[package]]
 name = "malva"
 version = "0.16.0"
-source = "git+https://github.com/UnknownPlatypus/malva?rev=1d7b2e48a5cb14810a3e41bd9b9748103d48f20d#1d7b2e48a5cb14810a3e41bd9b9748103d48f20d"
+source = "git+https://github.com/UnknownPlatypus/malva?rev=9a7ee71bfad747490ebe0428d07d1f82467f0c3f#9a7ee71bfad747490ebe0428d07d1f82467f0c3f"
 dependencies = [
  "aho-corasick",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ insta = { version = "1.47.2", features = ["filters", "glob", "yaml"] }
 insta-cmd = { version = "0.7.0" }
 malva = {
   git = "https://github.com/UnknownPlatypus/malva",
-  rev = "1d7b2e48a5cb14810a3e41bd9b9748103d48f20d",
+  rev = "9a7ee71bfad747490ebe0428d07d1f82467f0c3f",
   features = ["config_serde"]
 }
 markup_fmt = {

--- a/crates/djangofmt/tests/fmt/malva/css_declaration_order.html
+++ b/crates/djangofmt/tests/fmt/malva/css_declaration_order.html
@@ -1,0 +1,10 @@
+<style>
+    .a {
+        margin-top: 5px;
+        margin: 0;
+    }
+    .b {
+        color: red;
+        display: block;
+    }
+</style>

--- a/crates/djangofmt/tests/fmt/malva/css_declaration_order.snap
+++ b/crates/djangofmt/tests/fmt/malva/css_declaration_order.snap
@@ -1,0 +1,13 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<style>
+    .a {
+        margin-top: 5px;
+        margin: 0;
+    }
+    .b {
+        display: block;
+        color: red;
+    }
+</style>


### PR DESCRIPTION
Before / after, in a `<style>` block:

```css
/* input */
.a { margin-top: 5px; margin: 0; }
.b { color: red; display: block; }

/* before */                    /* after */
.a {                            .a {
    margin: 0;                      margin-top: 5px;
    margin-top: 5px;                margin: 0;
}                               }
.b {                            .b {
    display: block;                 display: block;
    color: red;                     color: red;
}                               }
```

Sorting still happens (.b); only pairs that would change computed styles keep their source order. Vendor prefixes (-webkit-animation-name vs animation), mixed case (Margin), and all are covered. Same approach as css-declaration-sorter's keepOverrides.

Also fixes a malva panic on <style> blocks mixing 20+ custom and known properties (Rust ≥ 1.81 sort_by total-order check, e.g. Bootstrap's .card), which previously fell back to leaving the block unformatted.