### PR TITLE
fix(format): Keep a comment-only CSS block instead of emptying it

### DIFF
--- a/crates/djangofmt/src/commands/format.rs
+++ b/crates/djangofmt/src/commands/format.rs
@@ -376,12 +376,18 @@ pub fn format_text(
                     if code.contains('{') {
                         Ok(formatted_css)
                     } else {
-                        Ok(formatted_css
+                        let joined = formatted_css
                             .lines()
                             .map(str::trim)
                             .collect::<Vec<_>>()
-                            .join(" ")
-                            .into())
+                            .join(" ");
+                        // `single_line_top_level_declarations` makes malva drop comments here,
+                        // which empties a comment-only block. Keep the source rather than delete it.
+                        if joined.trim().is_empty() {
+                            Ok(code.into())
+                        } else {
+                            Ok(joined.into())
+                        }
                     }
                 }
                 _ => Ok(code.into()),

--- a/crates/djangofmt/tests/fmt/malva/css_comment_only.html
+++ b/crates/djangofmt/tests/fmt/malva/css_comment_only.html
@@ -1,0 +1,3 @@
+<style>/*! license */</style>
+<div style="/* only a comment */"></div>
+<div style="color: red; /* dropped, see malva#44 */"></div>

--- a/crates/djangofmt/tests/fmt/malva/css_comment_only.snap
+++ b/crates/djangofmt/tests/fmt/malva/css_comment_only.snap
@@ -1,0 +1,8 @@
+---
+source: crates/djangofmt/tests/fmt/main.rs
+---
+<style>
+    /*! license */
+</style>
+<div style="/* only a comment */"></div>
+<div style="color: red"></div>


### PR DESCRIPTION
Prevent this issue:

```diff
-<div style="/* only a comment */"></div>
+<div style=""></div>
```