### PR TITLE
refactor(lint): Add `source_span`/`source_end` helpers and derive spans from slices

### DIFF
--- a/.agents/skills/add-lint-rule/SKILL.md
+++ b/.agents/skills/add-lint-rule/SKILL.md
@@ -153,6 +153,7 @@ Reference: `MissingTitle` / `TitleViolation` (`accessibility/missing_title.rs`).
 pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     // Guard: return early if element/attr doesn't match
     // Skip interpolated values with helpers::contains_interpolation()
+    let span = checker.source_span(value_str);
     let mut guard = checker.report_diagnostic(&violation, span);
     // For rules with fixes, attach via the guard before it drops:
     guard.set_fix(Fix::safe_edit(Edit::deletion(span)));
@@ -164,11 +165,11 @@ Key points:
 - The `Checker` is passed as `&Checker<'_>`, **not** `&mut` — diagnostics are buffered through interior mutability (`RefCell`).
 - `checker.report_diagnostic(&violation, span)` returns a `DiagnosticGuard`. On `Drop` the guard pushes the diagnostic into the context's buffer. Hold the guard in a `let mut guard = ...` binding only if you need to attach a fix or override fields; otherwise let the temporary drop immediately.
 - If the rule is **not** gated upfront in `checker.rs` (Step 4), call `checker.report_diagnostic_if_enabled(...)` instead — it returns `Option<DiagnosticGuard>` and short-circuits when disabled.
-- For fixes: build an `Edit` (`Edit::deletion`, `Edit::insertion`, `Edit::replacement`), wrap it with the `Fix` constructor chosen in 1c, then call `guard.set_fix(fix)`.
-- Rules that need the raw source offset of an AST slice use `checker.source_offset(slice)`.
-- **Report the narrowest span that names the problem** — the offending value or attribute, not the whole element. Each failure mode can point at its own slice: `source_offset(value)` for a bad value, `source_offset(attr.name)` for a bad attribute, `source_offset(element.tag_name)` when the element itself is at fault.
+- For fixes: build an `Edit` (`Edit::deletion`, `Edit::insertion`, `Edit::replacement`) and wrap it with `Fix::safe_edit(...)` or `Fix::unsafe_edit(...)`, then call `guard.set_fix(fix)`.
+- **A slice locates itself**: build spans with `checker.source_span(slice)`. `checker.source_offset(slice)` / `checker.source_end(slice)` are its bounds, for range arithmetic such as widening a deletion over surrounding whitespace; the free `span(start, len)` is for offsets no slice provides.
+- **Report the narrowest span that names the problem** — the offending value or attribute, not the whole element. Each failure mode can point at its own slice: `source_span(value)` for a bad value, `source_span(attr.name)` for a bad attribute, `source_span(element.tag_name)` when the element itself is at fault.
 - **Match HTML case-insensitively** — tag names, attribute names, and enumerated values alike: `name.eq_ignore_ascii_case("scope")`, `value.eq_ignore_ascii_case("col")`.
-- For attribute rules, fold the value match into the `let…else` that destructures the attribute rather than unwrapping it in a separate step: `let Attribute::Native(NativeAttribute { name, value: Some((value_str, offset)), .. }) = attr else { continue; };`.
+- For attribute rules, fold the value match into the `let…else` that destructures the attribute rather than unwrapping it in a separate step: `let Attribute::Native(NativeAttribute { name, value: Some((value_str, _)), .. }) = attr else { continue; };` (the paired offset is redundant with `source_span(value_str)`).
 
 The function signature depends on what AST node the rule inspects. Element-level rules take `&Element<'_>`; Jinja block rules take `&JinjaBlock<'_, Node<'_>>`.
 

--- a/crates/djangofmt_lint/src/checker.rs
+++ b/crates/djangofmt_lint/src/checker.rs
@@ -56,6 +56,26 @@ impl<'a> Checker<'a> {
         self.context.source_offset(slice)
     }
 
+    /// The byte offset just past `slice` within the source.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is not fully contained within the source.
+    #[must_use]
+    pub fn source_end(&self, slice: &str) -> usize {
+        self.context.source_end(slice)
+    }
+
+    /// The span of `slice` within the source.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is not fully contained within the source.
+    #[must_use]
+    pub fn source_span(&self, slice: &str) -> SourceSpan {
+        self.context.source_span(slice)
+    }
+
     /// Returns whether the given rule should be checked.
     #[must_use]
     #[inline]

--- a/crates/djangofmt_lint/src/fix/edits.rs
+++ b/crates/djangofmt_lint/src/fix/edits.rs
@@ -2,24 +2,16 @@ use crate::fix::{Edit, Fix};
 use crate::lint_context::LintContext;
 use crate::span;
 
-/// Builds a safe fix that deletes a whole native attribute.
+/// Builds a safe fix that deletes a whole native attribute (e.g. `type="text/javascript"`).
 ///
-/// Removes the attribute's name, `=`, and quoted value, absorbing the leading
-/// whitespace that separates it from the previous token so deleting the only
-/// attribute leaves `<div>` rather than `<div >`.
+/// Removes the full attribute name, `=` and value, absorbing the leading whitespace that
+/// separates it from the previous token to avoid leaving `<div >` for solo attribute and have `<div>` instead.
 ///
-/// `name` is the attribute-name slice; `value_str` and `value_offset` locate the
-/// value in the source; `quoted` indicates whether the value is wrapped in quotes
-/// (so the closing quote is included in the deletion).
-pub fn delete_attr_fix(
-    ctx: &LintContext<'_>,
-    name: &str,
-    value_str: &str,
-    value_offset: usize,
-    quoted: bool,
-) -> Fix {
+/// `name` and `value_str` are the attribute's name and value slices.
+/// `quoted` indicates whether the value is wrapped in quotes (to include it in the deletion).
+pub fn delete_attr_fix(ctx: &LintContext<'_>, name: &str, value_str: &str, quoted: bool) -> Fix {
     let name_start = ctx.source_offset(name);
-    let attr_end = value_offset + value_str.len() + usize::from(quoted);
+    let attr_end = ctx.source_end(value_str) + usize::from(quoted);
     let fix_start = reverse_consume_ws(ctx.source().as_bytes(), name_start);
     Fix::safe_edit(Edit::deletion(span(fix_start, attr_end - fix_start)))
 }

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -68,6 +68,8 @@ pub fn graphical_handler(theme: GraphicalTheme) -> GraphicalReportHandler {
 }
 
 /// Build a [`SourceSpan`] from `usize` byte offsets.
+///
+/// For a span covering a slice of the source, use [`LintContext::source_span`] instead:
 #[must_use]
 pub fn span(start: usize, len: usize) -> SourceSpan {
     SourceSpan::new(clamp_offset(start).into(), clamp_offset(len))

--- a/crates/djangofmt_lint/src/lint_context.rs
+++ b/crates/djangofmt_lint/src/lint_context.rs
@@ -14,6 +14,7 @@ use crate::Settings;
 use crate::fix::Fix;
 use crate::registry::Rule;
 use crate::rule_set::RuleSet;
+use crate::span;
 use crate::suppression;
 use crate::violation::Violation;
 
@@ -94,6 +95,26 @@ impl<'a> LintContext<'a> {
         );
 
         slice_start - src_start
+    }
+
+    /// The byte offset just past `slice` within the source.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is not a subslice of the source.
+    #[must_use]
+    pub fn source_end(&self, slice: &str) -> usize {
+        self.source_offset(slice) + slice.len()
+    }
+
+    /// The span of `slice` within the source.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is not a subslice of the source.
+    #[must_use]
+    pub fn source_span(&self, slice: &str) -> SourceSpan {
+        span(self.source_offset(slice), slice.len())
     }
 
     /// Build a guard for an enabled rule. Returns `None` if the rule is disabled.

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_html_lang.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::Element;
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::declares_native_attr;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `<html>` tags that do not declare a `lang` attribute.
@@ -61,6 +61,5 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         return;
     }
 
-    let offset = checker.source_offset(element.tag_name);
-    checker.report_diagnostic(&MissingHtmlLang, span(offset, element.tag_name.len()));
+    checker.report_diagnostic(&MissingHtmlLang, checker.source_span(element.tag_name));
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_img_alt.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_img_alt.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::Element;
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::declares_native_attr;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `<img>` tags that do not declare an `alt` attribute.
@@ -57,6 +57,5 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         return;
     }
 
-    let offset = checker.source_offset(element.tag_name);
-    checker.report_diagnostic(&MissingImgAlt, span(offset, element.tag_name.len()));
+    checker.report_diagnostic(&MissingImgAlt, checker.source_span(element.tag_name));
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_img_dimensions.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::Element;
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::declares_native_attr;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `<img>` tags that omit the `height` or `width` attribute.
@@ -59,6 +59,5 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         }
     }
 
-    let offset = checker.source_offset(element.tag_name);
-    checker.report_diagnostic(&MissingImgDimensions, span(offset, element.tag_name.len()));
+    checker.report_diagnostic(&MissingImgDimensions, checker.source_span(element.tag_name));
 }

--- a/crates/djangofmt_lint/src/rules/accessibility/missing_title.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/missing_title.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Element, JinjaBlock, JinjaTagOrChildren, Node, NodeKind};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum TitleViolation {
@@ -72,8 +72,10 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         TitleStatus::Absent => TitleViolation::Absent,
     };
 
-    let offset = checker.source_offset(element.tag_name);
-    checker.report_diagnostic(&MissingTitle { kind }, span(offset, element.tag_name.len()));
+    checker.report_diagnostic(
+        &MissingTitle { kind },
+        checker.source_span(element.tag_name),
+    );
 }
 
 /// Outcome of inspecting a `<head>`'s descendants for a `<title>`.

--- a/crates/djangofmt_lint/src/rules/accessibility/table_header_missing_scope.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/table_header_missing_scope.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Attribute, Element};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::{contains_interpolation, declares_native_attr};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// The keywords a `scope` attribute may take (HTML spec / WCAG H63).
 const VALID_SCOPE_VALUES: [&str; 4] = ["row", "col", "rowgroup", "colgroup"];
@@ -103,7 +103,7 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
     };
 
     match scope.value {
-        Some((value, offset)) if !value.is_empty() => {
+        Some((value, _)) if !value.is_empty() => {
             if contains_interpolation(value)
                 || VALID_SCOPE_VALUES
                     .iter()
@@ -117,7 +117,7 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
                         value: value.into(),
                     },
                 },
-                span(offset, value.len()),
+                checker.source_span(value),
             );
         }
         // `scope=""` or a valueless `scope`: present but with no usable value.

--- a/crates/djangofmt_lint/src/rules/accessibility/table_header_missing_scope.rs
+++ b/crates/djangofmt_lint/src/rules/accessibility/table_header_missing_scope.rs
@@ -93,12 +93,11 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         {
             return;
         }
-        let offset = checker.source_offset(element.tag_name);
         checker.report_diagnostic(
             &TableHeaderMissingScope {
                 kind: ScopeViolation::MissingOrEmpty,
             },
-            span(offset, element.tag_name.len()),
+            checker.source_span(element.tag_name),
         );
         return;
     };
@@ -123,12 +122,11 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         }
         // `scope=""` or a valueless `scope`: present but with no usable value.
         _ => {
-            let offset = checker.source_offset(scope.name);
             checker.report_diagnostic(
                 &TableHeaderMissingScope {
                     kind: ScopeViolation::MissingOrEmpty,
                 },
-                span(offset, scope.name.len()),
+                checker.source_span(scope.name),
             );
         }
     }

--- a/crates/djangofmt_lint/src/rules/correctness/duplicate_block_name.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/duplicate_block_name.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for multiple `{% block %}` tags that share the same name within a single template.
@@ -76,8 +76,7 @@ pub fn check(checker: &Checker<'_>) {
     let names = checker.block_names();
     for (i, &name) in names.iter().enumerate() {
         if names[..i].contains(&name) {
-            let offset = checker.source_offset(name);
-            checker.report_diagnostic(&DuplicateBlockName { name }, span(offset, name.len()));
+            checker.report_diagnostic(&DuplicateBlockName { name }, checker.source_span(name));
         }
     }
 }

--- a/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/invalid_attr_value.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Element, NativeAttribute};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::contains_interpolation;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for HTML attributes whose value is not in the set allowed by the
@@ -78,7 +78,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
 
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -102,7 +102,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
                 attribute: "method",
                 allowed,
             },
-            span(*offset, value_str.len()),
+            checker.source_span(value_str),
         );
     }
 }

--- a/crates/djangofmt_lint/src/rules/correctness/untrimmed_blocktranslate.rs
+++ b/crates/djangofmt_lint/src/rules/correctness/untrimmed_blocktranslate.rs
@@ -3,10 +3,10 @@ use std::borrow::Cow;
 use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node};
 use markup_fmt::parser::parse_jinja_tag_name;
 
+use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `{% blocktranslate %}` / `{% blocktrans %}` blocks that omit
@@ -75,16 +75,14 @@ pub fn check(block: &JinjaBlock<'_, Node<'_>>, checker: &Checker<'_>) {
         return;
     }
 
-    let span = span(open_tag.start, open_tag.content.len());
+    let span = checker.source_span(open_tag.content);
     let Some(mut guard) = checker.report_diagnostic_if_enabled(&UntrimmedBlocktranslate, span)
     else {
         return;
     };
 
-    let local_offset = open_tag
-        .content
-        .find(tag_name)
-        .expect("tag_name was extracted from tag.content by parse_jinja_tag_name");
-    let insertion_at = open_tag.start + local_offset + tag_name.len();
-    guard.set_fix(Fix::safe_edit(Edit::insertion(" trimmed", insertion_at)));
+    guard.set_fix(Fix::safe_edit(Edit::insertion(
+        " trimmed",
+        checker.source_end(tag_name),
+    )));
 }

--- a/crates/djangofmt_lint/src/rules/helpers.rs
+++ b/crates/djangofmt_lint/src/rules/helpers.rs
@@ -8,21 +8,15 @@ pub fn contains_interpolation(value: &str) -> bool {
     value.contains("{{") || value.contains("{%")
 }
 
-/// Yields each `srcset` candidate URL with its byte offset in the source.
+/// Yields each `srcset` candidate URL.
 ///
 /// `srcset` holds a comma-separated list of candidates, each `<url> <descriptor>`
 /// (e.g. `a.png 1x, b.png 2x`); the URL is the first whitespace-delimited token of
-/// each candidate. `base` is the byte offset of `value` in the source, so the
-/// yielded offset points at the candidate URL itself.
-pub fn srcset_candidates(value: &str, base: usize) -> impl Iterator<Item = (&str, usize)> {
-    let mut pos = 0;
-    value.split(',').filter_map(move |candidate| {
-        let start = pos;
-        pos += candidate.len() + 1; // skip the candidate and its `,`
-        let trimmed = candidate.trim_start_matches(|c: char| c.is_ascii_whitespace());
-        let url = trimmed.split_ascii_whitespace().next()?;
-        Some((url, base + start + candidate.len() - trimmed.len()))
-    })
+/// each candidate.
+pub fn srcset_candidates(value: &str) -> impl Iterator<Item = &str> {
+    value
+        .split(',')
+        .filter_map(|candidate| candidate.split_ascii_whitespace().next())
 }
 
 /// Returns true if `attr` declares a native HTML attribute named `name`

--- a/crates/djangofmt_lint/src/rules/style/empty_attr_value.rs
+++ b/crates/djangofmt_lint/src/rules/style/empty_attr_value.rs
@@ -2,11 +2,11 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::NativeAttribute;
 
+use crate::Checker;
 use crate::fix::FixAvailability;
 use crate::fix::edits::delete_attr_fix;
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for empty `id` or `class` attribute values on HTML elements.
@@ -49,7 +49,7 @@ impl Violation for EmptyAttrValue<'_> {
 pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         quote,
     } = attr
     else {
@@ -66,14 +66,13 @@ pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
 
     let mut guard = checker.report_diagnostic(
         &EmptyAttrValue { attr: name },
-        span(*offset, value_str.len()),
+        checker.source_span(value_str),
     );
 
     guard.set_fix(delete_attr_fix(
         checker.context(),
         name,
         value_str,
-        *offset,
         quote.is_some(),
     ));
 }

--- a/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
+++ b/crates/djangofmt_lint/src/rules/style/form_action_whitespace.rs
@@ -2,11 +2,11 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::NativeAttribute;
 
+use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::contains_interpolation;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for leading or trailing whitespace in the `action` attribute of `<form>` elements.
@@ -61,7 +61,7 @@ impl Violation for FormActionWhitespace {
 pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -81,7 +81,7 @@ pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
         return;
     }
 
-    let span = span(*offset, value_str.len());
+    let span = checker.source_span(value_str);
     let mut guard = checker.report_diagnostic(&FormActionWhitespace, span);
 
     let edit = if trimmed.is_empty() {

--- a/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
+++ b/crates/djangofmt_lint/src/rules/style/missing_doctype.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 use markup_fmt::ast::{JinjaBlock, JinjaTagOrChildren, Node, NodeKind, Root};
 use markup_fmt::parser::parse_jinja_tag_name;
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for HTML documents that contain an `<html>` tag but no `<!DOCTYPE html>` declaration.
@@ -82,8 +82,7 @@ pub fn check(root: &Root<'_>, checker: &Checker<'_>) {
         return;
     };
 
-    let offset = checker.source_offset(html.tag_name);
-    checker.report_diagnostic(&MissingDoctype, span(offset, html.tag_name.len()));
+    checker.report_diagnostic(&MissingDoctype, checker.source_span(html.tag_name));
 }
 
 /// Returns `true` if the block opens with `{% block %}`, marking the file as a partial.

--- a/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
+++ b/crates/djangofmt_lint/src/rules/style/redundant_type_attr.rs
@@ -2,12 +2,12 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Element, NativeAttribute};
 
+use crate::Checker;
 use crate::fix::FixAvailability;
 use crate::fix::edits::delete_attr_fix;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::contains_interpolation;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for redundant `type` attributes on `<script>` and `<style>` tags.
@@ -77,7 +77,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
 
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         quote,
     } = attr
     else {
@@ -101,14 +101,13 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
             tag: tag.into(),
             type_value: (*value_str).into(),
         },
-        span(*offset, value_str.len()),
+        checker.source_span(value_str),
     );
 
     guard.set_fix(delete_attr_fix(
         checker.context(),
         name,
         value_str,
-        *offset,
         quote.is_some(),
     ));
 }

--- a/crates/djangofmt_lint/src/rules/style/unsorted_tailwind_classes.rs
+++ b/crates/djangofmt_lint/src/rules/style/unsorted_tailwind_classes.rs
@@ -3,10 +3,10 @@ use std::borrow::Cow;
 use markup_fmt::ast::NativeAttribute;
 use rustywind_core::{RustyWind, SourceLanguage};
 
+use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `class` attributes whose Tailwind CSS utility classes are not in the canonical
@@ -56,7 +56,7 @@ impl Violation for UnsortedTailwindClasses {
 // The caller gates this on the `class` attribute name.
 pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
     let NativeAttribute {
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -83,7 +83,7 @@ pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
         return;
     }
 
-    let span = span(*offset, value_str.len());
+    let span = checker.source_span(value_str);
     let mut guard = checker.report_diagnostic(&UnsortedTailwindClasses, span);
     guard.set_fix(Fix::safe_edit(Edit::replacement(sorted.into_owned(), span)));
 }

--- a/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
+++ b/crates/djangofmt_lint/src/rules/style/uppercase_form_method.rs
@@ -2,11 +2,11 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::NativeAttribute;
 
+use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::contains_interpolation;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for non-lowercase `method` attribute values on `<form>` elements.
@@ -59,7 +59,7 @@ impl Violation for UppercaseFormMethod<'_> {
 pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -80,11 +80,11 @@ pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
 
     let mut guard = checker.report_diagnostic(
         &UppercaseFormMethod { value: value_str },
-        span(*offset, value_str.len()),
+        checker.source_span(value_str),
     );
 
     guard.set_fix(Fix::safe_edit(Edit::replacement(
         value_str.to_ascii_lowercase(),
-        span(*offset, value_str.len()),
+        checker.source_span(value_str),
     )));
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_static_url.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Element, NativeAttribute};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::{contains_interpolation, srcset_candidates};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for asset URLs in `<link>`, `<img>`, `<script>`, and `<source>` elements that point at a
@@ -79,7 +79,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
 
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -96,22 +96,21 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
     // `srcset` is a comma-separated candidate list; every other attribute
     // holds a single URL.
     if *canonical == "srcset" {
-        for (url, at) in srcset_candidates(value_str, *offset) {
-            report_static_path(url, at, canonical, checker);
+        for url in srcset_candidates(value_str) {
+            report_static_path(url, canonical, checker);
         }
     } else {
-        report_static_path(value_str, *offset, canonical, checker);
+        report_static_path(value_str, canonical, checker);
     }
 }
 
 /// Reports a URL that points at a hardcoded `static/` path.
-/// `offset` is the byte offset of `url` in the source.
-fn report_static_path(url: &str, offset: usize, attribute: &'static str, checker: &Checker<'_>) {
+fn report_static_path(url: &str, attribute: &'static str, checker: &Checker<'_>) {
     if contains_interpolation(url) {
         return;
     }
     // Browsers strip surrounding ASCII whitespace when resolving URL attributes.
     if starts_with_static_path(url.trim_ascii()) {
-        checker.report_diagnostic(&DjangoStaticUrl { attribute }, span(offset, url.len()));
+        checker.report_diagnostic(&DjangoStaticUrl { attribute }, checker.source_span(url));
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/django_url_pattern.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Element, NativeAttribute};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::contains_interpolation;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for hardcoded internal URLs in HTML link attributes that should use Django's
@@ -76,7 +76,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
     }
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -97,7 +97,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
             &DjangoUrlPattern {
                 attribute: canonical,
             },
-            span(*offset, value_str.len()),
+            checker.source_span(value_str),
         );
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/duplicate_attr.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/duplicate_attr.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Attribute, Element, NativeAttribute};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for the same attribute name appearing more than once on an HTML element.
@@ -66,8 +66,7 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         });
 
         if is_duplicate {
-            let offset = checker.source_offset(name);
-            checker.report_diagnostic(&DuplicateAttr { name }, span(offset, name.len()));
+            checker.report_diagnostic(&DuplicateAttr { name }, checker.source_span(name));
         }
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/empty_tag_pair.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Element, Node, NodeKind};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for non-void elements with no attributes whose open and close tags wrap no content.
@@ -86,11 +86,10 @@ pub fn check(element: &Element<'_>, checker: &Checker<'_>) {
         return;
     }
 
-    let offset = checker.source_offset(element.tag_name);
     checker.report_diagnostic(
         &EmptyTagPair {
             tag: element.tag_name.into(),
         },
-        span(offset, element.tag_name.len()),
+        checker.source_span(element.tag_name),
     );
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/javascript_url.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/javascript_url.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use markup_fmt::ast::{Element, NativeAttribute};
 
+use crate::Checker;
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::contains_interpolation;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `javascript:` URLs in HTML elements.
@@ -77,7 +77,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
     }
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -101,7 +101,7 @@ pub fn check(attr: &NativeAttribute<'_>, element: &Element<'_>, checker: &Checke
             &JavascriptUrl {
                 attribute: canonical,
             },
-            span(*offset, value_str.len()),
+            checker.source_span(value_str),
         );
     }
 }

--- a/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
+++ b/crates/djangofmt_lint/src/rules/suspicious/use_https.rs
@@ -4,11 +4,11 @@ use std::net::IpAddr;
 
 use markup_fmt::ast::NativeAttribute;
 
+use crate::Checker;
 use crate::fix::{Edit, Fix, FixAvailability};
 use crate::registry::{Rule, RuleCategory};
 use crate::rules::helpers::srcset_candidates;
 use crate::violation::{Violation, ViolationMetadata, derive_message_formats};
-use crate::{Checker, span};
 
 /// ## What it does
 /// Checks for `http://` URLs in HTML attributes that load or link external resources.
@@ -69,7 +69,7 @@ const HTTPS_SCHEME: &str = "https://";
 pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
     let NativeAttribute {
         name,
-        value: Some((value_str, offset)),
+        value: Some((value_str, _)),
         ..
     } = attr
     else {
@@ -83,11 +83,11 @@ pub fn check(attr: &NativeAttribute<'_>, checker: &Checker<'_>) {
     // `srcset` is a comma-separated candidate list; every other attribute
     // holds a single URL.
     if canonical == "srcset" {
-        for (url, at) in srcset_candidates(value_str, *offset) {
-            report_http_scheme(url, at, canonical, checker);
+        for url in srcset_candidates(value_str) {
+            report_http_scheme(url, canonical, checker);
         }
     } else {
-        report_http_scheme(value_str, *offset, canonical, checker);
+        report_http_scheme(value_str, canonical, checker);
     }
 }
 
@@ -108,16 +108,15 @@ fn canonical_url_attr(name: &str) -> Option<&'static str> {
 }
 
 /// Reports (and offers a fix for) a URL that uses the insecure `http://` scheme.
-/// `offset` is the byte offset of `url` in the source.
-fn report_http_scheme(url: &str, offset: usize, attribute: &'static str, checker: &Checker<'_>) {
+fn report_http_scheme(url: &str, attribute: &'static str, checker: &Checker<'_>) {
     let trimmed = url.trim_start_matches(|c: char| c.is_ascii_whitespace());
-    let Some(rest) = trimmed.get(HTTP_SCHEME.len()..) else {
+    let Some((scheme, rest)) = trimmed.split_at_checked(HTTP_SCHEME.len()) else {
         return;
     };
-    if !trimmed[..HTTP_SCHEME.len()].eq_ignore_ascii_case(HTTP_SCHEME) || is_local_host(rest) {
+    if !scheme.eq_ignore_ascii_case(HTTP_SCHEME) || is_local_host(rest) {
         return;
     }
-    let scheme_span = span(offset + url.len() - trimmed.len(), HTTP_SCHEME.len());
+    let scheme_span = checker.source_span(scheme);
     let mut guard = checker.report_diagnostic(&UseHttps { attribute }, scheme_span);
     guard.set_fix(Fix::unsafe_edit(Edit::replacement(
         HTTPS_SCHEME,

--- a/crates/djangofmt_lint/src/suppression.rs
+++ b/crates/djangofmt_lint/src/suppression.rs
@@ -68,7 +68,7 @@ fn siblings_after<'n, 's>(
     checker: &Checker<'_>,
 ) -> Option<&'n [Node<'s>]> {
     let start = |node: &Node<'_>| checker.source_offset(node.raw);
-    let end = |node: &Node<'_>| checker.source_offset(node.raw) + node.raw.len();
+    let end = |node: &Node<'_>| checker.source_end(node.raw);
     loop {
         // Siblings are ordered and disjoint: the container is the first one ending past `offset`.
         let index = nodes.partition_point(|node| end(node) <= offset);
@@ -93,7 +93,7 @@ fn guarded_ranges(checker: &Checker<'_>, rest: &[Node<'_>]) -> Option<SmallVec<[
             && !matches!(node.kind, NodeKind::JinjaComment(_) | NodeKind::Comment(_))
     })?;
     let start = checker.source_offset(target.raw);
-    let end = start + target.raw.len();
+    let end = checker.source_end(target.raw);
     let mut ranges = SmallVec::new();
     let mut cursor = start;
     for child in child_slices(target).flatten() {


### PR DESCRIPTION
Mostly enable these nice simplifications and any manual span / end from source computation

```diff
-let offset = checker.source_offset(element.tag_name);
-checker.report_diagnostic(&MissingImgAlt, span(offset, element.tag_name.len()));
+checker.report_diagnostic(&MissingImgAlt, checker.source_span(element.tag_name));
```

