### PR TITLE
chore(deps): Bump `markup_fmt` to keep one-token Jinja tags on one line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "markup_fmt"
 version = "0.27.3"
-source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=42cb647a38a4e7285212b496f0f69fcab73f5d58#42cb647a38a4e7285212b496f0f69fcab73f5d58"
+source = "git+https://github.com/UnknownPlatypus/markup_fmt?rev=57dad77f80c29c78ee23b8c9abd11543bd4a72f0#57dad77f80c29c78ee23b8c9abd11543bd4a72f0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ malva = {
 }
 markup_fmt = {
   git = "https://github.com/UnknownPlatypus/markup_fmt",
-  rev = "42cb647a38a4e7285212b496f0f69fcab73f5d58",
+  rev = "57dad77f80c29c78ee23b8c9abd11543bd4a72f0",
 }
 miette = { package = "oxc-miette", version = "3.0.1", features = ["fancy"] }
 proc-macro2 = { version = "1.0" }


### PR DESCRIPTION
Breaking a one-token Jinja tag across three lines never shortens the line it sits on, so `{% endtrans %}` and friends now always print flat.

Pre-existing, but #491 made it common:

Before:
```jinja
{%
  trans
%}An untrimmed body is one atom, so this line overflows whatever the tag does.{%
  endtrans
%}
```

After:
```jinja
{% trans %}An untrimmed body is one atom, so this line overflows whatever the tag does.{% endtrans %}
```