### PR TITLE
refactor(lint): Route `check`, `--fix` and the playground through one `lint_text` api

### DIFF
--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -344,17 +344,7 @@ fn check_path(
         fix,
         Some(path),
     ) {
-        Ok(Some(outcome)) => outcome,
-        Ok(None) => {
-            debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
-            return Ok(CheckResult {
-                path: path.to_path_buf(),
-                file_diagnostics: FileDiagnostics::empty(),
-                applied_count: 0,
-                fixes_by_rule: FxHashMap::default(),
-                skipped: true,
-            });
-        }
+        Ok(outcome) => outcome,
         Err(err) => {
             return Err(ParseError::new(
                 Some(path.to_path_buf()),
@@ -364,6 +354,11 @@ fn check_path(
             .into());
         }
     };
+    let skipped = outcome.is_none();
+    if skipped {
+        debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
+    }
+    let outcome = outcome.unwrap_or_default();
 
     if let Some(fixed) = &outcome.fixed {
         fs::write(path, fixed).map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
@@ -384,7 +379,7 @@ fn check_path(
         file_diagnostics,
         applied_count: outcome.applied_count,
         fixes_by_rule: outcome.applied_by_rule,
-        skipped: false,
+        skipped,
     })
 }
 

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -1,7 +1,4 @@
-use djangofmt_lint::{
-    Applicability, FileDiagnostics, FileIgnores, FixerError, RuleFixSummary, Settings, lint_fix,
-    lint_source,
-};
+use djangofmt_lint::{Applicability, FileDiagnostics, RuleFixSummary, Settings, lint_text};
 use markup_fmt::FormatError;
 use miette::{SourceCode, SpanContents};
 use rayon::iter::Either::{Left, Right};
@@ -16,7 +13,7 @@ use tracing::{debug, error, info, warn};
 use crate::ExitStatus;
 use crate::args::{CheckCommand, OutputFormat, Profile};
 use crate::config::{resolve_bool_arg, resolve_profile, resolve_rule_selection};
-use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
+use crate::error::{CommandError, ParseError, Result};
 use crate::fs::relativize_path;
 use crate::per_file_ignores::PerFileIgnores;
 use crate::pyproject::LintSettings;
@@ -125,6 +122,8 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
     } else {
         Applicability::Safe
     };
+    // One value carries both "should we fix" and "how far", so they can't disagree.
+    let fix = config.fix.then_some(threshold);
 
     // Same custom blocks as `format`, so both commands lint/format the same AST.
     let custom_blocks = merge_custom_blocks(
@@ -149,15 +148,8 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
                 resolved.pyproject.profile,
                 Some(path),
             );
-            super::catch_file_panic(path, || {
-                check_path(
-                    path,
-                    profile,
-                    settings,
-                    &custom_blocks,
-                    config.fix,
-                    threshold,
-                )
+            super::catch_file_panic(Some(path), || {
+                check_path(path, profile, settings, &custom_blocks, fix)
             })
         })
         .partition_map(|result| match result {
@@ -339,105 +331,61 @@ fn check_path(
     profile: Profile,
     settings: &Settings,
     custom_blocks: &[String],
-    fix: bool,
-    threshold: Applicability,
+    fix: Option<Applicability>,
 ) -> std::result::Result<CheckResult, Box<CommandError>> {
     let source = fs::read_to_string(path)
         .map_err(|err| CommandError::Read(Some(path.to_path_buf()), err))?;
 
-    if fix {
-        match lint_fix(
-            &source,
-            settings,
-            profile.into(),
-            custom_blocks,
-            threshold,
-            Some(path),
-        ) {
-            Ok(result) => {
-                if result.applied_count > 0 && result.source != source {
-                    fs::write(path, &result.source)
-                        .map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
-                }
-
-                let file_diagnostics = if result.remaining_diagnostics.is_empty() {
-                    FileDiagnostics::empty()
-                } else {
-                    FileDiagnostics::new(
-                        relativize_path(path),
-                        result.source,
-                        result.remaining_diagnostics,
-                    )
-                };
-
-                return Ok(CheckResult {
-                    path: path.to_path_buf(),
-                    file_diagnostics,
-                    applied_count: result.applied_count,
-                    fixes_by_rule: result.applied_by_rule,
-                    skipped: false,
-                });
-            }
-            Err(FixerError::InitialParse(err)) => {
-                return parse_failure(path, source, err);
-            }
-            Err(FixerError::SyntaxRegression {
-                iteration,
-                error: _,
-            }) => {
-                error!(
-                    "Fix introduced a syntax error in {} at iteration {iteration}, leaving file unchanged",
-                    path.display()
-                );
-                // Fall through and lint the unchanged source.
-            }
+    let outcome = match lint_text(
+        &source,
+        settings,
+        profile.into(),
+        custom_blocks,
+        fix,
+        Some(path),
+    ) {
+        Ok(Some(outcome)) => outcome,
+        Ok(None) => {
+            debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
+            return Ok(CheckResult {
+                path: path.to_path_buf(),
+                file_diagnostics: FileDiagnostics::empty(),
+                applied_count: 0,
+                fixes_by_rule: FxHashMap::default(),
+                skipped: true,
+            });
         }
+        Err(err) => {
+            return Err(ParseError::new(
+                Some(path.to_path_buf()),
+                source,
+                &FormatError::Syntax(err),
+            )
+            .into());
+        }
+    };
+
+    if let Some(fixed) = &outcome.fixed {
+        fs::write(path, fixed).map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
     }
 
-    let diagnostics =
-        match lint_source(&source, profile.into(), custom_blocks, settings, Some(path)) {
-            Ok(diagnostics) => diagnostics,
-            Err(err) => {
-                return parse_failure(path, source, err);
-            }
-        };
-    let file_diagnostics = if diagnostics.is_empty() {
+    let file_diagnostics = if outcome.diagnostics.is_empty() {
         FileDiagnostics::empty()
     } else {
-        FileDiagnostics::new(relativize_path(path), source, diagnostics)
+        FileDiagnostics::new(
+            relativize_path(path),
+            outcome.fixed.unwrap_or(source),
+            outcome.diagnostics,
+        )
     };
 
     Ok(CheckResult {
         path: path.to_path_buf(),
         file_diagnostics,
-        applied_count: 0,
-        fixes_by_rule: FxHashMap::default(),
+        applied_count: outcome.applied_count,
+        fixes_by_rule: outcome.applied_by_rule,
         skipped: false,
     })
-}
-
-/// Skip the file if it is quarantined with `file-ignore[invalid-syntax]`,
-/// otherwise report the error with a hint at the escape hatches.
-fn parse_failure(
-    path: &Path,
-    source: String,
-    err: markup_fmt::SyntaxError,
-) -> std::result::Result<CheckResult, Box<CommandError>> {
-    if FileIgnores::parse(&source).invalid_syntax {
-        debug!("Skipping {} (file-ignore[invalid-syntax])", path.display());
-        return Ok(CheckResult {
-            path: path.to_path_buf(),
-            file_diagnostics: FileDiagnostics::empty(),
-            applied_count: 0,
-            fixes_by_rule: FxHashMap::default(),
-            skipped: true,
-        });
-    }
-    Err(
-        ParseError::new(Some(path.to_path_buf()), source, &FormatError::Syntax(err))
-            .with_fallback_hint(SKIP_FILE_HINT)
-            .into(),
-    )
 }
 
 #[cfg(test)]

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -13,7 +13,7 @@ use crate::ExitStatus;
 use crate::args::{FormatCommand, OutputFormat, Profile};
 use crate::config::{resolve_bool_arg, resolve_profile};
 use crate::editorconfig::{self, EditorconfigSettings};
-use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
+use crate::error::{CommandError, ParseError, Result};
 use crate::fs::relativize_path;
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 use crate::panic::catch_unwind;
@@ -282,7 +282,7 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
     let (results, errors): (Vec<_>, Vec<_>) = resolved
         .files
         .par_iter()
-        .map(|entry| super::catch_file_panic(entry, || format_path(entry, &context)))
+        .map(|entry| super::catch_file_panic(Some(entry), || format_path(entry, &context)))
         .partition_map(|result| match result {
             Ok(fmt_res) => Left(fmt_res),
             Err(err) => Right(*err),
@@ -458,9 +458,7 @@ fn format_path(
     let formatted = match format_text(&unformatted, &config, profile, Some(path)) {
         Ok(f) => f,
         Err(err) => {
-            return Err(ParseError::new(Some(path.to_path_buf()), unformatted, &err)
-                .with_fallback_hint(SKIP_FILE_HINT)
-                .into());
+            return Err(ParseError::new(Some(path.to_path_buf()), unformatted, &err).into());
         }
     };
 

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -8,7 +8,7 @@ use crate::args::{FormatCommand, Profile};
 use crate::commands::format::{FormatterConfig, format_text};
 use crate::config::resolve_profile;
 use crate::editorconfig;
-use crate::error::{CommandError, ParseError, Result, SKIP_FILE_HINT};
+use crate::error::{CommandError, ParseError, Result};
 use crate::pyproject::load_pyproject_from_cwd;
 use crate::resolver::{ResolvedDiscoveryConfig, is_force_excluded};
 
@@ -36,7 +36,9 @@ pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
     );
     let config = FormatterConfig::from_args(cli, &pyproject, &settings);
 
-    match format_source_code(stdin_filename, &config, profile) {
+    match super::catch_file_panic(stdin_filename, || {
+        format_source_code(stdin_filename, &config, profile)
+    }) {
         Ok(()) => Ok(ExitStatus::Success),
         Err(err) => {
             error!("{:?}", miette::Report::new(*err));
@@ -59,9 +61,7 @@ fn format_source_code(
     let formatted = match format_text(&source, config, profile, path) {
         Ok(f) => f,
         Err(err) => {
-            return Err(ParseError::new(path.map(Path::to_path_buf), source, &err)
-                .with_fallback_hint(SKIP_FILE_HINT)
-                .into());
+            return Err(ParseError::new(path.map(Path::to_path_buf), source, &err).into());
         }
     };
 

--- a/crates/djangofmt/src/commands/mod.rs
+++ b/crates/djangofmt/src/commands/mod.rs
@@ -35,13 +35,15 @@ pub(crate) fn resolve_command(
 }
 
 /// Run a per-file task, converting a panic into a [`CommandError::Panic`] so the run survives it.
+///
+/// `path` is [`None`] for a source with no backing file, such as stdin.
 pub(crate) fn catch_file_panic<T>(
-    path: &Path,
+    path: Option<&Path>,
     f: impl FnOnce() -> std::result::Result<T, Box<CommandError>> + UnwindSafe,
 ) -> std::result::Result<T, Box<CommandError>> {
     crate::panic::catch_unwind(f).unwrap_or_else(|error| {
         Err(Box::new(CommandError::Panic(
-            Some(path.to_path_buf()),
+            path.map(Path::to_path_buf),
             Box::new(error),
         )))
     })

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -159,15 +159,9 @@ impl ParseError {
             message,
             src: NamedSource::new(name, source),
             span,
-            hint,
+            // Every parse error offers a way out, unless the kind had something better to say.
+            hint: hint.or_else(|| Some(SKIP_FILE_HINT.to_string())),
         }
-    }
-
-    /// Help text used only when the error carries no more specific hint.
-    #[must_use]
-    pub fn with_fallback_hint(mut self, hint: &str) -> Self {
-        self.hint.get_or_insert_with(|| hint.to_string());
-        self
     }
 
     /// 1-based line and column the error points at.

--- a/crates/djangofmt/src/error.rs
+++ b/crates/djangofmt/src/error.rs
@@ -54,7 +54,7 @@ pub struct ParseError {
     #[label("here")]
     span: SourceSpan,
     #[help]
-    hint: Option<String>,
+    hint: String,
 }
 
 /// An error that can occur while processing a file in a command (format or check).
@@ -160,7 +160,7 @@ impl ParseError {
             src: NamedSource::new(name, source),
             span,
             // Every parse error offers a way out, unless the kind had something better to say.
-            hint: hint.or_else(|| Some(SKIP_FILE_HINT.to_string())),
+            hint: hint.unwrap_or_else(|| SKIP_FILE_HINT.to_string()),
         }
     }
 

--- a/crates/djangofmt/tests/parse_error/malformed_attribute.snap
+++ b/crates/djangofmt/tests/parse_error/malformed_attribute.snap
@@ -9,3 +9,4 @@ source: crates/djangofmt/tests/parse_error/main.rs
    ·                      ╰── here
  2 │     <p>Malformed attribute with missing value</p>
    ╰────
+  help: Add `{# djangofmt: file-ignore[invalid-syntax] #}` at the top of this file, or list it in `extend-exclude`, to skip it.

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -227,7 +227,7 @@ pub fn lint_source(
 }
 
 /// A completed [`lint_text`] run.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct LintOutcome {
     /// The rewritten source, set only when fixes changed it: write exactly when this is [`Some`].
     pub fixed: Option<String>,
@@ -241,9 +241,8 @@ pub struct LintOutcome {
 
 /// Lint `source`, applying fixes up to the given threshold when `fix` is [`Some`].
 ///
-/// Returns [`None`] when a leading `file-ignore[invalid-syntax]` comment quarantines a file that
-/// does not parse, mirroring the skip signal of the formatter's own door. A fix that breaks
-/// previously valid syntax is reported and the untouched source linted instead.
+/// Returns [`None`] when a leading `file-ignore[invalid-syntax]` comment quarantines a file
+/// that does not parse, like the formatter's `format_text`.
 pub fn lint_text(
     source: &str,
     settings: &Settings,
@@ -252,103 +251,56 @@ pub fn lint_text(
     fix: Option<Applicability>,
     path: Option<&Path>,
 ) -> Result<Option<LintOutcome>, SyntaxError> {
-    if let Some(threshold) = fix {
-        match lint_fix(source, settings, language, custom_blocks, threshold, path) {
-            Ok(result) => {
-                return Ok(Some(LintOutcome {
-                    fixed: (result.source != source).then_some(result.source),
-                    diagnostics: result.remaining_diagnostics,
-                    applied_count: result.applied_count,
-                    applied_by_rule: result.applied_by_rule,
-                }));
+    let check_only = || {
+        lint_source(source, language, custom_blocks, settings, path).map(|diagnostics| {
+            LintOutcome {
+                diagnostics,
+                ..LintOutcome::default()
             }
-            Err(FixerError::InitialParse(err)) => return quarantined_or_error(source, err),
-            Err(FixerError::SyntaxRegression { iteration, .. }) => {
-                tracing::error!(
-                    "Fix introduced a syntax error in {} at iteration {iteration}, leaving file unchanged",
-                    path.unwrap_or_else(|| Path::new("<source>")).display()
-                );
-                // Fall through and lint the unchanged source.
-            }
+        })
+    };
+    let result = match fix
+        .map(|threshold| lint_fix(source, settings, language, custom_blocks, threshold, path))
+    {
+        Some(Ok(result)) => Ok(LintOutcome {
+            // The compare is skipped when nothing was applied: `source` is then a plain clone.
+            fixed: (result.applied_count > 0 && result.source != source).then_some(result.source),
+            diagnostics: result.remaining_diagnostics,
+            applied_count: result.applied_count,
+            applied_by_rule: result.applied_by_rule,
+        }),
+        Some(Err(FixerError::InitialParse(err))) => Err(err),
+        Some(Err(FixerError::SyntaxRegression { iteration, .. })) => {
+            tracing::error!(
+                "Fix introduced a syntax error in {} at iteration {iteration}, leaving file unchanged",
+                path.unwrap_or_else(|| Path::new("<source>")).display()
+            );
+            check_only()
         }
-    }
-
-    match lint_source(source, language, custom_blocks, settings, path) {
-        Ok(diagnostics) => Ok(Some(LintOutcome {
-            fixed: None,
-            diagnostics,
-            applied_count: 0,
-            applied_by_rule: FxHashMap::default(),
-        })),
-        Err(err) => quarantined_or_error(source, err),
-    }
-}
-
-/// `file-ignore[invalid-syntax]` turns a file that cannot be parsed into a skip, not an error.
-fn quarantined_or_error(
-    source: &str,
-    err: SyntaxError,
-) -> Result<Option<LintOutcome>, SyntaxError> {
-    if FileIgnores::parse(source).invalid_syntax {
-        Ok(None)
-    } else {
-        Err(err)
+        None => check_only(),
+    };
+    match result {
+        // `file-ignore[invalid-syntax]` quarantines the file instead of reporting.
+        Err(_) if FileIgnores::parse(source).invalid_syntax => Ok(None),
+        other => other.map(Some),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::registry::Rule;
-
-    const UNCLOSED: &str = "<div>";
-    const BOTH_MODES: [Option<Applicability>; 2] = [None, Some(Applicability::Safe)];
-
-    fn only(rule: Rule) -> Settings {
-        Settings {
-            rules: RuleSet::from_rule(rule),
-            ..Settings::default()
-        }
-    }
-
-    fn lint(source: &str, settings: &Settings, fix: Option<Applicability>) -> Option<LintOutcome> {
-        lint_text(source, settings, Language::Jinja, &[], fix, None)
-            .expect("source parses or is quarantined")
-    }
 
     #[test]
     fn quarantine_covers_check_and_fix() {
         let settings = Settings::all();
-        let quarantined = format!("{{# djangofmt: file-ignore[invalid-syntax] #}}\n{UNCLOSED}");
-
-        for fix in BOTH_MODES {
+        let quarantined = "{# djangofmt: file-ignore[invalid-syntax] #}\n<div>";
+        for fix in [None, Some(Applicability::Safe)] {
+            let lint = |source| lint_text(source, &settings, Language::Jinja, &[], fix, None);
             assert!(
-                lint(&quarantined, &settings, fix).is_none(),
-                "opted-out file should be skipped (fix={fix:?})"
+                lint(quarantined).is_ok_and(|outcome| outcome.is_none()),
+                "{fix:?}"
             );
-            assert!(
-                lint_text(UNCLOSED, &settings, Language::Jinja, &[], fix, None).is_err(),
-                "unparsable file without the opt-out should error (fix={fix:?})"
-            );
+            assert!(lint("<div>").is_err(), "{fix:?}");
         }
-    }
-
-    #[test]
-    fn fixed_source_is_set_only_when_it_changed() {
-        let settings = only(Rule::UppercaseFormMethod);
-        let source = r#"<form method="POST"></form>"#;
-
-        let fixed = lint(source, &settings, Some(Applicability::Safe)).expect("not quarantined");
-        assert_eq!(fixed.applied_count, 1);
-        assert_eq!(
-            fixed.fixed.as_deref(),
-            Some(r#"<form method="post"></form>"#)
-        );
-        assert!(fixed.diagnostics.is_empty());
-
-        let checked = lint(source, &settings, None).expect("not quarantined");
-        assert_eq!(checked.applied_count, 0);
-        assert_eq!(checked.fixed, None, "nothing to write in check mode");
-        assert_eq!(checked.diagnostics.len(), 1);
     }
 }

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -46,6 +46,7 @@ use markup_fmt::ast::Root;
 use markup_fmt::parser::Parser;
 use markup_fmt::{Language, SyntaxError};
 use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme, NamedSource, Report, SourceSpan};
+use rustc_hash::FxHashMap;
 use std::fmt;
 use std::sync::{Arc, LazyLock};
 
@@ -223,4 +224,131 @@ pub fn lint_source(
 ) -> Result<Vec<LintDiagnostic>, SyntaxError> {
     let ast = parse(source, language, custom_blocks)?;
     Ok(check_ast(source, &ast, settings, path))
+}
+
+/// A completed [`lint_text`] run.
+#[derive(Debug)]
+pub struct LintOutcome {
+    /// The rewritten source, set only when fixes changed it: write exactly when this is [`Some`].
+    pub fixed: Option<String>,
+    /// Diagnostics left over, span-aligned to [`Self::fixed`] when there is one.
+    pub diagnostics: Vec<LintDiagnostic>,
+    /// Fixes applied.
+    pub applied_count: usize,
+    /// Per-rule applied summaries, for `--show-fixes`.
+    pub applied_by_rule: FxHashMap<&'static str, RuleFixSummary>,
+}
+
+/// Lint `source`, applying fixes up to the given threshold when `fix` is [`Some`].
+///
+/// Returns [`None`] when a leading `file-ignore[invalid-syntax]` comment quarantines a file that
+/// does not parse, mirroring the skip signal of the formatter's own door. A fix that breaks
+/// previously valid syntax is reported and the untouched source linted instead.
+pub fn lint_text(
+    source: &str,
+    settings: &Settings,
+    language: Language,
+    custom_blocks: &[String],
+    fix: Option<Applicability>,
+    path: Option<&Path>,
+) -> Result<Option<LintOutcome>, SyntaxError> {
+    if let Some(threshold) = fix {
+        match lint_fix(source, settings, language, custom_blocks, threshold, path) {
+            Ok(result) => {
+                return Ok(Some(LintOutcome {
+                    fixed: (result.source != source).then_some(result.source),
+                    diagnostics: result.remaining_diagnostics,
+                    applied_count: result.applied_count,
+                    applied_by_rule: result.applied_by_rule,
+                }));
+            }
+            Err(FixerError::InitialParse(err)) => return quarantined_or_error(source, err),
+            Err(FixerError::SyntaxRegression { iteration, .. }) => {
+                tracing::error!(
+                    "Fix introduced a syntax error in {} at iteration {iteration}, leaving file unchanged",
+                    path.unwrap_or_else(|| Path::new("<source>")).display()
+                );
+                // Fall through and lint the unchanged source.
+            }
+        }
+    }
+
+    match lint_source(source, language, custom_blocks, settings, path) {
+        Ok(diagnostics) => Ok(Some(LintOutcome {
+            fixed: None,
+            diagnostics,
+            applied_count: 0,
+            applied_by_rule: FxHashMap::default(),
+        })),
+        Err(err) => quarantined_or_error(source, err),
+    }
+}
+
+/// `file-ignore[invalid-syntax]` turns a file that cannot be parsed into a skip, not an error.
+fn quarantined_or_error(
+    source: &str,
+    err: SyntaxError,
+) -> Result<Option<LintOutcome>, SyntaxError> {
+    if FileIgnores::parse(source).invalid_syntax {
+        Ok(None)
+    } else {
+        Err(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::Rule;
+
+    const UNCLOSED: &str = "<div>";
+    const BOTH_MODES: [Option<Applicability>; 2] = [None, Some(Applicability::Safe)];
+
+    fn only(rule: Rule) -> Settings {
+        Settings {
+            rules: RuleSet::from_rule(rule),
+            ..Settings::default()
+        }
+    }
+
+    fn lint(source: &str, settings: &Settings, fix: Option<Applicability>) -> Option<LintOutcome> {
+        lint_text(source, settings, Language::Jinja, &[], fix, None)
+            .expect("source parses or is quarantined")
+    }
+
+    #[test]
+    fn quarantine_covers_check_and_fix() {
+        let settings = Settings::all();
+        let quarantined = format!("{{# djangofmt: file-ignore[invalid-syntax] #}}\n{UNCLOSED}");
+
+        for fix in BOTH_MODES {
+            assert!(
+                lint(&quarantined, &settings, fix).is_none(),
+                "opted-out file should be skipped (fix={fix:?})"
+            );
+            assert!(
+                lint_text(UNCLOSED, &settings, Language::Jinja, &[], fix, None).is_err(),
+                "unparsable file without the opt-out should error (fix={fix:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_source_is_set_only_when_it_changed() {
+        let settings = only(Rule::UppercaseFormMethod);
+        let source = r#"<form method="POST"></form>"#;
+
+        let fixed = lint(source, &settings, Some(Applicability::Safe)).expect("not quarantined");
+        assert_eq!(fixed.applied_count, 1);
+        assert_eq!(
+            fixed.fixed.as_deref(),
+            Some(r#"<form method="post"></form>"#)
+        );
+        assert!(fixed.diagnostics.is_empty());
+
+        let checked = lint(source, &settings, None).expect("not quarantined");
+        assert_eq!(checked.applied_count, 0);
+        assert_eq!(checked.fixed, None, "nothing to write in check mode");
+        assert_eq!(checked.diagnostics.len(), 1);
+    }
 }

--- a/crates/djangofmt_wasm/src/lib.rs
+++ b/crates/djangofmt_wasm/src/lib.rs
@@ -2,7 +2,7 @@ use djangofmt::args::Profile;
 use djangofmt::commands::format::{FormatterConfig, format_text};
 use djangofmt::error::ParseError;
 use djangofmt::line_width::{IndentWidth, LineLength, SelfClosing};
-use djangofmt_lint::{FileDiagnostics, FileIgnores, Settings, graphical_handler, lint_source};
+use djangofmt_lint::{FileDiagnostics, Settings, graphical_handler, lint_text};
 use miette::GraphicalTheme;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -186,25 +186,23 @@ pub fn lint(source: &str, profile: &str) -> Result<JsValue, JsError> {
 
 fn lint_inner(source: &str, profile: &str) -> Result<LintResult, JsError> {
     let profile = get_profile(profile);
-    let diagnostics = match lint_source(source, profile.into(), &[], &Settings::all(), None) {
-        Ok(diagnostics) => diagnostics,
+    let outcome = match lint_text(source, &Settings::all(), profile.into(), &[], None, None) {
+        Ok(Some(outcome)) => outcome,
+        // A leading `file-ignore[invalid-syntax]` quarantines the file.
+        Ok(None) => return Ok(LintResult::new(0, String::new())),
         Err(e) => {
-            // Match the CLI: `file-ignore[invalid-syntax]` skips the file.
-            if FileIgnores::parse(source).invalid_syntax {
-                return Ok(LintResult::new(0, String::new()));
-            }
             let err = markup_fmt::FormatError::Syntax(e);
             return Ok(LintResult::new(1, render_parse_error(source, &err)));
         }
     };
-    let error_count = diagnostics.len();
+    let error_count = outcome.diagnostics.len();
 
     if error_count == 0 {
         let result = LintResult::new(0, String::new());
         return Ok(result);
     }
 
-    let file_diagnostics = FileDiagnostics::new("", source, diagnostics);
+    let file_diagnostics = FileDiagnostics::new("", source, outcome.diagnostics);
     let handler = graphical_handler(GraphicalTheme::unicode());
     let mut output = String::new();
     file_diagnostics


### PR DESCRIPTION
`format_text` already owns the formatter's file-level decisions (skip on `file-ignore`, quarantine unparsable files). 

The lint side had that logic copied into `check_path` and the wasm playground. 

This adds `lint_text` to `djangofmt_lint` as the matching door:
- one call handles check vs fix
- the syntax-regression fallback and the `file-ignore[invalid-syntax]` quarantine,
- and returns exactly what the caller must write.

Also folds the "skip this file" hint into `ParseError::new` so every parse error carries it, and lets `catch_file_panic` cover stdin.

No behavior change.