### PR TITLE
feat(lint): Infer `target-version` from the `django` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ fix = true
 "templates/admin/*.html" = ["missing-img-alt"]
 ```
 
-`target-version` is the Django version your templates target. While it is unset, the rules that depend on it stay disabled.
+`target-version` is the Django version your templates target. When unset, it is inferred from the lower bound of the `django` requirement in `[project] dependencies` (e.g. `django>=4.2` gives `4.2`); without such a bound, the rules that depend on it stay disabled.
 See [Lint rules](https://unknownplatypus.github.io/djangofmt/docs/rules/) for the available rule names and categories.
 
 Djangofmt looks for a `pyproject.toml` file by traversing directories upward from the current working directory.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ fix = true
 "templates/admin/*.html" = ["missing-img-alt"]
 ```
 
-`target-version` is the Django version your templates target. When unset, it is inferred from the lower bound of the `django` requirement in `[project] dependencies` (e.g. `django>=4.2` gives `4.2`); without such a bound, the rules that depend on it stay disabled.
+`target-version` is the Django version your templates target. When unset, it comes from the minimum supported Django version in `[project] dependencies`.
+Rules that depend on it stay disabled until it is known.
 See [Lint rules](https://unknownplatypus.github.io/djangofmt/docs/rules/) for the available rule names and categories.
 
 Djangofmt looks for a `pyproject.toml` file by traversing directories upward from the current working directory.

--- a/crates/djangofmt/src/django_requirement.rs
+++ b/crates/djangofmt/src/django_requirement.rs
@@ -1,14 +1,8 @@
 //! Inference of the targeted Django version from the `django` requirement of a project.
-//!
-//! Requirements are skimmed rather than parsed,
-//! since a PEP 508 parser would still leave the name, extras and marker splitting to us.
 
 use djangofmt_lint::DjangoVersion;
 
 /// The oldest Django version the project may run on, from its `django` requirements.
-///
-/// Entries split by an environment marker each bound a single environment,
-/// and a template has to work on all of them, hence the minimum.
 pub fn infer_target_version<'a>(
     requirements: impl IntoIterator<Item = &'a str>,
 ) -> Option<DjangoVersion> {

--- a/crates/djangofmt/src/django_requirement.rs
+++ b/crates/djangofmt/src/django_requirement.rs
@@ -1,27 +1,25 @@
 //! Inference of the targeted Django version from the `django` requirement of a project.
 //!
-//! Only the release segments of lower-bound specifiers matter here, so requirements are
-//! skimmed rather than parsed: a full PEP 508 parser would still leave the name, extras and
-//! marker splitting below to us.
+//! Requirements are skimmed rather than parsed,
+//! since a PEP 508 parser would still leave the name, extras and marker splitting to us.
 
 use djangofmt_lint::DjangoVersion;
 
-/// The lowest Django version satisfying every `django` requirement in `requirements`.
+/// The oldest Django version the project may run on, from its `django` requirements.
 ///
-/// Entries are usually split by an environment marker, and templates have to work on the
-/// oldest Django the project may run on, hence the minimum.
-pub fn detect_target_version<'a>(
+/// Entries split by an environment marker each bound a single environment,
+/// and a template has to work on all of them, hence the minimum.
+pub fn infer_target_version<'a>(
     requirements: impl IntoIterator<Item = &'a str>,
 ) -> Option<DjangoVersion> {
     requirements
         .into_iter()
         .filter_map(django_lower_bound)
         .min()
-        .map(|(major, minor)| DjangoVersion::new(major, minor))
 }
 
-/// Lower bound of a PEP 508 requirement when it names `django`, as `(major, minor)`.
-fn django_lower_bound(requirement: &str) -> Option<(u8, u8)> {
+/// Lower bound of a PEP 508 requirement when it names `django`.
+fn django_lower_bound(requirement: &str) -> Option<DjangoVersion> {
     let requirement = requirement.trim();
     let name_end = requirement
         .find(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
@@ -52,7 +50,7 @@ fn django_lower_bound(requirement: &str) -> Option<(u8, u8)> {
 }
 
 /// Lower bound of a single PEP 440 specifier. Upper bounds and exclusions bound nothing.
-fn specifier_lower_bound(specifier: &str) -> Option<(u8, u8)> {
+fn specifier_lower_bound(specifier: &str) -> Option<DjangoVersion> {
     let specifier = specifier.trim();
     let operator_end = specifier
         .find(|c: char| !matches!(c, '=' | '~' | '>' | '<' | '!'))
@@ -68,7 +66,7 @@ fn specifier_lower_bound(specifier: &str) -> Option<(u8, u8)> {
     let mut segments = version.split('.');
     let major = leading_number(segments.next()?)?;
     let minor = segments.next().and_then(leading_number).unwrap_or(0);
-    Some((major, minor))
+    Some(DjangoVersion::new(major, minor))
 }
 
 /// Digits at the start of a release segment, so `2a1`, `2rc1`, `dev1` and `*` stop early.
@@ -81,43 +79,49 @@ fn leading_number(segment: &str) -> Option<u8> {
 
 #[cfg(test)]
 mod tests {
-    use super::{detect_target_version, django_lower_bound};
+    use super::{django_lower_bound, infer_target_version};
     use djangofmt_lint::DjangoVersion;
     use rstest::rstest;
 
     #[rstest]
-    #[case("django>=4.2", Some((4, 2)))]
-    #[case("Django==5.1.0", Some((5, 1)))]
-    #[case("django~=4.1", Some((4, 1)))]
-    #[case("django[argon2]>=4.2", Some((4, 2)))]
-    #[case("django >= 4.2.1", Some((4, 2)))]
-    #[case("django>=4.2,<5.0", Some((4, 2)))]
-    #[case("django[argon2]>=6,<6.1", Some((6, 0)))]
-    #[case("django==5.2.*", Some((5, 2)))]
-    #[case("django==5.*", Some((5, 0)))]
-    #[case("django>=5.0; python_version >= \"3.10\"", Some((5, 0)))]
-    #[case("Django>=4.2a1", Some((4, 2)))]
-    #[case("django>=4.2.dev1", Some((4, 2)))]
+    #[case("django>=4.2", Some(DjangoVersion::new(4, 2)))]
+    #[case("Django==5.1.0", Some(DjangoVersion::new(5, 1)))]
+    #[case("django~=4.1", Some(DjangoVersion::new(4, 1)))]
+    #[case("django >= 4.2.1", Some(DjangoVersion::new(4, 2)))]
+    #[case("django>=4.2,<5.0", Some(DjangoVersion::new(4, 2)))]
+    #[case("django[argon2]>=6,<6.1", Some(DjangoVersion::new(6, 0)))]
+    #[case("django==5.2.*", Some(DjangoVersion::new(5, 2)))]
+    #[case("django==5.*", Some(DjangoVersion::new(5, 0)))]
+    #[case(
+        "django>=5.0; python_version >= \"3.10\"",
+        Some(DjangoVersion::new(5, 0))
+    )]
+    #[case("Django>=4.2a1", Some(DjangoVersion::new(4, 2)))]
+    #[case("django>=4.2.dev1", Some(DjangoVersion::new(4, 2)))]
     // The smallest release satisfying a strict lower bound is still a 4.2.x.
-    #[case("django>4.2", Some((4, 2)))]
-    #[case("django (>=4.2)", Some((4, 2)))]
-    #[case("django>=4.2,!=4.2.1", Some((4, 2)))]
-    #[case("django>=4.2 ; extra == \"a,b\"", Some((4, 2)))]
-    #[case("DJANGO[a,b] ~= 5.0.3", Some((5, 0)))]
-    #[case("django>=1!4.2", Some((4, 2)))]
+    #[case("django>4.2", Some(DjangoVersion::new(4, 2)))]
+    #[case("django (>=4.2)", Some(DjangoVersion::new(4, 2)))]
+    #[case("django>=4.2,!=4.2.1", Some(DjangoVersion::new(4, 2)))]
+    #[case("django>=4.2 ; extra == \"a,b\"", Some(DjangoVersion::new(4, 2)))]
+    #[case("DJANGO[a,b] ~= 5.0.3", Some(DjangoVersion::new(5, 0)))]
+    #[case("django>=1!4.2", Some(DjangoVersion::new(4, 2)))]
     #[case("django", None)]
     #[case("django<6", None)]
     #[case("django @ git+https://github.com/django/django", None)]
     #[case("django-debug-toolbar>=4", None)]
+    #[case("django_extensions>=3.0", None)]
     #[case("requests>=2.0", None)]
-    fn lower_bound_of_a_requirement(#[case] requirement: &str, #[case] expected: Option<(u8, u8)>) {
+    fn lower_bound_of_a_requirement(
+        #[case] requirement: &str,
+        #[case] expected: Option<DjangoVersion>,
+    ) {
         assert_eq!(django_lower_bound(requirement), expected);
     }
 
     #[test]
     fn marker_split_requirements_keep_the_oldest_version() {
         assert_eq!(
-            detect_target_version([
+            infer_target_version([
                 "requests>=2",
                 "django>=5.0; python_version>='3.10'",
                 "django>=4.2; python_version<'3.10'",

--- a/crates/djangofmt/src/django_requirement.rs
+++ b/crates/djangofmt/src/django_requirement.rs
@@ -1,0 +1,128 @@
+//! Inference of the targeted Django version from the `django` requirement of a project.
+//!
+//! Only the release segments of lower-bound specifiers matter here, so requirements are
+//! skimmed rather than parsed: a full PEP 508 parser would still leave the name, extras and
+//! marker splitting below to us.
+
+use djangofmt_lint::DjangoVersion;
+
+/// The lowest Django version satisfying every `django` requirement in `requirements`.
+///
+/// Entries are usually split by an environment marker, and templates have to work on the
+/// oldest Django the project may run on, hence the minimum.
+pub fn detect_target_version<'a>(
+    requirements: impl IntoIterator<Item = &'a str>,
+) -> Option<DjangoVersion> {
+    requirements
+        .into_iter()
+        .filter_map(django_lower_bound)
+        .min()
+        .map(|(major, minor)| DjangoVersion::new(major, minor))
+}
+
+/// Lower bound of a PEP 508 requirement when it names `django`, as `(major, minor)`.
+fn django_lower_bound(requirement: &str) -> Option<(u8, u8)> {
+    let requirement = requirement.trim();
+    let name_end = requirement
+        .find(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
+        .unwrap_or(requirement.len());
+    if !requirement[..name_end].eq_ignore_ascii_case("django") {
+        return None;
+    }
+
+    let mut rest = requirement[name_end..].trim_start();
+    if let Some(after_bracket) = rest.strip_prefix('[') {
+        rest = after_bracket.split_once(']')?.1.trim_start();
+    }
+    // Drop the environment marker, then refuse URL requirements (`django @ git+...`).
+    let specifiers = rest
+        .split_once(';')
+        .map_or(rest, |(before, _)| before)
+        .trim();
+    if specifiers.starts_with('@') {
+        return None;
+    }
+
+    specifiers
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .split(',')
+        .filter_map(specifier_lower_bound)
+        .min()
+}
+
+/// Lower bound of a single PEP 440 specifier. Upper bounds and exclusions bound nothing.
+fn specifier_lower_bound(specifier: &str) -> Option<(u8, u8)> {
+    let specifier = specifier.trim();
+    let operator_end = specifier
+        .find(|c: char| !matches!(c, '=' | '~' | '>' | '<' | '!'))
+        .unwrap_or(specifier.len());
+    let (operator, version) = specifier.split_at(operator_end);
+    if !matches!(operator, "==" | "===" | "~=" | ">=" | ">") {
+        return None;
+    }
+
+    let version = version.trim();
+    // An epoch (`1!4.2`) only reorders releases against each other.
+    let version = version.rsplit_once('!').map_or(version, |(_, rest)| rest);
+    let mut segments = version.split('.');
+    let major = leading_number(segments.next()?)?;
+    let minor = segments.next().and_then(leading_number).unwrap_or(0);
+    Some((major, minor))
+}
+
+/// Digits at the start of a release segment, so `2a1`, `2rc1`, `dev1` and `*` stop early.
+fn leading_number(segment: &str) -> Option<u8> {
+    let end = segment
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(segment.len());
+    segment[..end].parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_target_version, django_lower_bound};
+    use djangofmt_lint::DjangoVersion;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("django>=4.2", Some((4, 2)))]
+    #[case("Django==5.1.0", Some((5, 1)))]
+    #[case("django~=4.1", Some((4, 1)))]
+    #[case("django[argon2]>=4.2", Some((4, 2)))]
+    #[case("django >= 4.2.1", Some((4, 2)))]
+    #[case("django>=4.2,<5.0", Some((4, 2)))]
+    #[case("django[argon2]>=6,<6.1", Some((6, 0)))]
+    #[case("django==5.2.*", Some((5, 2)))]
+    #[case("django==5.*", Some((5, 0)))]
+    #[case("django>=5.0; python_version >= \"3.10\"", Some((5, 0)))]
+    #[case("Django>=4.2a1", Some((4, 2)))]
+    #[case("django>=4.2.dev1", Some((4, 2)))]
+    // The smallest release satisfying a strict lower bound is still a 4.2.x.
+    #[case("django>4.2", Some((4, 2)))]
+    #[case("django (>=4.2)", Some((4, 2)))]
+    #[case("django>=4.2,!=4.2.1", Some((4, 2)))]
+    #[case("django>=4.2 ; extra == \"a,b\"", Some((4, 2)))]
+    #[case("DJANGO[a,b] ~= 5.0.3", Some((5, 0)))]
+    #[case("django>=1!4.2", Some((4, 2)))]
+    #[case("django", None)]
+    #[case("django<6", None)]
+    #[case("django @ git+https://github.com/django/django", None)]
+    #[case("django-debug-toolbar>=4", None)]
+    #[case("requests>=2.0", None)]
+    fn lower_bound_of_a_requirement(#[case] requirement: &str, #[case] expected: Option<(u8, u8)>) {
+        assert_eq!(django_lower_bound(requirement), expected);
+    }
+
+    #[test]
+    fn marker_split_requirements_keep_the_oldest_version() {
+        assert_eq!(
+            detect_target_version([
+                "requests>=2",
+                "django>=5.0; python_version>='3.10'",
+                "django>=4.2; python_version<'3.10'",
+            ]),
+            Some(DjangoVersion::new(4, 2))
+        );
+    }
+}

--- a/crates/djangofmt/src/lib.rs
+++ b/crates/djangofmt/src/lib.rs
@@ -9,6 +9,7 @@ use crate::logging::setup_tracing;
 pub mod args;
 pub mod commands;
 pub mod config;
+mod django_requirement;
 pub mod editorconfig;
 pub mod error;
 pub mod fs;

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -10,7 +10,7 @@ use std::{
 use tracing::debug;
 
 use crate::args::{OutputFormat, Profile};
-use crate::django_requirement::detect_target_version;
+use crate::django_requirement::infer_target_version;
 use crate::error::{Error, Result};
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 
@@ -148,9 +148,9 @@ pub struct LintSettings {
 
     /// The Django version the templates target, as a `major.minor` string.
     ///
-    /// When unset, it is inferred from the lower bound of the `django` requirement in
-    /// `[project] dependencies`, e.g. `django>=4.2` gives `4.2`. Without such a bound, the
-    /// rules that depend on it stay disabled.
+    /// When unset, it is inferred from the lower bound of the `django` requirement,
+    /// e.g. `django>=4.2` in `[project] dependencies` gives `4.2`.
+    /// Without such a bound, the rules that depend on it stay disabled.
     #[option(
         default = "null",
         value_type = "str",
@@ -223,25 +223,19 @@ impl UnsortedTailwindClassesOptions {
 #[derive(Deserialize, Debug)]
 struct PyProject {
     tool: Option<Tool>,
-    project: Option<Project>,
+    /// The PEP 621 table, left untyped so that nothing in it can fail the load,
+    /// since validating `[project]` is the packaging tools' job, not ours.
+    project: Option<toml::Value>,
 }
 
-/// The PEP 621 table. Only `dependencies` is read, and anything that is not a list of
-/// strings is ignored: validating `[project]` is the packaging tools' job, not ours.
-#[derive(Deserialize, Debug)]
-struct Project {
-    dependencies: Option<toml::Value>,
-}
-
-impl Project {
-    fn dependencies(project: Option<&Self>) -> impl Iterator<Item = &str> {
-        project
-            .and_then(|project| project.dependencies.as_ref())
-            .and_then(toml::Value::as_array)
-            .into_iter()
-            .flatten()
-            .filter_map(toml::Value::as_str)
-    }
+/// The string entries of `[project] dependencies`, ignoring anything shaped differently.
+fn project_dependencies(project: Option<&toml::Value>) -> impl Iterator<Item = &str> {
+    project
+        .and_then(|project| project.get("dependencies"))
+        .and_then(toml::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(toml::Value::as_str)
 }
 
 #[derive(Deserialize, Debug)]
@@ -256,14 +250,14 @@ fn load_options_from_pyproject_toml(content: &str) -> Result<PyprojectSettings> 
         .map_err(|err| Error::Resolve(format!("Failed to parse pyproject.toml: {err}")))?;
     let mut settings = pyproject.tool.and_then(|t| t.djangofmt).unwrap_or_default();
 
-    // Only materialize the lint table on a hit, so an undetected version stays indistinguishable
-    // from a pyproject.toml without any djangofmt settings.
+    // Only materialize the lint table on a hit,
+    // so an undetected version leaves the settings exactly as the file spelled them.
     if settings
         .lint
         .as_ref()
         .is_none_or(|lint| lint.target_version.is_none())
         && let Some(version) =
-            detect_target_version(Project::dependencies(pyproject.project.as_ref()))
+            infer_target_version(project_dependencies(pyproject.project.as_ref()))
     {
         debug!("Inferred target-version {version} from the `django` requirement in pyproject.toml");
         settings.lint.get_or_insert_default().target_version = Some(version);
@@ -521,10 +515,6 @@ target-version = "5.2"
         "[project]\ndependencies = [{ name = \"django\" }, \"django>=5.1\"]",
         Some(DjangoVersion::new(5, 1))
     )]
-    #[case::malformed_dependencies_never_fail_the_load(
-        "[project]\ndependencies = \"django>=4.2\"",
-        None
-    )]
     fn test_target_version_is_inferred(
         #[case] content: &str,
         #[case] expected: Option<DjangoVersion>,
@@ -533,9 +523,11 @@ target-version = "5.2"
         assert_eq!(result.lint.and_then(|lint| lint.target_version), expected);
     }
 
-    #[test]
-    fn test_undetected_target_version_leaves_the_lint_table_unset() {
-        let content = "[project]\ndependencies = [\"requests>=2\"]";
+    #[rstest]
+    #[case::no_django_requirement("[project]\ndependencies = [\"requests>=2\"]")]
+    #[case::dependencies_is_not_a_list("[project]\ndependencies = \"django>=4.2\"")]
+    #[case::project_is_not_a_table("project = \"nonsense\"")]
+    fn test_an_uninferrable_target_version_leaves_the_settings_untouched(#[case] content: &str) {
         let result = load_options_from_pyproject_toml(content).unwrap();
         assert_eq!(result, PyprojectSettings::default());
     }

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -148,9 +148,8 @@ pub struct LintSettings {
 
     /// The Django version the templates target, as a `major.minor` string.
     ///
-    /// When unset, it is inferred from the lower bound of the `django` requirement,
-    /// e.g. `django>=4.2` in `[project] dependencies` gives `4.2`.
-    /// Without such a bound, the rules that depend on it stay disabled.
+    /// When unset, it comes from the minimum supported Django version in `[project] dependencies`.
+    /// Rules that depend on it stay disabled until it is known.
     #[option(
         default = "null",
         value_type = "str",
@@ -223,8 +222,7 @@ impl UnsortedTailwindClassesOptions {
 #[derive(Deserialize, Debug)]
 struct PyProject {
     tool: Option<Tool>,
-    /// The PEP 621 table, left untyped so that nothing in it can fail the load,
-    /// since validating `[project]` is the packaging tools' job, not ours.
+    /// The PEP 621 table, left untyped because we don't do strong validation and only infer loosely.
     project: Option<toml::Value>,
 }
 
@@ -250,8 +248,7 @@ fn load_options_from_pyproject_toml(content: &str) -> Result<PyprojectSettings> 
         .map_err(|err| Error::Resolve(format!("Failed to parse pyproject.toml: {err}")))?;
     let mut settings = pyproject.tool.and_then(|t| t.djangofmt).unwrap_or_default();
 
-    // Only materialize the lint table on a hit,
-    // so an undetected version leaves the settings exactly as the file spelled them.
+    // Guarded so a miss never runs `get_or_insert_default` and invents an empty lint table.
     if settings
         .lint
         .as_ref()

--- a/crates/djangofmt/src/pyproject.rs
+++ b/crates/djangofmt/src/pyproject.rs
@@ -10,6 +10,7 @@ use std::{
 use tracing::debug;
 
 use crate::args::{OutputFormat, Profile};
+use crate::django_requirement::detect_target_version;
 use crate::error::{Error, Result};
 use crate::line_width::{IndentWidth, LineLength, SelfClosing};
 
@@ -145,8 +146,11 @@ pub struct LintSettings {
     #[option(default = "false", value_type = "bool", example = "preview = true")]
     pub preview: Option<bool>,
 
-    /// The Django version the templates target, as a `major.minor` string. Unset leaves the
-    /// rules that depend on it disabled.
+    /// The Django version the templates target, as a `major.minor` string.
+    ///
+    /// When unset, it is inferred from the lower bound of the `django` requirement in
+    /// `[project] dependencies`, e.g. `django>=4.2` gives `4.2`. Without such a bound, the
+    /// rules that depend on it stay disabled.
     #[option(
         default = "null",
         value_type = "str",
@@ -219,6 +223,25 @@ impl UnsortedTailwindClassesOptions {
 #[derive(Deserialize, Debug)]
 struct PyProject {
     tool: Option<Tool>,
+    project: Option<Project>,
+}
+
+/// The PEP 621 table. Only `dependencies` is read, and anything that is not a list of
+/// strings is ignored: validating `[project]` is the packaging tools' job, not ours.
+#[derive(Deserialize, Debug)]
+struct Project {
+    dependencies: Option<toml::Value>,
+}
+
+impl Project {
+    fn dependencies(project: Option<&Self>) -> impl Iterator<Item = &str> {
+        project
+            .and_then(|project| project.dependencies.as_ref())
+            .and_then(toml::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(toml::Value::as_str)
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -231,7 +254,21 @@ struct Tool {
 fn load_options_from_pyproject_toml(content: &str) -> Result<PyprojectSettings> {
     let pyproject = toml::from_str::<PyProject>(content)
         .map_err(|err| Error::Resolve(format!("Failed to parse pyproject.toml: {err}")))?;
-    Ok(pyproject.tool.and_then(|t| t.djangofmt).unwrap_or_default())
+    let mut settings = pyproject.tool.and_then(|t| t.djangofmt).unwrap_or_default();
+
+    // Only materialize the lint table on a hit, so an undetected version stays indistinguishable
+    // from a pyproject.toml without any djangofmt settings.
+    if settings
+        .lint
+        .as_ref()
+        .is_none_or(|lint| lint.target_version.is_none())
+        && let Some(version) =
+            detect_target_version(Project::dependencies(pyproject.project.as_ref()))
+    {
+        debug!("Inferred target-version {version} from the `django` requirement in pyproject.toml");
+        settings.lint.get_or_insert_default().target_version = Some(version);
+    }
+    Ok(settings)
 }
 
 /// Load `pyproject.toml` settings rooted at the current working directory,
@@ -469,6 +506,38 @@ target-version = "5.2"
                 ..Default::default()
             }
         );
+    }
+
+    #[rstest]
+    #[case::inferred_from_dependencies(
+        "[project]\ndependencies = [\"django>=4.2\"]",
+        Some(DjangoVersion::new(4, 2))
+    )]
+    #[case::explicit_key_wins(
+        "[project]\ndependencies = [\"django>=4.2\"]\n[tool.djangofmt.lint]\ntarget-version = \"5.0\"",
+        Some(DjangoVersion::new(5, 0))
+    )]
+    #[case::non_string_entries_are_skipped(
+        "[project]\ndependencies = [{ name = \"django\" }, \"django>=5.1\"]",
+        Some(DjangoVersion::new(5, 1))
+    )]
+    #[case::malformed_dependencies_never_fail_the_load(
+        "[project]\ndependencies = \"django>=4.2\"",
+        None
+    )]
+    fn test_target_version_is_inferred(
+        #[case] content: &str,
+        #[case] expected: Option<DjangoVersion>,
+    ) {
+        let result = load_options_from_pyproject_toml(content).unwrap();
+        assert_eq!(result.lint.and_then(|lint| lint.target_version), expected);
+    }
+
+    #[test]
+    fn test_undetected_target_version_leaves_the_lint_table_unset() {
+        let content = "[project]\ndependencies = [\"requests>=2\"]";
+        let result = load_options_from_pyproject_toml(content).unwrap();
+        assert_eq!(result, PyprojectSettings::default());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #492. 

When `target-version` is unset, infer it from the `django` requirement in `[project] dependencies`.

Same derivation ruff uses for `requires-python`: the minimum over lower-bound specifiers (`==`, `===`, `~=`, `>=`, `>`), ignoring upper bounds, exclusions, extras, markers and URL requirements. Without a lower bound nothing is inferred and the version-gated rules stay off.

Hand-written instead of a new dependency — `pep508_rs` costs ~1.7MB and ~60 crates which is a lot too much for this feature.

No rule reads `target-version` yet, so this changes no output.