### PR TITLE
ci(ecosystem): Add a parse check that fails when formatting breaks templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           echo "$PWD/python/benchmarks/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Run `djangofmt` ecosystem check
+        id: ecosystem
         env:
           # djangofmt was built above, don't rebuild it via project install and maturin
           UV_NO_PROJECT: 1
@@ -111,6 +112,12 @@ jobs:
 
           printf "\n---\n\n### \`pr\` vs \`main\` check diff\n" >> ecosystem-result
           uv run ecosystem-check check ./main_djangofmt ./pr_djangofmt --cache-dir ./checkouts | tee -a ecosystem-result
+
+          printf "\n---\n\n### \`pr\` parse check\n" >> ecosystem-result
+          # Keep going on failure so the summary, comment and artifacts are still produced.
+          validate_status=0
+          uv run ecosystem-check validate ./pr_djangofmt --cache-dir ./checkouts | tee -a ecosystem-result || validate_status=$?
+          echo "validate_status=${validate_status}" >> "$GITHUB_OUTPUT"
 
           if [ "$(stat -c%s "ecosystem-result")" -gt 1024000 ]; then
             echo -e "\n\n> [!CAUTION]\n> **Summary Truncated:** The original output was $(du -h ecosystem-result | cut -f1), which exceeds GitHub's 1024k limit." >> "$GITHUB_STEP_SUMMARY"
@@ -156,6 +163,10 @@ jobs:
         with:
           name: pr-number
           path: pr-number
+
+      - name: Fail on parse regressions
+        if: steps.ecosystem.outputs.validate_status != '0'
+        run: exit 1
 
   clippy_check:
     name: "cargo clippy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,25 +98,21 @@ jobs:
           uv venv --python 3.12
           uv pip install ./python/ecosystem-check
 
-          printf "### \`pr\` vs \`main\` format diff\n" >> ecosystem-result
-          uv run ecosystem-check format ./main_djangofmt ./pr_djangofmt --cache-dir ./checkouts | tee -a ecosystem-result
-
-          printf "\n### \`pr\` format stability\n" >> ecosystem-result
-          uv run ecosystem-check format ./pr_djangofmt ./pr_djangofmt --cache-dir ./checkouts --format-comparison base-then-comp | tee -a ecosystem-result
-
-          printf "\n### \`pr\` + \`rustywind\` format stability\n" >> ecosystem-result
-          uv run ecosystem-check format rustywind ./pr_djangofmt  --cache-dir ./checkouts --format-comparison base-then-comp-converge | tee -a ecosystem-result
-
-          printf "\n### \`pr\` + \`djade\` format stability\n" >> ecosystem-result
-          uv run ecosystem-check format djade ./pr_djangofmt --cache-dir ./checkouts --format-comparison base-then-comp-converge | tee -a ecosystem-result
-
-          printf "\n---\n\n### \`pr\` vs \`main\` check diff\n" >> ecosystem-result
-          uv run ecosystem-check check ./main_djangofmt ./pr_djangofmt --cache-dir ./checkouts | tee -a ecosystem-result
-
-          printf "\n---\n\n### \`pr\` parse check\n" >> ecosystem-result
+          # Each check prints one status line, plus collapsed details when it found something.
+          # The blank line in between stops a trailing `<details>` from swallowing the next status line.
+          uv run ecosystem-check format ./main_djangofmt ./pr_djangofmt --cache-dir ./checkouts --title "\`pr\` vs \`main\` format diff" | tee -a ecosystem-result
+          echo >> ecosystem-result
+          uv run ecosystem-check format ./pr_djangofmt ./pr_djangofmt --cache-dir ./checkouts --format-comparison base-then-comp --title "\`pr\` format stability" | tee -a ecosystem-result
+          echo >> ecosystem-result
+          uv run ecosystem-check format rustywind ./pr_djangofmt --cache-dir ./checkouts --format-comparison base-then-comp-converge --title "\`pr\` + \`rustywind\` format stability" | tee -a ecosystem-result
+          echo >> ecosystem-result
+          uv run ecosystem-check format djade ./pr_djangofmt --cache-dir ./checkouts --format-comparison base-then-comp-converge --title "\`pr\` + \`djade\` format stability" | tee -a ecosystem-result
+          echo >> ecosystem-result
+          uv run ecosystem-check check ./main_djangofmt ./pr_djangofmt --cache-dir ./checkouts --title "\`pr\` vs \`main\` check diff" | tee -a ecosystem-result
+          echo >> ecosystem-result
           # Keep going on failure so the summary, comment and artifacts are still produced.
           validate_status=0
-          uv run ecosystem-check validate ./pr_djangofmt --cache-dir ./checkouts | tee -a ecosystem-result || validate_status=$?
+          uv run ecosystem-check validate ./pr_djangofmt --cache-dir ./checkouts --title "\`pr\` parse check" | tee -a ecosystem-result || validate_status=$?
           echo "validate_status=${validate_status}" >> "$GITHUB_OUTPUT"
 
           if [ "$(stat -c%s "ecosystem-result")" -gt 1024000 ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,9 @@ repos:
     rev: 7ff8d35ae36a7d2b968f2f90b4c723e292e594ee  # frozen: v2.3.1
     hooks:
       - id: mypy
+        additional_dependencies:
+          - django-stubs==5.2.9
+          - jinja2==3.1.6
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: 05c1426671b9237fb5e1444dd63aa5731bec0dfb  # frozen: v3.13.1-1
     hooks:

--- a/justfile
+++ b/justfile
@@ -229,6 +229,12 @@ ecosystem-check-lint-dev:
     cargo build -p djangofmt
     uv run ecosystem-check check djangofmt "target/debug/djangofmt" --cache-dir {{ecosystem_cache_dir}}
 
+# Check that formatting keeps ecosystem templates parseable by Django or Jinja
+[group('ecosystem-check')]
+ecosystem-check-validate executable="target/debug/djangofmt" *args:
+    cargo build -p djangofmt
+    uv run ecosystem-check validate {{executable}} --cache-dir {{ecosystem_cache_dir}} {{args}}
+
 # Clean ecosystem check git repos cache
 [group('ecosystem-check')]
 ecosystem-check-clean-cache:

--- a/python/ecosystem-check/README.md
+++ b/python/ecosystem-check/README.md
@@ -27,6 +27,16 @@ just ecosystem-check djangofmt ./target/debug/djangofmt --format-comparison base
 The default output format is markdown, which includes nice summaries of the changes. You can use `--output-format json` to display the raw data — this is
 particularly useful when making changes to the ecosystem checks.
 
+## Parse check
+
+`validate` takes a single executable and checks that formatting never turns a template Django (or
+Jinja, for `jinja` profile projects) can parse into one it cannot. Unknown tags, filters and libraries
+are accepted, so only the built-in grammar is checked. Any regression makes the command exit with 1.
+
+```shell
+just ecosystem-check-validate
+```
+
 ## Development
 
 When developing, it can be useful to set the `--pdb` flag to drop into a debugger on failure:

--- a/python/ecosystem-check/ecosystem_check/check.py
+++ b/python/ecosystem-check/ecosystem_check/check.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     )
 
 
-def markdown_check_result(result: Result) -> str:
+def markdown_check_result(result: Result, title: str) -> str:
     """
     Render a `djangofmt check` ecosystem check result as markdown.
     """
@@ -39,60 +39,50 @@ def markdown_check_result(result: Result) -> str:
         comp.diff for _, comp in result.completed if isinstance(comp.diff, CheckDiff)
     ]
     projects_with_changes = sum(bool(d) for d in diffs)
-    total_added = sum(d.diagnostics_added for d in diffs)
-    total_removed = sum(d.diagnostics_removed for d in diffs)
-    total_fixed_added = sum(d.fix_diff.lines_added for d in diffs)
-    total_fixed_removed = sum(d.fix_diff.lines_removed for d in diffs)
-
     if projects_with_changes == 0 and error_count == 0:
-        return "\u2705 ecosystem check detected no check changes."
+        return f"✅ {title}"
 
-    lines: list[str] = []
     if projects_with_changes == 0:
-        lines.append(
-            f"\u2139\ufe0f ecosystem check **encountered check errors**. "
-            f"(no diagnostic changes; {error_count} project error{add_s(error_count)})"
+        summary = (
+            f"no diagnostic changes; {error_count} project error{add_s(error_count)}"
         )
     else:
-        changes = (
+        total_added = sum(d.diagnostics_added for d in diffs)
+        total_removed = sum(d.diagnostics_removed for d in diffs)
+        total_fixed_added = sum(d.fix_diff.lines_added for d in diffs)
+        total_fixed_removed = sum(d.fix_diff.lines_removed for d in diffs)
+        summary = (
             f"+{total_added} -{total_removed} diagnostic lines, "
             f"+{total_fixed_added} -{total_fixed_removed} fixed lines "
             f"in {projects_with_changes} project{add_s(projects_with_changes)}"
         )
-
         if error_count:
-            changes += f"; {error_count} project error{add_s(error_count)}"
-
+            summary += f"; {error_count} project error{add_s(error_count)}"
         unchanged_projects = len(result.completed) - projects_with_changes
         if unchanged_projects:
-            changes += (
+            summary += (
                 f"; {unchanged_projects} project{add_s(unchanged_projects)} unchanged"
             )
-
-        lines.append(
-            f"\u2139\ufe0f ecosystem check **detected check changes**. ({changes})"
-        )
-
-    lines.append("")
+    lines = [f"\u2139\ufe0f {title}: {summary}", ""]
 
     for project, comparison in result.completed:
         diff = comparison.diff
         if not diff or not isinstance(diff, CheckDiff):
             continue
 
-        title = (
+        section_title = (
             f"+{diff.diagnostics_added} -{diff.diagnostics_removed} diagnostic lines"
         )
         if diff.fix_diff:
             files = diff.fix_diff.modified_files
-            title += (
+            section_title += (
                 f", +{diff.fix_diff.lines_added} -{diff.fix_diff.lines_removed} "
                 f"fixed lines across {files} file{add_s(files)}"
             )
 
         lines.extend(
             markdown_project_section(
-                title=title,
+                title=section_title,
                 content=diff.format_markdown(repo=comparison.repo),
                 options=project.cli_options,
                 project=project,

--- a/python/ecosystem-check/ecosystem_check/cli.py
+++ b/python/ecosystem-check/ecosystem_check/cli.py
@@ -49,7 +49,10 @@ def entrypoint() -> None:
         logging.basicConfig(level=logging.INFO)
 
     baseline_executable = resolve_executable(args.baseline_executable, "baseline")
-    comparison_executable = resolve_executable(args.comparison_executable, "comparison")
+    # `validate` takes a single executable, which fills both slots to keep the pipeline uniform.
+    comparison_executable = resolve_executable(
+        args.comparison_executable or args.baseline_executable, "comparison"
+    )
 
     # Use a temporary directory for caching if no cache is specified
     cache_context = (
@@ -146,10 +149,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "comparison_executable",
         type=Path,
+        nargs="?",
+        help="Not used by `validate`, which checks a single executable",
     )
     # https://docs.python.org/3.14/library/argparse.html#suggest-on-error
     parser.suggest_on_error = True  # type: ignore[attr-defined, unused-ignore]
-    return parser.parse_args()
+    args = parser.parse_args()
+    if (args.command == Command.VALIDATE) != (args.comparison_executable is None):
+        parser.error("`validate` takes one executable, `format` and `check` take two")
+    return args
 
 
 def _get_executable_path(name: str) -> Path | None:

--- a/python/ecosystem-check/ecosystem_check/cli.py
+++ b/python/ecosystem-check/ecosystem_check/cli.py
@@ -86,6 +86,7 @@ async def _run_main(
             targets=DEFAULT_TARGETS,
             output_format=OutputFormat(args.output_format),
             project_dir=Path(cache),
+            title=args.title,
             raise_on_failure=args.pdb,
             format_comparison=(
                 FormatComparison(args.format_comparison)
@@ -136,6 +137,11 @@ def parse_args() -> argparse.Namespace:
         choices=list(FormatComparison),
         default=FormatComparison.BASE_AND_COMP,
         help="Type of comparison to make when checking formatting.",
+    )
+    parser.add_argument(
+        "--title",
+        default="ecosystem check",
+        help="Name of the check, used as the markdown status line",
     )
     parser.add_argument(
         "command",

--- a/python/ecosystem-check/ecosystem_check/format.py
+++ b/python/ecosystem-check/ecosystem_check/format.py
@@ -49,7 +49,7 @@ def can_format_project(
     )
 
 
-def markdown_format_result(result: Result) -> str:
+def markdown_format_result(result: Result, title: str) -> str:
     """
     Render a `djangofmt` ecosystem check result as markdown.
     """
@@ -61,42 +61,28 @@ def markdown_format_result(result: Result) -> str:
         if isinstance(comp.diff, (Diff, HistoriesForHunks))
     ]
     projects_with_changes = sum(bool(d) for d in diffs)
-    total_lines_added = sum(d.lines_added for d in diffs)
-    total_lines_removed = sum(d.lines_removed for d in diffs)
-    total_files_modified = sum(d.modified_files for d in diffs)
+    if projects_with_changes == 0 and error_count == 0:
+        return f"✅ {title}"
 
-    if total_lines_removed == 0 and total_lines_added == 0 and error_count == 0:
-        return "\u2705 ecosystem check detected no format changes."
-
-    # Summarize the total changes
-    lines: list[str] = []
-    if total_lines_added == 0 and total_lines_added == 0:
-        # Only errors
-        lines.append(
-            f"\u2139\ufe0f ecosystem check **encountered format errors**. "
-            f"(no format changes; {error_count} project error{add_s(error_count)})"
-        )
+    if projects_with_changes == 0:
+        summary = f"no format changes; {error_count} project error{add_s(error_count)}"
     else:
-        changes = (
+        total_lines_added = sum(d.lines_added for d in diffs)
+        total_lines_removed = sum(d.lines_removed for d in diffs)
+        total_files_modified = sum(d.modified_files for d in diffs)
+        summary = (
             f"+{total_lines_added} -{total_lines_removed} lines "
             f"in {total_files_modified} file{add_s(total_files_modified)} in "
-            f"{projects_with_changes} projects"
+            f"{projects_with_changes} project{add_s(projects_with_changes)}"
         )
-
         if error_count:
-            changes += f"; {error_count} project error{add_s(error_count)}"
-
+            summary += f"; {error_count} project error{add_s(error_count)}"
         unchanged_projects = len(result.completed) - projects_with_changes
         if unchanged_projects:
-            changes += (
+            summary += (
                 f"; {unchanged_projects} project{add_s(unchanged_projects)} unchanged"
             )
-
-        lines.append(
-            f"\u2139\ufe0f ecosystem check **detected format changes**. ({changes})"
-        )
-
-    lines.append("")
+    lines = [f"\u2139\ufe0f {title}: {summary}", ""]
 
     # Then per-project changes
     for project, comparison in result.completed:
@@ -105,11 +91,11 @@ def markdown_format_result(result: Result) -> str:
             continue  # Skip empty diffs
 
         files = diff.modified_files
-        title = f"+{diff.lines_added} -{diff.lines_removed} lines across {files} file{add_s(files)}"
+        section_title = f"+{diff.lines_added} -{diff.lines_removed} lines across {files} file{add_s(files)}"
 
         lines.extend(
             markdown_project_section(
-                title=title,
+                title=section_title,
                 content=diff.format_markdown(repo=comparison.repo),
                 options=project.cli_options,
                 project=project,
@@ -325,7 +311,7 @@ async def format(
 
 
 def markdown_stale_exclusions(executable: Path, result: Result) -> str:
-    """Report exclusions that are no longer needed, so they don't linger unnoticed."""
+    """Report exclusions that are no longer needed, so they don't linger unnoticed; empty when none are."""
     lines: list[str] = []
     for project, comparison in result.completed:
         options = project.cli_options
@@ -339,7 +325,7 @@ def markdown_stale_exclusions(executable: Path, result: Result) -> str:
             lines.append(f"- `{project.repo.fullname}`: {' '.join(stale)}")
 
     if not lines:
-        return "✅ every exclusion is still needed."
+        return ""
     return "\n".join(
         [
             "⚠️ these exclusions are stale (file gone, or formats without error "

--- a/python/ecosystem-check/ecosystem_check/main.py
+++ b/python/ecosystem-check/ecosystem_check/main.py
@@ -45,6 +45,7 @@ async def main(
     project_dir: Path,
     output_format: OutputFormat,
     format_comparison: FormatComparison | None,
+    title: str,
     max_parallelism: int = 50,
     raise_on_failure: bool = False,
 ) -> None:
@@ -108,14 +109,18 @@ async def main(
         case OutputFormat.MARKDOWN:
             match command:
                 case Command.FORMAT:
-                    print(markdown_format_result(result))
-                    if format_comparison is FormatComparison.BASE_AND_COMP:
+                    print(markdown_format_result(result, title))
+                    if format_comparison is FormatComparison.BASE_AND_COMP and (
+                        stale := markdown_stale_exclusions(
+                            comparison_executable, result
+                        )
+                    ):
                         print()
-                        print(markdown_stale_exclusions(comparison_executable, result))
+                        print(stale)
                 case Command.CHECK:
-                    print(markdown_check_result(result))
+                    print(markdown_check_result(result, title))
                 case Command.VALIDATE:
-                    print(markdown_validate_result(result))
+                    print(markdown_validate_result(result, title))
                 case _:
                     raise ValueError(f"Unknown target command {command}")
         case _:

--- a/python/ecosystem-check/ecosystem_check/main.py
+++ b/python/ecosystem-check/ecosystem_check/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import json
+import sys
 from collections.abc import Awaitable
 from enum import StrEnum
 from pathlib import Path
@@ -25,6 +26,7 @@ from ecosystem_check.projects import (
     Project,
 )
 from ecosystem_check.types import Comparison, Result, Serializable
+from ecosystem_check.validate import markdown_validate_result, validate_project
 
 T = TypeVar("T")
 GITHUB_MAX_COMMENT_LENGTH = 65536
@@ -61,7 +63,7 @@ async def main(
                     baseline_executable, comparison_executable, target
                 )
             ]
-        case Command.CHECK:
+        case Command.CHECK | Command.VALIDATE:
             pass
     logger.debug("Checking %s targets", len(targets))
 
@@ -112,11 +114,16 @@ async def main(
                         print(markdown_stale_exclusions(comparison_executable, result))
                 case Command.CHECK:
                     print(markdown_check_result(result))
+                case Command.VALIDATE:
+                    print(markdown_validate_result(result))
                 case _:
                     raise ValueError(f"Unknown target command {command}")
         case _:
             raise ValueError(f"Unknown output format {format}")
 
+    # The parse check is the only one that gates CI: a regression fails the job.
+    if command is Command.VALIDATE and any(comp.diff for _, comp in result.completed):
+        sys.exit(1)
     return None
 
 
@@ -152,6 +159,10 @@ async def clone_and_compare(
                     comparison_executable,
                     target.cli_options,
                     cloned_repo,
+                )
+            case Command.VALIDATE:
+                return await validate_project(
+                    comparison_executable, target.cli_options, cloned_repo
                 )
             case _:
                 raise ValueError(f"Unknown target command {command}")

--- a/python/ecosystem-check/ecosystem_check/oracle.py
+++ b/python/ecosystem-check/ecosystem_check/oracle.py
@@ -1,0 +1,76 @@
+"""
+Parse a template with Django or Jinja, accepting unknown tags, filters and libraries.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+
+import jinja2
+from django.template import Engine, Origin, TemplateSyntaxError
+from django.template.base import Lexer, Node, Parser, TextNode, Token
+from django.template.library import Library
+
+JINJA_ENV = jinja2.Environment(
+    extensions=[
+        "jinja2.ext.i18n",
+        "jinja2.ext.do",
+        "jinja2.ext.loopcontrols",
+        "jinja2.ext.debug",
+    ]
+)
+# Parsing never reads settings, so neither `settings.configure()` nor `django.setup()` is needed.
+DJANGO_ENGINE = Engine()
+
+
+def noop_tag(parser: Parser, token: Token) -> Node:
+    return TextNode("")
+
+
+def noop_filter(value: Any, arg: Any = None) -> Any:
+    return value
+
+
+class PermissiveParser(Parser):
+    """Compiles unknown tags, filters and libraries to no-ops, so only Django's own grammar is checked."""
+
+    def __init__(
+        self,
+        tokens: list[Token],
+        libraries: dict[str, Library],
+        builtins: list[Library],
+        origin: Origin,
+    ) -> None:
+        super().__init__(tokens, libraries, builtins, origin)
+        self.tags = defaultdict(lambda: noop_tag, self.tags)
+        self.libraries = defaultdict(Library, self.libraries)
+
+    def find_filter(self, filter_name: str) -> Callable[..., Any]:
+        return self.filters.get(filter_name, noop_filter)
+
+
+def parse_django(source: str, template_name: str) -> str | None:
+    """Return the parse error, or `None` when the template parses."""
+    # Relative `{% include %}` and `{% extends %}` paths resolve against the origin's template name.
+    origin = Origin(name=template_name, template_name=template_name)
+    parser = PermissiveParser(
+        Lexer(source).tokenize(),
+        DJANGO_ENGINE.template_libraries,
+        DJANGO_ENGINE.template_builtins,
+        origin,
+    )
+    try:
+        parser.parse()
+    except TemplateSyntaxError as e:
+        return str(e)
+    return None
+
+
+def parse_jinja(source: str, template_name: str) -> str | None:
+    try:
+        JINJA_ENV.parse(source, name=template_name)
+    except jinja2.TemplateSyntaxError as e:
+        return str(e)
+    return None

--- a/python/ecosystem-check/ecosystem_check/projects.py
+++ b/python/ecosystem-check/ecosystem_check/projects.py
@@ -28,6 +28,7 @@ class Project(Serializable):
 class Command(enum.StrEnum):
     FORMAT = enum.auto()
     CHECK = enum.auto()
+    VALIDATE = enum.auto()
 
 
 class GitDomain(enum.StrEnum):

--- a/python/ecosystem-check/ecosystem_check/types.py
+++ b/python/ecosystem-check/ecosystem_check/types.py
@@ -179,6 +179,16 @@ class HunkDetail:
     length: int
 
 
+class ParseRegressions(dict[str, str]):
+    """Templates that parsed before formatting but not after, mapped to the new parse error."""
+
+    def format_markdown(self, repo: ClonedRepository) -> str:
+        return "\n".join(
+            f"- <a href='{repo.url_for(path)}'>{path}</a>: `{error}`"
+            for path, error in self.items()
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class Result(Serializable):
     """
@@ -195,7 +205,7 @@ class Comparison(Serializable):
     The result of a completed ecosystem comparison for a single project.
     """
 
-    diff: Diff | HistoriesForHunks | CheckDiff
+    diff: Diff | HistoriesForHunks | CheckDiff | ParseRegressions
     repo: ClonedRepository
 
 

--- a/python/ecosystem-check/ecosystem_check/validate.py
+++ b/python/ecosystem-check/ecosystem_check/validate.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from ecosystem_check.projects import CliOptions, ClonedRepository
 
 
-def markdown_validate_result(result: Result) -> str:
+def markdown_validate_result(result: Result, title: str) -> str:
     """
     Render a parse check ecosystem result as markdown.
     """
@@ -28,16 +28,19 @@ def markdown_validate_result(result: Result) -> str:
         if isinstance(comparison.diff, ParseRegressions) and comparison.diff
     ]
     if not regressions and not result.errored:
-        return "✅ ecosystem check detected no parse regressions."
+        return f"✅ {title}"
 
     templates = sum(len(diff) for _, _, diff in regressions)
     summary = (
-        f"{templates} template{add_s(templates)} "
+        f"{templates} parse regression{add_s(templates)} "
         f"in {len(regressions)} project{add_s(len(regressions))}"
+        if regressions
+        else "no parse regressions"
     )
     if result.errored:
         summary += f"; {len(result.errored)} project error{add_s(len(result.errored))}"
-    lines = [f"❌ ecosystem check **detected parse regressions**. ({summary})", ""]
+    status = "❌" if regressions else "\u2139\ufe0f"
+    lines = [f"{status} {title}: {summary}", ""]
 
     for project, repo, diff in regressions:
         lines.extend(

--- a/python/ecosystem-check/ecosystem_check/validate.py
+++ b/python/ecosystem-check/ecosystem_check/validate.py
@@ -1,0 +1,90 @@
+"""
+Execution and summary of the parse check: formatting must keep templates parseable.
+"""
+
+from __future__ import annotations
+
+import glob
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ecosystem_check.format import add_s, format
+from ecosystem_check.markdown import markdown_project_section
+from ecosystem_check.oracle import parse_django, parse_jinja
+from ecosystem_check.projects import Profile
+from ecosystem_check.types import Comparison, ParseRegressions, Result
+
+if TYPE_CHECKING:
+    from ecosystem_check.projects import CliOptions, ClonedRepository
+
+
+def markdown_validate_result(result: Result) -> str:
+    """
+    Render a parse check ecosystem result as markdown.
+    """
+    regressions = [
+        (project, comparison.repo, comparison.diff)
+        for project, comparison in result.completed
+        if isinstance(comparison.diff, ParseRegressions) and comparison.diff
+    ]
+    if not regressions and not result.errored:
+        return "✅ ecosystem check detected no parse regressions."
+
+    templates = sum(len(diff) for _, _, diff in regressions)
+    summary = (
+        f"{templates} template{add_s(templates)} "
+        f"in {len(regressions)} project{add_s(len(regressions))}"
+    )
+    if result.errored:
+        summary += f"; {len(result.errored)} project error{add_s(len(result.errored))}"
+    lines = [f"❌ ecosystem check **detected parse regressions**. ({summary})", ""]
+
+    for project, repo, diff in regressions:
+        lines.extend(
+            markdown_project_section(
+                title=f"{len(diff)} parse regression{add_s(len(diff))}",
+                content=diff.format_markdown(repo),
+                options=project.cli_options,
+                project=project,
+            )
+        )
+
+    for project, error in result.errored:
+        lines.extend(
+            markdown_project_section(
+                title="error",
+                content=f"```\n{str(error).strip()}\n```",
+                options=project.cli_options,
+                project=project,
+            )
+        )
+
+    return "\n".join(lines)
+
+
+async def validate_project(
+    executable: Path, options: CliOptions, cloned_repo: ClonedRepository
+) -> Comparison:
+    """Format the checkout in place and report the templates that no longer parse."""
+    parse = parse_jinja if options.profile is Profile.JINJA else parse_django
+    files = set(
+        glob.iglob("**/*templates/**/*.html", recursive=True, root_dir=cloned_repo.path)
+    ) - set(options.excluded_files())
+
+    def read(file: str) -> str:
+        return cloned_repo.path.joinpath(file).read_text("utf8", errors="replace")
+
+    # A template that is already invalid cannot tell us anything about the formatter.
+    parseable = sorted(file for file in files if parse(read(file), file) is None)
+    await format(
+        executable=executable.resolve(),
+        path=cloned_repo.path,
+        repo_fullname=cloned_repo.fullname,
+        options=options,
+    )
+
+    regressions = ParseRegressions()
+    for file in parseable:
+        if error := parse(read(file), file):
+            regressions[file] = error
+    return Comparison(diff=regressions, repo=cloned_repo)

--- a/python/ecosystem-check/pyproject.toml
+++ b/python/ecosystem-check/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.0.0"
 requires-python = ">=3.11"
 dependencies = [
   "djade==1.9.0",
+  "django==5.2.17",
+  "jinja2==3.1.6",
   "tomli==2.4.1",
   "tomli_w==1.2.0",
   "unidiff==1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,15 @@ members = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "astral-dev-toolchain-cargo-insta"
 version = "1.48.0"
 source = { registry = "https://pypi.org/simple" }
@@ -114,6 +123,20 @@ wheels = [
 ]
 
 [[package]]
+name = "django"
+version = "5.2.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "asgiref" },
+  { name = "sqlparse" },
+  { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
+]
+
+[[package]]
 name = "djangofmt"
 version = "0.2.12"
 source = { editable = "." }
@@ -132,6 +155,7 @@ docs = [
 ]
 
 [package.metadata]
+
 [package.metadata.requires-dev]
 dev = [
   { name = "astral-dev-toolchain-cargo-insta", specifier = ">=1.48.0" },
@@ -166,6 +190,8 @@ version = "0.0.0"
 source = { editable = "python/ecosystem-check" }
 dependencies = [
   { name = "djade" },
+  { name = "django" },
+  { name = "jinja2" },
   { name = "tomli" },
   { name = "tomli-w" },
   { name = "unidiff" },
@@ -174,6 +200,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
   { name = "djade", specifier = "==1.9.0" },
+  { name = "django", specifier = "==5.2.17" },
+  { name = "jinja2", specifier = "==3.1.6" },
   { name = "tomli", specifier = "==2.4.1" },
   { name = "tomli-w", specifier = "==1.2.0" },
   { name = "unidiff", specifier = "==1.0.0" },
@@ -638,6 +666,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -707,6 +744,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Formatting can produce output that djangofmt is happy with but Django or Jinja no longer parses. 
Nothing in CI caught that until now but this is very important insights because it means `markup_fmt` parser needs fixing

### Parse check

`ecosystem-check validate <executable>` formats every ecosystem template and reports the ones that parsed before but not after. Templates that are already invalid are skipped, since they say nothing about the formatter.

The check is done with:
- a permissive Django parser: unknown tags, filters and `{% load %}` libraries compile to no-ops, so only Django's own grammar is checked and third-party tag libraries don't cause false positives. 
- Jinja projects go through `jinja2.Environment.parse` with the usual extensions enabled.

The check runs in the ecosystem job and is the only one that gates CI: any regression fails the job. 

### Compact PR comment

Each check now prints a single status line, with collapsed details only when it found something. 