### PR TITLE
test(format): Pin lowercased CSS property names as intended

### DIFF
--- a/crates/djangofmt/tests/fmt/malva/css_property_case.html
+++ b/crates/djangofmt/tests/fmt/malva/css_property_case.html
@@ -1,0 +1,11 @@
+<!-- Lowercasing property names is intentional.
+     The `Margin` Outlook.com email hack doesn't warrant an option, `djangofmt:ignore` covers it. -->
+<style>
+  .a { Margin: 0; margin: 0; }
+  .b {
+    /* djangofmt:ignore */
+    Margin: 0;
+    margin: 0;
+  }
+</style>
+<td style="Margin:0;margin:0">x</td>

--- a/crates/djangofmt/tests/fmt/malva/css_property_case.snap
+++ b/crates/djangofmt/tests/fmt/malva/css_property_case.snap
@@ -1,0 +1,17 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<!-- Lowercasing property names is intentional.
+     The `Margin` Outlook.com email hack doesn't warrant an option, `djangofmt:ignore` covers it. -->
+<style>
+    .a {
+        margin: 0;
+        margin: 0;
+    }
+    .b {
+        /* djangofmt:ignore */
+        Margin: 0;
+        margin: 0;
+    }
+</style>
+<td style="margin: 0; margin: 0">x</td>


### PR DESCRIPTION
## CSS property names are lowercased

Property names in `<style>` blocks and `style` attributes are normalized to lowercase by malva. CSS property names are case-insensitive, so this is a no-op for browsers, but it does undo the `Margin: 0` capitalization hack that HTML emails use to reach Outlook.com.

Where you need the hack, opt the declaration out:

```css
.footer {
    /* djangofmt:ignore */
    Margin: 0;
}
```