### PR TITLE
feat(cli): Add `--target-version` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ html-void-self-closing = "never"
 preserve-unquoted-attrs = false
 ```
 
+Lint rules, used by the `djangofmt check` command, are configured in the nested `[tool.djangofmt.lint]` section:
+
+```toml
+[tool.djangofmt.lint]
+select = ["category:all"]
+ignore = ["category:style"]
+preview = true
+target-version = "5.2"
+fix = true
+
+[tool.djangofmt.lint.per-file-ignores]
+"templates/admin/*.html" = ["missing-img-alt"]
+```
+
+`target-version` is the Django version your templates target. While it is unset, the rules that depend on it stay disabled.
+See [Lint rules](https://unknownplatypus.github.io/djangofmt/docs/rules/) for the available rule names and categories.
+
 Djangofmt looks for a `pyproject.toml` file by traversing directories upward from the current working directory.
 The first `pyproject.toml` found is used. If no file is found or the file doesn't contain a `[tool.djangofmt]` section, defaults are used.
 

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -5,7 +5,7 @@ use clap::builder::styling::{AnsiColor, Effects};
 use serde::Deserialize;
 use std::path::PathBuf;
 
-use djangofmt_lint::RuleSelector;
+use djangofmt_lint::{DjangoVersion, RuleSelector};
 use markup_fmt::Language;
 
 /// All configuration options that can be passed "globally",
@@ -80,7 +80,7 @@ pub struct FileSelectionArgs {
     pub no_force_exclude: bool,
 }
 
-/// CLI arguments controlling how templates are parsed, shared by `format` and `check`.
+/// CLI arguments describing the templates being processed, shared by `format` and `check`.
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct TemplateArgs {
     /// Template language profile to use [default: django]
@@ -240,6 +240,9 @@ pub struct CheckCommand {
     pub show_fixes: bool,
     #[arg(long, overrides_with("show_fixes"), hide = true)]
     pub no_show_fixes: bool,
+    /// The Django version the templates target, as major.minor (e.g. 5.2)
+    #[arg(long, value_name = "VERSION")]
+    pub target_version: Option<DjangoVersion>,
     #[clap(flatten)]
     pub rule_selection: RuleSelectionArgs,
     #[clap(flatten)]
@@ -398,6 +401,20 @@ mod tests {
 
         For more information, try '--help'.
         ");
+    }
+
+    #[test]
+    fn test_cli_invalid_target_version() {
+        assert_cmd_snapshot!(cli().args(["check", "--target-version", "5", "test.html"]), @r#"
+        success: false
+        exit_code: 2
+        ----- stdout -----
+
+        ----- stderr -----
+        error: invalid value '5' for '--target-version <VERSION>': target-version must be a `major.minor` version (got `5`)
+
+        For more information, try '--help'.
+        "#);
     }
 
     #[test]

--- a/crates/djangofmt/src/commands/check.rs
+++ b/crates/djangofmt/src/commands/check.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::ExitStatus;
 use crate::args::{CheckCommand, OutputFormat, Profile};
-use crate::config::{resolve_bool_arg, resolve_profile, resolve_rule_selection};
+use crate::config::{resolve_bool_arg, resolve_lint_configuration, resolve_profile};
 use crate::error::{CommandError, ParseError, Result};
 use crate::fs::relativize_path;
 use crate::per_file_ignores::PerFileIgnores;
@@ -107,7 +107,7 @@ pub fn check(args: &CheckCommand) -> Result<ExitStatus> {
     let lint = resolved.pyproject.lint.as_ref();
     let config = CheckConfig::from_args(args, lint);
 
-    let (settings, warnings) = resolve_rule_selection(&args.rule_selection, lint).into_settings();
+    let (settings, warnings) = resolve_lint_configuration(args, lint).into_settings();
     for warning in &warnings {
         warn!("{warning}");
     }

--- a/crates/djangofmt/src/config.rs
+++ b/crates/djangofmt/src/config.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use djangofmt_lint::LintConfiguration;
 
-use crate::args::{Profile, RuleSelectionArgs};
+use crate::args::{CheckCommand, Profile};
 use crate::pyproject::{LintSettings, UnsortedTailwindClassesOptions};
 
 /// Collapse a `--flag` / `--no-flag` pair into an optional bool.
@@ -36,12 +36,13 @@ pub fn resolve_profile(
         .unwrap_or_default()
 }
 
-/// Merge CLI rule-selection flags with `[tool.djangofmt.lint]` into a [`LintConfiguration`].
+/// Merge the CLI lint flags with `[tool.djangofmt.lint]` into a [`LintConfiguration`].
 #[must_use]
-pub fn resolve_rule_selection(
-    cli: &RuleSelectionArgs,
+pub fn resolve_lint_configuration(
+    args: &CheckCommand,
     lint: Option<&LintSettings>,
 ) -> LintConfiguration {
+    let cli = &args.rule_selection;
     let select = cli
         .select
         .clone()
@@ -54,6 +55,9 @@ pub fn resolve_rule_selection(
     let preview = resolve_bool_arg(cli.preview, cli.no_preview)
         .or_else(|| lint.and_then(|l| l.preview))
         .unwrap_or(false);
+    let target_version = args
+        .target_version
+        .or_else(|| lint.and_then(|l| l.target_version));
     // Per-rule config is pyproject-only, it has no CLI flags.
     let unsorted_tailwind_classes = lint
         .and_then(|l| l.unsorted_tailwind_classes.clone())
@@ -64,6 +68,7 @@ pub fn resolve_rule_selection(
         select,
         ignore,
         preview,
+        target_version,
         unsorted_tailwind_classes,
     }
 }

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -1,5 +1,5 @@
-use djangofmt_lint::RuleSelector;
 use djangofmt_lint::settings::unsorted_tailwind_classes;
+use djangofmt_lint::{DjangoVersion, RuleSelector};
 use djangofmt_macros::OptionsMetadata;
 use serde::Deserialize;
 use std::{
@@ -144,6 +144,15 @@ pub struct LintSettings {
     /// Whether to enable rules that are still in preview.
     #[option(default = "false", value_type = "bool", example = "preview = true")]
     pub preview: Option<bool>,
+
+    /// The Django version the templates target, as a `major.minor` string. Unset leaves the
+    /// rules that depend on it disabled.
+    #[option(
+        default = "null",
+        value_type = "str",
+        example = r#"target-version = "5.2""#
+    )]
+    pub target_version: Option<DjangoVersion>,
 
     /// Whether to apply safe fixes automatically.
     #[option(default = "false", value_type = "bool", example = "fix = true")]
@@ -337,6 +346,7 @@ mod tests {
     #[case("[tool.djangofmt]\nline-length = 321")]
     #[case("[tool.djangofmt]\nindent-width = 0")]
     #[case("[tool.djangofmt]\nindent-width = 17")]
+    #[case("[tool.djangofmt.lint]\ntarget-version = \"5\"")]
     #[case("[tool.djangofmt.lint]\nselect = [\"not-a-real-rule\"]")]
     #[case("[tool.djangofmt.lint.unsorted-tailwind-classes]\nunknown-key = 1")]
     fn test_load_options_errors_on_invalid_toml(#[case] content: &str) {
@@ -432,7 +442,7 @@ prefix = "tw-"
     }
 
     #[test]
-    fn test_load_lint_select_ignore_preview() {
+    fn test_load_lint_options() {
         use djangofmt_lint::{Rule, RuleCategory};
 
         let content = r#"
@@ -440,6 +450,7 @@ prefix = "tw-"
 select = ["category:all"]
 ignore = ["category:style", "missing-img-alt"]
 preview = true
+target-version = "5.2"
 "#;
         let result = load_options_from_pyproject_toml(content).unwrap();
         assert_eq!(
@@ -452,6 +463,7 @@ preview = true
                         RuleSelector::Rule(Rule::MissingImgAlt)
                     ]),
                     preview: Some(true),
+                    target_version: Some(DjangoVersion::new(5, 2)),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/crates/djangofmt_benchmark/benches/linter.rs
+++ b/crates/djangofmt_benchmark/benches/linter.rs
@@ -2,7 +2,6 @@ use djangofmt_benchmark::{
     ALL_TEMPLATES, DJANGO_TEMPLATE_LARGE, FORMATTER_DIRECTIVE, LINT_DIRECTIVE, TestFile, warmup,
     with_directive,
 };
-use djangofmt_lint::settings::unsorted_tailwind_classes;
 use djangofmt_lint::{RuleSet, Settings, check_ast, parse};
 
 fn main() {
@@ -17,7 +16,7 @@ fn check_no_rules(bencher: divan::Bencher, template: &'static TestFile) {
         template,
         &Settings {
             rules: RuleSet::empty(),
-            unsorted_tailwind_classes: unsorted_tailwind_classes::Settings::default(),
+            ..Settings::default()
         },
     );
 }

--- a/crates/djangofmt_lint/src/django_version.rs
+++ b/crates/djangofmt_lint/src/django_version.rs
@@ -1,0 +1,87 @@
+//! The Django version templates target, used to gate version-specific rules.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// A `major.minor` Django release, e.g. `5.2`.
+///
+/// Any `major.minor` pair is accepted so a new Django release needs no code change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DjangoVersion {
+    pub major: u8,
+    pub minor: u8,
+}
+
+impl DjangoVersion {
+    #[must_use]
+    pub const fn new(major: u8, minor: u8) -> Self {
+        Self { major, minor }
+    }
+}
+
+impl fmt::Display for DjangoVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+impl FromStr for DjangoVersion {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let invalid = || format!("target-version must be a `major.minor` version (got `{value}`)");
+        let (major, minor) = value.split_once('.').ok_or_else(invalid)?;
+        let (Ok(major), Ok(minor)) = (major.parse(), minor.parse()) else {
+            return Err(invalid());
+        };
+        Ok(Self::new(major, minor))
+    }
+}
+
+/// Deserialize from the string form, reusing [`FromStr`] so `pyproject.toml` and the CLI
+/// accept exactly the same syntax.
+impl<'de> serde::Deserialize<'de> for DjangoVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        value.trim().parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DjangoVersion;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("5.2", DjangoVersion::new(5, 2))]
+    #[case("4.10", DjangoVersion::new(4, 10))]
+    fn parses_major_minor(#[case] input: &str, #[case] expected: DjangoVersion) {
+        assert_eq!(input.parse::<DjangoVersion>(), Ok(expected));
+        assert_eq!(expected.to_string(), input);
+    }
+
+    #[rstest]
+    #[case("5")]
+    #[case("5.2.1")]
+    #[case("v5.2")]
+    #[case("five.two")]
+    #[case("5.")]
+    #[case("")]
+    fn rejects_anything_else(#[case] input: &str) {
+        assert_eq!(
+            input.parse::<DjangoVersion>(),
+            Err(format!(
+                "target-version must be a `major.minor` version (got `{input}`)"
+            ))
+        );
+    }
+
+    #[test]
+    fn orders_by_major_then_minor() {
+        assert!(DjangoVersion::new(4, 2) < DjangoVersion::new(5, 0));
+        assert!(DjangoVersion::new(3, 2) < DjangoVersion::new(3, 10));
+    }
+}

--- a/crates/djangofmt_lint/src/lib.rs
+++ b/crates/djangofmt_lint/src/lib.rs
@@ -15,6 +15,7 @@
 //! ```
 
 mod checker;
+pub mod django_version;
 pub mod fix;
 pub mod lint_context;
 pub mod registry;
@@ -26,6 +27,7 @@ mod suppression;
 mod violation;
 
 pub use checker::Checker;
+pub use django_version::DjangoVersion;
 pub use fix::apply::{
     AppliedFix, ApplyResult, FixerError, FixerResult, MAX_FIX_ITERATIONS, RuleFixSummary,
     apply_fixes, fix_ast, lint_fix,

--- a/crates/djangofmt_lint/src/settings.rs
+++ b/crates/djangofmt_lint/src/settings.rs
@@ -1,5 +1,6 @@
 use strum::IntoEnumIterator;
 
+use crate::django_version::DjangoVersion;
 use crate::registry::Rule;
 use crate::rule_selector::{RuleSelector, SelectionWarning};
 use crate::rule_set::RuleSet;
@@ -19,6 +20,8 @@ pub mod unsorted_tailwind_classes {
 pub struct Settings {
     /// The set of rules that are active for this run.
     pub rules: RuleSet,
+    /// The Django version the templates target. `None` keeps version-gated rules off.
+    pub target_version: Option<DjangoVersion>,
     pub unsorted_tailwind_classes: unsorted_tailwind_classes::Settings,
 }
 
@@ -37,6 +40,7 @@ impl Settings {
             rules: Rule::iter()
                 .filter(|rule| !rule.is_deprecated() && !rule.is_removed())
                 .collect(),
+            target_version: None,
             unsorted_tailwind_classes: unsorted_tailwind_classes::Settings::default(),
         }
     }
@@ -66,6 +70,8 @@ pub struct LintConfiguration {
     pub ignore: Vec<RuleSelector>,
     /// Whether preview rules are enabled.
     pub preview: bool,
+    /// The Django version the templates target.
+    pub target_version: Option<DjangoVersion>,
     pub unsorted_tailwind_classes: unsorted_tailwind_classes::Settings,
 }
 
@@ -117,6 +123,7 @@ impl LintConfiguration {
         (
             Settings {
                 rules,
+                target_version: self.target_version,
                 unsorted_tailwind_classes: self.unsorted_tailwind_classes,
             },
             warnings,
@@ -129,7 +136,7 @@ mod tests {
     use std::str::FromStr;
     use strum::VariantNames;
 
-    use super::{LintConfiguration, Settings, unsorted_tailwind_classes};
+    use super::{LintConfiguration, Settings};
     use crate::registry::{Rule, RuleCategory};
     use crate::rule_selector::{ALL_GROUP, RuleSelector, SelectionWarning};
     use crate::rule_set::RuleSet;
@@ -144,13 +151,13 @@ mod tests {
 
         let none = Settings {
             rules: RuleSet::default(),
-            unsorted_tailwind_classes: unsorted_tailwind_classes::Settings::default(),
+            ..Settings::default()
         };
         assert!(!none.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
 
         let partial = Settings {
             rules: RuleSet::from_rule(Rule::UseHttps),
-            unsorted_tailwind_classes: unsorted_tailwind_classes::Settings::default(),
+            ..Settings::default()
         };
         assert!(partial.any_rule_enabled(&[Rule::UseHttps, Rule::InvalidAttrValue]));
         assert!(!partial.any_rule_enabled(&[Rule::InvalidAttrValue]));
@@ -163,7 +170,7 @@ mod tests {
             select: Some(vec![RuleSelector::All, RuleSelector::Rule(Rule::UseHttps)]),
             ignore: vec![RuleSelector::Category(RuleCategory::Suspicious)],
             preview: false,
-            unsorted_tailwind_classes: unsorted_tailwind_classes::Settings::default(),
+            ..LintConfiguration::default()
         };
         let (settings, warnings) = selection.into_settings();
         assert!(warnings.is_empty());

--- a/python/ecosystem-check/ecosystem_check/defaults.py
+++ b/python/ecosystem-check/ecosystem_check/defaults.py
@@ -147,10 +147,6 @@ DEFAULT_TARGETS = [
                     # <div> opened in {% if %}/{% else %} branches, closed once outside
                     "cms/templates/cms/toolbar/toolbar_with_structure.html",
                 ),
-                ExcludeReason.TEMPLATE_TAG_AS_ATTRIBUTE: (
-                    # {{ attr }}="{{ val }}" dynamic attribute name
-                    "cms/templates/cms/widgets/pagesmartlinkwidget.html",
-                ),
                 ExcludeReason.MISSING_END_TAG: (
                     "cms/templates/cms/noapphook.html",  # </html>
                 ),
@@ -292,7 +288,6 @@ DEFAULT_TARGETS = [
                 ),
                 ExcludeReason.INVALID_SOURCE_HTML: (
                     "djangoproject/templates/start.html",  # </span> inside a {% translate %} string
-                    "docs/templates/docs/genindex.html",  # Invalid <br/ > self close
                 ),
             },
         ),
@@ -340,15 +335,6 @@ DEFAULT_TARGETS = [
                     "netbox/templates/django/forms/widgets/select.html",
                     "netbox/utilities/templates/builtins/badge.html",
                     "netbox/utilities/templates/builtins/tag.html",
-                ),
-                ExcludeReason.TEMPLATE_TAG_AS_ATTRIBUTE: (
-                    "netbox/templates/core/buttons/bulk_sync.html",
-                    "netbox/templates/dcim/buttons/bulk_add_components.html",
-                    "netbox/templates/dcim/buttons/bulk_disconnect.html",
-                    "netbox/templates/virtualization/buttons/bulk_add_components.html",
-                    "netbox/utilities/templates/buttons/bulk_delete.html",
-                    "netbox/utilities/templates/buttons/bulk_edit.html",
-                    "netbox/utilities/templates/buttons/bulk_rename.html",
                 ),
                 ExcludeReason.MISSING_END_TAG: (
                     "netbox/templates/core/inc/config_data.html",  # </tr>

--- a/python/ecosystem-check/ecosystem_check/defaults.py
+++ b/python/ecosystem-check/ecosystem_check/defaults.py
@@ -489,6 +489,10 @@ DEFAULT_TARGETS = [
                     "bookwyrm/templates/book/sections/description.html",
                     "bookwyrm/templates/widgets/select.html",
                 ),
+                ExcludeReason.INVALID_SOURCE_HTML: (
+                    # Stray </div> between </tbody> and </form>
+                    "bookwyrm/templates/settings/manage-data/manual-merge.html",
+                ),
             },
         ),
     ),


### PR DESCRIPTION
Add a cli flag + pyproject entry to track the target django-version.

It will be useful for some lint rules that are doing upgrades
