### PR TITLE
feat(format): support `--check` option for checking formatting without making changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,6 @@ djangofmt templates/base.html  # Format individual files
 When given a directory, djangofmt recurses into it and formats all `*.html`, `*.jinja`, `*.jinja2`, and `*.j2` files it finds.
 It also respects `.gitignore` files.
 
-### Looking for a check mode ?
-
-djangofmt intentionally does not provide a built-in check functionality because CI is too late for a code formatter. We strongly recommend using pre-commit or any IDE "format on save" integration. That being said, you can emulate check capability by chaining with a git diff command like so:
-
-```bash
-djangofmt .
-git diff --exit-code -- '*.html' || (echo "HTML templates are not formatted. Run 'djangofmt' to fix." && exit 1)
-```
-
 ## Pre-commit hook
 
 See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions.
@@ -125,6 +116,16 @@ There is a dedicated pre-commit hook for these:
   hooks:
     - id: djangofmt-svg
 ```
+
+### Check mode
+
+`--check` reports the files that would be reformatted without writing anything, exiting with `1` if any would change:
+
+```shell
+djangofmt --check .
+```
+
+CI is usually too late for a code formatter though: prefer the pre-commit hook above or an IDE "format on save" integration.
 
 ## Configuration
 

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -115,6 +115,10 @@ pub struct FormatCommand {
     /// Self-closing style for void HTML elements (e.g. <br> vs <br />) [default: never]
     #[arg(long, value_enum)]
     pub html_void_self_closing: Option<SelfClosing>,
+    /// Avoid writing any formatted files back; instead, exit with a non-zero status code if any
+    /// files would be reformatted.
+    #[arg(long)]
+    pub check: bool,
     /// Preserve unquoted HTML attribute values (e.g. prop=True stays unquoted).
     /// Use `--no-preserve-unquoted-attrs` to disable.
     #[arg(long, overrides_with("no_preserve_unquoted_attrs"))]
@@ -342,6 +346,10 @@ mod tests {
                   - never:     Never use self-closing syntax
                   - always:    Always use self-closing syntax
                   - unchanged: Keep existing style as-is
+
+              --check
+                  Avoid writing any formatted files back; instead, exit with a non-zero status code if any
+                  files would be reformatted
 
               --preserve-unquoted-attrs
                   Preserve unquoted HTML attribute values (e.g. prop=True stays unquoted). Use

--- a/crates/djangofmt/src/args.rs
+++ b/crates/djangofmt/src/args.rs
@@ -116,7 +116,7 @@ pub struct FormatCommand {
     #[arg(long, value_enum)]
     pub html_void_self_closing: Option<SelfClosing>,
     /// Avoid writing any formatted files back; instead, exit with a non-zero status code if any
-    /// files would be reformatted.
+    /// files would have been modified, and zero otherwise.
     #[arg(long)]
     pub check: bool,
     /// Preserve unquoted HTML attribute values (e.g. prop=True stays unquoted).
@@ -349,7 +349,7 @@ mod tests {
 
               --check
                   Avoid writing any formatted files back; instead, exit with a non-zero status code if any
-                  files would be reformatted
+                  files would have been modified, and zero otherwise
 
               --preserve-unquoted-attrs
                   Preserve unquoted HTML attribute values (e.g. prop=True stays unquoted). Use

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -276,13 +276,17 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
     let resolved = super::resolve_command(&args.files, &args.file_selection)?;
     let editorconfig = editorconfig::load_editorconfig_from_cwd();
     let context = FormatContext::new(args, &resolved.pyproject, editorconfig.as_ref());
+    let check = args.check;
 
     // Format files in parallel
     let start = Instant::now();
     let (results, errors): (Vec<_>, Vec<_>) = resolved
         .files
         .par_iter()
-        .map(|entry| super::catch_file_panic(Some(entry), || format_path(entry, &context)))
+        .map(|entry| {
+            super::catch_file_panic(Some(entry), || format_path(entry, &context, check))
+                .map(|fmt_res| (entry.as_path(), fmt_res))
+        })
         .partition_map(|result| match result {
             Ok(fmt_res) => Left(fmt_res),
             Err(err) => Right(*err),
@@ -296,17 +300,34 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
 
     let nb_errors = super::report_errors(errors, "format", OutputFormat::Full);
 
+    // In check mode, report which files would be reformatted.
+    if check {
+        for (path, result) in &results {
+            if *result == FormatResult::Formatted {
+                info!("Would reformat: {}", path.display());
+            }
+        }
+    }
+
     // Report on the formatting changes.
-    let summary = build_summary(results.as_ref());
+    let format_results: Vec<FormatResult> = results.iter().map(|(_, res)| *res).collect();
+    let summary = build_summary(&format_results, check);
     if !summary.is_empty() {
         info!("{} !", summary);
     }
 
-    if nb_errors == 0 {
-        Ok(ExitStatus::Success)
-    } else {
-        Ok(ExitStatus::Error)
+    let nb_would_reformat = format_results
+        .iter()
+        .filter(|res| **res == FormatResult::Formatted)
+        .count();
+
+    if nb_errors > 0 {
+        return Ok(ExitStatus::Error);
     }
+    if check && nb_would_reformat > 0 {
+        return Ok(ExitStatus::Failure);
+    }
+    Ok(ExitStatus::Success)
 }
 
 /// Format the given source code.
@@ -449,6 +470,7 @@ fn format_or_fallback<'a>(
 fn format_path(
     path: &Path,
     context: &FormatContext,
+    check: bool,
 ) -> std::result::Result<FormatResult, Box<CommandError>> {
     let profile = context.profile_for(path);
     let config = context.config_for(path);
@@ -470,19 +492,21 @@ fn format_path(
     if formatted == unformatted {
         Ok(FormatResult::Unchanged)
     } else {
-        let mut writer =
-            File::create(path).map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
+        if !check {
+            let mut writer = File::create(path)
+                .map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
 
-        writer
-            .write_all(formatted.as_bytes())
-            .map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
+            writer
+                .write_all(formatted.as_bytes())
+                .map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
+        }
 
         Ok(FormatResult::Formatted)
     }
 }
 
 /// The result of an individual formatting operation.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum FormatResult {
     /// The file was formatted.
     Formatted,
@@ -496,7 +520,7 @@ pub enum FormatResult {
 
 /// Write a summary of the formatting results to stdout.
 #[must_use]
-pub fn build_summary(results: &[FormatResult]) -> String {
+pub fn build_summary(results: &[FormatResult], check: bool) -> String {
     let (mut changed, mut unchanged, mut skipped) = (0usize, 0usize, 0usize);
     for result in results {
         match result {
@@ -506,8 +530,13 @@ pub fn build_summary(results: &[FormatResult]) -> String {
         }
     }
 
+    let reformatted_label = if check {
+        "would be reformatted"
+    } else {
+        "reformatted"
+    };
     let parts: Vec<String> = [
-        (changed, "reformatted"),
+        (changed, reformatted_label),
         (unchanged, "left unchanged"),
         (skipped, "skipped"),
     ]
@@ -730,6 +759,16 @@ mod tests {
         FormatResult::Skipped,
     ], "2 files reformatted, 1 file left unchanged, 3 files skipped")]
     fn test_write_summary(#[case] results: Vec<FormatResult>, #[case] expected: &str) {
-        assert_eq!(build_summary(&results), expected);
+        assert_eq!(build_summary(&results, false), expected);
+    }
+
+    #[rstest]
+    #[case(vec![], "")]
+    #[case(vec![FormatResult::Formatted], "1 file would be reformatted")]
+    #[case(vec![FormatResult::Formatted, FormatResult::Formatted], "2 files would be reformatted")]
+    #[case(vec![FormatResult::Unchanged], "1 file left unchanged")]
+    #[case(vec![FormatResult::Formatted, FormatResult::Unchanged], "1 file would be reformatted, 1 file left unchanged")]
+    fn test_write_summary_check_mode(#[case] results: Vec<FormatResult>, #[case] expected: &str) {
+        assert_eq!(build_summary(&results, true), expected);
     }
 }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -276,7 +276,6 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
     let resolved = super::resolve_command(&args.files, &args.file_selection)?;
     let editorconfig = editorconfig::load_editorconfig_from_cwd();
     let context = FormatContext::new(args, &resolved.pyproject, editorconfig.as_ref());
-    let check = args.check;
 
     // Format files in parallel
     let start = Instant::now();
@@ -284,7 +283,7 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
         .files
         .par_iter()
         .map(|entry| {
-            super::catch_file_panic(Some(entry), || format_path(entry, &context, check))
+            super::catch_file_panic(Some(entry), || format_path(entry, &context))
                 .map(|fmt_res| (entry.as_path(), fmt_res))
         })
         .partition_map(|result| match result {
@@ -300,31 +299,30 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
 
     let nb_errors = super::report_errors(errors, "format", OutputFormat::Full);
 
-    // In check mode, report which files would be reformatted.
-    if check {
-        for (path, result) in &results {
-            if *result == FormatResult::Formatted {
-                info!("Would reformat: {}", path.display());
-            }
+    // In check mode, list what would change instead of writing it.
+    // `resolved.files` is sorted and rayon keeps that order, so the listing is deterministic.
+    if args.check {
+        for (path, _) in results
+            .iter()
+            .filter(|(_, res)| *res == FormatResult::Formatted)
+        {
+            info!("Would reformat: {}", relativize_path(path));
         }
     }
 
     // Report on the formatting changes.
-    let format_results: Vec<FormatResult> = results.iter().map(|(_, res)| *res).collect();
-    let summary = build_summary(&format_results, check);
+    let summary = build_summary(results.iter().map(|(_, res)| res), args.check);
     if !summary.is_empty() {
         info!("{} !", summary);
     }
 
-    let nb_would_reformat = format_results
+    let any_formatted = results
         .iter()
-        .filter(|res| **res == FormatResult::Formatted)
-        .count();
-
+        .any(|(_, res)| *res == FormatResult::Formatted);
     if nb_errors > 0 {
         return Ok(ExitStatus::Error);
     }
-    if check && nb_would_reformat > 0 {
+    if args.check && any_formatted {
         return Ok(ExitStatus::Failure);
     }
     Ok(ExitStatus::Success)
@@ -470,7 +468,6 @@ fn format_or_fallback<'a>(
 fn format_path(
     path: &Path,
     context: &FormatContext,
-    check: bool,
 ) -> std::result::Result<FormatResult, Box<CommandError>> {
     let profile = context.profile_for(path);
     let config = context.config_for(path);
@@ -492,7 +489,7 @@ fn format_path(
     if formatted == unformatted {
         Ok(FormatResult::Unchanged)
     } else {
-        if !check {
+        if !context.args.check {
             let mut writer = File::create(path)
                 .map_err(|err| CommandError::Write(Some(path.to_path_buf()), err))?;
 
@@ -506,7 +503,7 @@ fn format_path(
 }
 
 /// The result of an individual formatting operation.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum FormatResult {
     /// The file was formatted.
     Formatted,
@@ -520,7 +517,10 @@ pub enum FormatResult {
 
 /// Write a summary of the formatting results to stdout.
 #[must_use]
-pub fn build_summary(results: &[FormatResult], check: bool) -> String {
+pub fn build_summary<'a>(
+    results: impl IntoIterator<Item = &'a FormatResult>,
+    check: bool,
+) -> String {
     let (mut changed, mut unchanged, mut skipped) = (0usize, 0usize, 0usize);
     for result in results {
         match result {
@@ -530,14 +530,14 @@ pub fn build_summary(results: &[FormatResult], check: bool) -> String {
         }
     }
 
-    let reformatted_label = if check {
-        "would be reformatted"
+    let (changed_label, unchanged_label) = if check {
+        ("would be reformatted", "already formatted")
     } else {
-        "reformatted"
+        ("reformatted", "left unchanged")
     };
     let parts: Vec<String> = [
-        (changed, reformatted_label),
-        (unchanged, "left unchanged"),
+        (changed, changed_label),
+        (unchanged, unchanged_label),
         (skipped, "skipped"),
     ]
     .iter()
@@ -763,11 +763,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case(vec![], "")]
     #[case(vec![FormatResult::Formatted], "1 file would be reformatted")]
-    #[case(vec![FormatResult::Formatted, FormatResult::Formatted], "2 files would be reformatted")]
-    #[case(vec![FormatResult::Unchanged], "1 file left unchanged")]
-    #[case(vec![FormatResult::Formatted, FormatResult::Unchanged], "1 file would be reformatted, 1 file left unchanged")]
+    #[case(vec![
+        FormatResult::Formatted,
+        FormatResult::Unchanged,
+        FormatResult::Skipped,
+    ], "1 file would be reformatted, 1 file already formatted, 1 file skipped")]
     fn test_write_summary_check_mode(#[case] results: Vec<FormatResult>, #[case] expected: &str) {
         assert_eq!(build_summary(&results, true), expected);
     }

--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -301,12 +301,13 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
 
     // In check mode, list what would change instead of writing it.
     // `resolved.files` is sorted and rayon keeps that order, so the listing is deterministic.
+    let mut would_reformat = false;
     if args.check {
-        for (path, _) in results
-            .iter()
-            .filter(|(_, res)| *res == FormatResult::Formatted)
-        {
-            info!("Would reformat: {}", relativize_path(path));
+        for (path, res) in &results {
+            if *res == FormatResult::Formatted {
+                would_reformat = true;
+                info!("Would reformat: {}", relativize_path(path));
+            }
         }
     }
 
@@ -316,13 +317,10 @@ pub fn format(args: &FormatCommand) -> Result<ExitStatus> {
         info!("{} !", summary);
     }
 
-    let any_formatted = results
-        .iter()
-        .any(|(_, res)| *res == FormatResult::Formatted);
     if nb_errors > 0 {
         return Ok(ExitStatus::Error);
     }
-    if args.check && any_formatted {
+    if would_reformat {
         return Ok(ExitStatus::Failure);
     }
     Ok(ExitStatus::Success)

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -41,7 +41,7 @@ pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
     match super::catch_file_panic(stdin_filename, || {
         format_source_code(stdin_filename, &config, profile, cli.check)
     }) {
-        Ok(would_reformat) if cli.check && would_reformat => Ok(ExitStatus::Failure),
+        Ok(true) if cli.check => Ok(ExitStatus::Failure),
         Ok(_) => Ok(ExitStatus::Success),
         Err(err) => {
             error!("{:?}", miette::Report::new(*err));

--- a/crates/djangofmt/src/commands/format_stdin.rs
+++ b/crates/djangofmt/src/commands/format_stdin.rs
@@ -24,7 +24,9 @@ pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
     if let Some(filename) = stdin_filename
         && is_force_excluded(filename, &discovery_config)?
     {
-        std::io::copy(&mut stdin().lock(), &mut stdout().lock())?;
+        if !cli.check {
+            std::io::copy(&mut stdin().lock(), &mut stdout().lock())?;
+        }
         return Ok(ExitStatus::Success);
     }
 
@@ -37,9 +39,10 @@ pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
     let config = FormatterConfig::from_args(cli, &pyproject, &settings);
 
     match super::catch_file_panic(stdin_filename, || {
-        format_source_code(stdin_filename, &config, profile)
+        format_source_code(stdin_filename, &config, profile, cli.check)
     }) {
-        Ok(()) => Ok(ExitStatus::Success),
+        Ok(would_reformat) if cli.check && would_reformat => Ok(ExitStatus::Failure),
+        Ok(_) => Ok(ExitStatus::Success),
         Err(err) => {
             error!("{:?}", miette::Report::new(*err));
             Ok(ExitStatus::Error)
@@ -47,11 +50,13 @@ pub fn format_stdin(cli: &FormatCommand) -> Result<ExitStatus> {
     }
 }
 
+/// Returns whether the source would be reformatted.
 fn format_source_code(
     path: Option<&Path>,
     config: &FormatterConfig,
     profile: Profile,
-) -> std::result::Result<(), Box<CommandError>> {
+    check: bool,
+) -> std::result::Result<bool, Box<CommandError>> {
     let mut source = String::new();
     stdin()
         .lock()
@@ -66,9 +71,13 @@ fn format_source_code(
     };
 
     let output = formatted.as_deref().unwrap_or(&source);
-    stdout()
-        .lock()
-        .write_all(output.as_bytes())
-        .map_err(|err| CommandError::Write(path.map(Path::to_path_buf), err))?;
-    Ok(())
+
+    // Check mode answers through the exit code only, so nothing is echoed back.
+    if !check {
+        stdout()
+            .lock()
+            .write_all(output.as_bytes())
+            .map_err(|err| CommandError::Write(path.map(Path::to_path_buf), err))?;
+    }
+    Ok(output != source)
 }

--- a/crates/djangofmt/tests/cli.rs
+++ b/crates/djangofmt/tests/cli.rs
@@ -80,6 +80,35 @@ fn format_directory() {
 }
 
 #[test]
+fn format_check_reports_without_writing() {
+    let original = "<div   class=\"foo\"  >\n</div>\n";
+    let project = Project::new().file("test.html", original);
+    assert_cmd_snapshot!(cli().current_dir(project.path()).args(["--check", "."]), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Would reformat: test.html
+    1 file would be reformatted !
+    ");
+    assert_eq!(project.read("test.html"), original);
+}
+
+#[test]
+fn format_check_formatted_file_exits_zero() {
+    let project = Project::new().file("test.html", "<div class=\"foo\"></div>\n");
+    assert_cmd_snapshot!(cli().current_dir(project.path()).args(["--check", "."]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    1 file already formatted !
+    ");
+}
+
+#[test]
 fn format_quiet() {
     let project = Project::new().file("test.html", "<div   ></div>\n");
     assert_cmd_snapshot!(cli().arg("-q").arg(project.join("test.html")), @"
@@ -180,6 +209,21 @@ fn format_stdin_with_filename_infers_jinja_profile() {
     exit_code: 0
     ----- stdout -----
     {% verbatim %}{{ x }}{% endverbatim %}
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn format_stdin_check_reports_through_exit_code() {
+    assert_cmd_snapshot!(
+        cli()
+            .args(["--check", "-"])
+            .pass_stdin("<div   class=\"foo\"  ></div>\n"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
 
     ----- stderr -----
     ");

--- a/crates/djangofmt_benchmark/benches/summary.rs
+++ b/crates/djangofmt_benchmark/benches/summary.rs
@@ -23,5 +23,5 @@ fn build_summary_mixed(bencher: divan::Bencher, n: usize) {
     // Roughly 1/3 of each variant
     let results = make_results(n / 2, n / 3, n / 4);
 
-    bencher.bench(|| build_summary(divan::black_box(&results)));
+    bencher.bench(|| build_summary(divan::black_box(&results), false));
 }

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,6 @@ docs = [
 ]
 
 [package.metadata]
-
 [package.metadata.requires-dev]
 dev = [
   { name = "astral-dev-toolchain-cargo-insta", specifier = ">=1.48.0" },


### PR DESCRIPTION
This PR adds support for a `--check` flag for djangofmt, as it would be useful for local development for users to be able to check if any files they're working on would need reformatting. 

I find this can be useful in a pre commit hook, as it gives users the chance to double check whether a file needs changes rather than automatically applying formatting changes. 